### PR TITLE
feat: extension status report + extensions_status tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 
+# Scratch artifacts accidentally created by automation
+'+CLAUDE_OUT+'
+
+# Agent loop run artifacts (timestamped logs/diffs)
+docs/agent-loop/runs/
+
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 

--- a/apps/agent_core/lib/agent_core/loop.ex
+++ b/apps/agent_core/lib/agent_core/loop.ex
@@ -751,7 +751,10 @@ defmodule AgentCore.Loop do
         # Return aborted results for remaining tool calls
         {aborted_results, context, new_messages} =
           Enum.reduce(pending_by_ref, {results, context, new_messages}, fn {_ref, %{tool_call: tool_call}}, {acc_results, acc_ctx, acc_msgs} ->
-            aborted_result = error_to_result("Tool execution aborted")
+            aborted_result = %AgentToolResult{
+              content: [%TextContent{type: :text, text: "Tool execution aborted"}],
+              details: %{error_type: :aborted}
+            }
 
             {acc_ctx, acc_msgs, acc_results} =
               emit_tool_result(tool_call, aborted_result, true, acc_ctx, acc_msgs, acc_results, stream)

--- a/apps/agent_core/lib/agent_core/proxy.ex
+++ b/apps/agent_core/lib/agent_core/proxy.ex
@@ -715,8 +715,9 @@ defmodule AgentCore.Proxy do
         _, acc -> acc
       end)
 
-    # Add closing characters
-    closing = String.duplicate("}", max(open_braces, 0)) <> String.duplicate("]", max(open_brackets, 0))
+    # Add closing characters.
+    # Close brackets before braces (e.g. `{ "items": [1,2` needs `]}` not `}]`).
+    closing = String.duplicate("]", max(open_brackets, 0)) <> String.duplicate("}", max(open_braces, 0))
     json <> closing
   end
 end

--- a/apps/agent_core/test/support/mocks.ex
+++ b/apps/agent_core/test/support/mocks.ex
@@ -353,7 +353,7 @@ defmodule AgentCore.Test.Mocks do
   Generates a unique ID for tool calls.
   """
   def generate_id do
-    "call_" <> :crypto.strong_rand_bytes(12) |> Base.encode16(case: :lower)
+    "call_" <> Base.encode16(:crypto.strong_rand_bytes(12), case: :lower)
   end
 
   @doc """

--- a/apps/ai/lib/ai/error.ex
+++ b/apps/ai/lib/ai/error.ex
@@ -293,6 +293,11 @@ defmodule Ai.Error do
   end
 
   # Provider-specific error message extraction
+  # Google API format (prefer first entry in errors array when a top-level message is present)
+  defp extract_provider_message(%{"error" => %{"errors" => [%{"message" => message} | _], "message" => _top_message}})
+       when is_binary(message),
+       do: message
+
   # Anthropic format
   defp extract_provider_message(%{"error" => %{"message" => message}}) when is_binary(message), do: message
   defp extract_provider_message(%{"error" => %{"type" => type, "message" => message}}) when is_binary(type) and is_binary(message) do
@@ -323,7 +328,6 @@ defmodule Ai.Error do
   defp extract_provider_message(%{"Message" => message}) when is_binary(message), do: message
   defp extract_provider_message(%{"detail" => detail}) when is_binary(detail), do: detail
   # Google API format
-  defp extract_provider_message(%{"error" => %{"errors" => [%{"message" => message} | _]}}) when is_binary(message), do: message
   defp extract_provider_message(%{"error" => %{"status" => status, "message" => message}}) when is_binary(status) and is_binary(message) do
     "#{status}: #{message}"
   end

--- a/apps/coding_agent/lib/coding_agent/extensions.ex
+++ b/apps/coding_agent/lib/coding_agent/extensions.ex
@@ -36,12 +36,61 @@ defmodule CodingAgent.Extensions do
 
       # Get hooks
       hooks = CodingAgent.Extensions.get_hooks(extensions)
+
+      # Get extension metadata for UIs/diagnostics
+      metadata = CodingAgent.Extensions.list_extensions()
   """
 
   alias CodingAgent.Config
 
   @type extension_module :: module()
   @type loaded_extensions :: [extension_module()]
+
+  @type extension_metadata :: %{
+          name: String.t(),
+          version: String.t(),
+          module: module(),
+          source_path: String.t() | nil,
+          capabilities: [atom()],
+          config_schema: map()
+        }
+
+  @typedoc """
+  Load error details for an extension that failed to load.
+
+  - `:source_path` - Path to the file that failed to load
+  - `:error` - The error reason (exception, compile error, etc.)
+  - `:error_message` - Human-readable error message
+  """
+  @type load_error :: %{
+          source_path: String.t(),
+          error: term(),
+          error_message: String.t()
+        }
+
+  @typedoc """
+  Structured status report for extension loading at session startup.
+
+  Published as a single `{:extension_status_report, report}` event for UI/CLI consumption.
+
+  - `:extensions` - List of successfully loaded extension metadata
+  - `:load_errors` - List of extensions that failed to load
+  - `:tool_conflicts` - Tool conflict report from ToolRegistry
+  - `:total_loaded` - Count of successfully loaded extensions
+  - `:total_errors` - Count of extensions that failed to load
+  - `:loaded_at` - Timestamp when extensions were loaded
+  """
+  @type extension_status_report :: %{
+          extensions: [extension_metadata()],
+          load_errors: [load_error()],
+          tool_conflicts: CodingAgent.ToolRegistry.conflict_report() | nil,
+          total_loaded: non_neg_integer(),
+          total_errors: non_neg_integer(),
+          loaded_at: integer()
+        }
+
+  # ETS table for storing extension source paths
+  @source_path_table :coding_agent_extension_source_paths
 
   # ============================================================================
   # Extension Loading
@@ -71,14 +120,78 @@ defmodule CodingAgent.Extensions do
   """
   @spec load_extensions([String.t()]) :: {:ok, loaded_extensions()} | {:error, term()}
   def load_extensions(paths) when is_list(paths) do
+    # Ensure the source path table exists
+    ensure_source_path_table()
+
     extensions =
       paths
+      |> Enum.filter(&is_binary/1)
       |> Enum.map(&Path.expand/1)
       |> Enum.filter(&File.dir?/1)
       |> Enum.flat_map(&discover_extensions/1)
       |> Enum.uniq()
 
     {:ok, extensions}
+  end
+
+  @doc """
+  Load extensions from the given paths, capturing any load errors.
+
+  Similar to `load_extensions/1` but returns both successfully loaded extensions
+  and a list of load errors for files that failed to compile or load.
+
+  ## Parameters
+
+    * `paths` - List of directory paths to search for extensions
+
+  ## Returns
+
+    * `{:ok, extensions, load_errors}` - Tuple with loaded extensions and errors
+
+  ## Examples
+
+      {:ok, extensions, errors} = CodingAgent.Extensions.load_extensions_with_errors([
+        "~/.lemon/agent/extensions",
+        "/path/to/project/.lemon/extensions"
+      ])
+
+      if errors != [] do
+        IO.puts("Some extensions failed to load:")
+        for error <- errors do
+          IO.puts("  - \#{error.source_path}: \#{error.error_message}")
+        end
+      end
+  """
+  @spec load_extensions_with_errors([String.t()]) ::
+          {:ok, loaded_extensions(), [load_error()]}
+  def load_extensions_with_errors(paths) when is_list(paths) do
+    # Ensure the source path table exists
+    ensure_source_path_table()
+
+    {extensions, errors} =
+      paths
+      |> Enum.filter(&is_binary/1)
+      |> Enum.map(&Path.expand/1)
+      |> Enum.filter(&File.dir?/1)
+      |> Enum.flat_map(&discover_extension_files/1)
+      |> Enum.reduce({[], []}, fn file, {exts, errs} ->
+        case load_extension_file_safe(file) do
+          {:ok, modules} ->
+            valid_modules = Enum.filter(modules, &implements_extension?/1)
+            {valid_modules ++ exts, errs}
+
+          {:error, error, message} ->
+            error_info = %{
+              source_path: file,
+              error: error,
+              error_message: message
+            }
+
+            {exts, [error_info | errs]}
+        end
+      end)
+
+    {:ok, Enum.uniq(extensions), Enum.reverse(errors)}
   end
 
   @doc """
@@ -130,11 +243,86 @@ defmodule CodingAgent.Extensions do
   """
   @spec get_tools(loaded_extensions(), String.t()) :: [AgentCore.Types.AgentTool.t()]
   def get_tools(extensions, cwd) when is_list(extensions) do
+    get_tools_with_source(extensions, cwd)
+    |> Enum.map(fn {tool, _module} -> tool end)
+  end
+
+  @doc """
+  Get tools from loaded extensions with source module tracking.
+
+  Similar to `get_tools/2` but returns tuples of `{tool, extension_module}`
+  to enable conflict detection and debugging.
+
+  ## Parameters
+
+    * `extensions` - List of loaded extension modules
+    * `cwd` - Current working directory (passed to each extension's `tools/1`)
+
+  ## Returns
+
+  A list of `{AgentCore.Types.AgentTool.t(), module()}` tuples.
+
+  ## Examples
+
+      tools_with_source = CodingAgent.Extensions.get_tools_with_source(extensions, cwd)
+      # => [{%AgentTool{name: "my_tool", ...}, MyExtension}, ...]
+  """
+  @spec get_tools_with_source(loaded_extensions(), String.t()) ::
+          [{AgentCore.Types.AgentTool.t(), module()}]
+  def get_tools_with_source(extensions, cwd) when is_list(extensions) do
     extensions
     |> Enum.filter(&has_callback?(&1, :tools, 1))
     |> Enum.flat_map(fn ext ->
       try do
         ext.tools(cwd)
+        |> Enum.map(fn tool -> {tool, ext} end)
+      rescue
+        _ -> []
+      end
+    end)
+  end
+
+  # ============================================================================
+  # Provider Collection
+  # ============================================================================
+
+  @doc """
+  Get providers from loaded extensions.
+
+  Collects all provider specifications from the given extension modules.
+  Each provider spec includes `:type`, `:name`, `:module`, and `:config`.
+
+  ## Parameters
+
+    * `extensions` - List of loaded extension modules
+
+  ## Returns
+
+  A list of `{provider_spec, extension_module}` tuples for tracking source.
+
+  ## Examples
+
+      providers = CodingAgent.Extensions.get_providers(extensions)
+      # => [{%{type: :model, name: :my_model, ...}, MyExtension}, ...]
+  """
+  @spec get_providers(loaded_extensions()) :: [{map(), module()}]
+  def get_providers(extensions) when is_list(extensions) do
+    extensions
+    |> Enum.filter(&has_callback?(&1, :providers, 0))
+    |> Enum.flat_map(fn ext ->
+      try do
+        ext.providers()
+        |> Enum.map(fn provider_spec ->
+          # Normalize the provider spec with defaults
+          normalized = %{
+            type: Map.get(provider_spec, :type),
+            name: Map.get(provider_spec, :name),
+            module: Map.get(provider_spec, :module),
+            config: Map.get(provider_spec, :config, %{})
+          }
+
+          {normalized, ext}
+        end)
       rescue
         _ -> []
       end
@@ -218,6 +406,12 @@ defmodule CodingAgent.Extensions do
         e ->
           # Log but don't crash on hook errors
           IO.warn("Hook error for #{event}: #{inspect(e)}")
+      catch
+        :throw, reason ->
+          IO.warn("Hook throw for #{event}: #{inspect(reason)}")
+
+        :exit, reason ->
+          IO.warn("Hook exit for #{event}: #{inspect(reason)}")
       end
     end
 
@@ -231,7 +425,9 @@ defmodule CodingAgent.Extensions do
   @doc """
   Get information about loaded extensions.
 
-  Returns a list of maps containing name and version for each extension.
+  Returns a list of maps containing name, version, module, source path,
+  capabilities, and config schema for each extension. This is useful for
+  UIs and diagnostics to show what plugins are active and render settings.
 
   ## Parameters
 
@@ -239,31 +435,225 @@ defmodule CodingAgent.Extensions do
 
   ## Returns
 
-  A list of maps with `:name`, `:version`, and `:module` keys.
+  A list of maps with `:name`, `:version`, `:module`, `:source_path`,
+  `:capabilities`, and `:config_schema` keys.
 
   ## Examples
 
       info = CodingAgent.Extensions.get_info(extensions)
-      # => [%{name: "my-ext", version: "1.0.0", module: MyExt}]
+      # => [%{name: "my-ext", version: "1.0.0", module: MyExt, source_path: "/path/to/ext.ex",
+      #       capabilities: [:tools, :hooks], config_schema: %{"type" => "object", ...}}]
   """
-  @spec get_info(loaded_extensions()) :: [%{name: String.t(), version: String.t(), module: module()}]
+  @spec get_info(loaded_extensions()) :: [extension_metadata()]
   def get_info(extensions) when is_list(extensions) do
     Enum.map(extensions, fn ext ->
       %{
         name: safe_call(ext, :name, [], "unknown"),
         version: safe_call(ext, :version, [], "0.0.0"),
-        module: ext
+        module: ext,
+        source_path: get_source_path(ext),
+        capabilities: safe_call(ext, :capabilities, [], []),
+        config_schema: safe_call(ext, :config_schema, [], %{})
       }
     end)
+  end
+
+  @doc """
+  Get the source file path for a loaded extension module.
+
+  Returns the path from which the extension was loaded, or nil if unknown.
+
+  ## Parameters
+
+    * `module` - The extension module
+
+  ## Returns
+
+  The file path as a string, or nil if not tracked.
+
+  ## Examples
+
+      path = CodingAgent.Extensions.get_source_path(MyExtension)
+      # => "/home/user/.lemon/agent/extensions/my_extension.ex"
+  """
+  @spec get_source_path(module()) :: String.t() | nil
+  def get_source_path(module) when is_atom(module) do
+    case :ets.whereis(@source_path_table) do
+      :undefined ->
+        nil
+
+      _tid ->
+        case :ets.lookup(@source_path_table, module) do
+          [{^module, path}] -> path
+          [] -> nil
+        end
+    end
+  end
+
+  @doc """
+  List all loaded extensions with their metadata.
+
+  Returns metadata for all extensions that have been loaded via
+  `load_extensions/1`. This is a convenience function for UIs and
+  diagnostics that don't have access to the session's extension list.
+
+  ## Returns
+
+  A list of extension metadata maps.
+
+  ## Examples
+
+      extensions = CodingAgent.Extensions.list_extensions()
+      # => [%{name: "my-ext", version: "1.0.0", module: MyExt, source_path: "..."}]
+  """
+  @spec list_extensions() :: [extension_metadata()]
+  def list_extensions do
+    case :ets.whereis(@source_path_table) do
+      :undefined ->
+        []
+
+      _tid ->
+        :ets.tab2list(@source_path_table)
+        |> Enum.map(fn {module, _path} -> module end)
+        |> get_info()
+    end
+  end
+
+  @doc """
+  Build a structured status report for extension loading.
+
+  Creates a comprehensive report suitable for UI/CLI consumption at session
+  startup. The report includes all loaded extensions, any load errors,
+  and tool conflict information.
+
+  ## Parameters
+
+    * `extensions` - List of successfully loaded extension modules
+    * `load_errors` - List of load error maps (from `load_extensions_with_errors/1`)
+    * `opts` - Options for the report:
+      * `:cwd` - Current working directory (required for tool conflict report)
+      * `:tool_conflict_report` - Pre-computed conflict report (optional)
+
+  ## Returns
+
+  An `extension_status_report()` map with all relevant information.
+
+  ## Examples
+
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors(paths)
+      report = Extensions.build_status_report(extensions, errors, cwd: "/path/to/project")
+
+      # Report structure:
+      # %{
+      #   extensions: [%{name: "my-ext", version: "1.0.0", ...}],
+      #   load_errors: [%{source_path: "/bad/ext.ex", error_message: "syntax error"}],
+      #   tool_conflicts: %{conflicts: [...], total_tools: 16, ...},
+      #   total_loaded: 2,
+      #   total_errors: 1,
+      #   loaded_at: 1706745600000
+      # }
+  """
+  @spec build_status_report(loaded_extensions(), [load_error()], keyword()) ::
+          extension_status_report()
+  def build_status_report(extensions, load_errors, opts \\ []) do
+    cwd = Keyword.get(opts, :cwd)
+    precomputed_conflicts = Keyword.get(opts, :tool_conflict_report)
+
+    # Get extension metadata
+    extension_info = get_info(extensions)
+
+    # Get tool conflicts if cwd is provided
+    tool_conflicts =
+      cond do
+        precomputed_conflicts != nil ->
+          precomputed_conflicts
+
+        cwd != nil ->
+          CodingAgent.ToolRegistry.tool_conflict_report(cwd)
+
+        true ->
+          nil
+      end
+
+    %{
+      extensions: extension_info,
+      load_errors: load_errors,
+      tool_conflicts: tool_conflicts,
+      total_loaded: length(extensions),
+      total_errors: length(load_errors),
+      loaded_at: System.system_time(:millisecond)
+    }
+  end
+
+  @doc """
+  Find duplicate tool names across loaded extensions.
+
+  Returns a map of tool names to the list of extension modules that
+  provide that tool. Only tools with multiple providers are included.
+  This is useful for detecting conflicts at the extension level before
+  merging with built-in tools.
+
+  ## Parameters
+
+    * `extensions` - List of loaded extension modules
+    * `cwd` - Current working directory (passed to each extension's `tools/1`)
+
+  ## Returns
+
+  A map where keys are tool names (strings) and values are lists of
+  extension modules that provide that tool.
+
+  ## Examples
+
+      duplicates = CodingAgent.Extensions.find_duplicate_tools(extensions, cwd)
+      # => %{"my_tool" => [ExtensionA, ExtensionB]}
+  """
+  @spec find_duplicate_tools(loaded_extensions(), String.t()) :: %{String.t() => [module()]}
+  def find_duplicate_tools(extensions, cwd) when is_list(extensions) do
+    extensions
+    |> get_tools_with_source(cwd)
+    |> Enum.group_by(fn {tool, _module} -> tool.name end, fn {_tool, module} -> module end)
+    |> Enum.filter(fn {_name, modules} -> length(modules) > 1 end)
+    |> Map.new()
   end
 
   # ============================================================================
   # Private Functions
   # ============================================================================
 
+  # Ensure the ETS table for source paths exists
+  @spec ensure_source_path_table() :: :ok
+  defp ensure_source_path_table do
+    case :ets.whereis(@source_path_table) do
+      :undefined ->
+        :ets.new(@source_path_table, [:set, :public, :named_table])
+        :ok
+
+      _tid ->
+        :ok
+    end
+  end
+
+  # Store the source path for an extension module
+  @spec store_source_path(module(), String.t()) :: true
+  defp store_source_path(module, path) do
+    ensure_source_path_table()
+    :ets.insert(@source_path_table, {module, path})
+  end
+
   # Discover extension modules in a directory
   @spec discover_extensions(String.t()) :: [module()]
   defp discover_extensions(dir) do
+    # Compile and load each file, extracting extension modules
+    dir
+    |> discover_extension_files()
+    |> Enum.flat_map(&load_extension_file/1)
+    |> Enum.filter(&implements_extension?/1)
+  end
+
+  # Discover extension files in a directory (without loading)
+  @spec discover_extension_files(String.t()) :: [String.t()]
+  defp discover_extension_files(dir) do
     # Look for .ex and .exs files
     patterns = [
       Path.join(dir, "*.ex"),
@@ -271,26 +661,61 @@ defmodule CodingAgent.Extensions do
       Path.join([dir, "*", "lib", "**", "*.ex"])
     ]
 
-    files =
-      patterns
-      |> Enum.flat_map(&Path.wildcard/1)
-      |> Enum.filter(&File.regular?/1)
-
-    # Compile and load each file, extracting extension modules
-    files
-    |> Enum.flat_map(&load_extension_file/1)
-    |> Enum.filter(&implements_extension?/1)
+    patterns
+    |> Enum.flat_map(&Path.wildcard/1)
+    |> Enum.filter(&File.regular?/1)
   end
 
-  # Load and compile an extension file
+  # Load and compile an extension file, tracking source paths
   @spec load_extension_file(String.t()) :: [module()]
   defp load_extension_file(path) do
     try do
-      Code.compile_file(path)
-      |> Enum.map(fn {module, _binary} -> module end)
+      modules =
+        Code.compile_file(path)
+        |> Enum.map(fn {module, _binary} -> module end)
+
+      extension_modules = Enum.filter(modules, &implements_extension?/1)
+
+      # Store the source path for each module
+      Enum.each(extension_modules, fn module ->
+        store_source_path(module, path)
+      end)
+
+      extension_modules
     rescue
       _ -> []
     end
+  end
+
+  # Load and compile an extension file with error tracking
+  # Returns {:ok, modules} or {:error, error, message}
+  @spec load_extension_file_safe(String.t()) ::
+          {:ok, [module()]} | {:error, term(), String.t()}
+  defp load_extension_file_safe(path) do
+    modules =
+      Code.compile_file(path)
+      |> Enum.map(fn {module, _binary} -> module end)
+
+    extension_modules = Enum.filter(modules, &implements_extension?/1)
+
+    # Store the source path for each module
+    Enum.each(extension_modules, fn module ->
+      store_source_path(module, path)
+    end)
+
+    {:ok, extension_modules}
+  rescue
+    e in CompileError ->
+      {:error, e, "Compile error: #{e.description}"}
+
+    e in SyntaxError ->
+      {:error, e, "Syntax error at line #{e.line}: #{e.description}"}
+
+    e in TokenMissingError ->
+      {:error, e, "Token error at line #{e.line}: #{e.description}"}
+
+    e ->
+      {:error, e, Exception.message(e)}
   end
 
   # Check if a module implements the Extension behaviour

--- a/apps/coding_agent/lib/coding_agent/extensions/extension.ex
+++ b/apps/coding_agent/lib/coding_agent/extensions/extension.ex
@@ -108,5 +108,128 @@ defmodule CodingAgent.Extensions.Extension do
   """
   @callback hooks() :: keyword()
 
-  @optional_callbacks [tools: 1, hooks: 0]
+  @doc """
+  Returns a list of capabilities provided by this extension.
+
+  Capabilities are atoms that describe what the extension can do,
+  allowing UIs and other systems to discover and filter extensions
+  by their functionality.
+
+  ## Common Capability Atoms
+
+    * `:tools` - Extension provides tools
+    * `:hooks` - Extension provides event hooks
+    * `:prompts` - Extension provides custom prompts/skills
+    * `:resources` - Extension provides resources (CLAUDE.md, etc.)
+    * `:mcp` - Extension connects to MCP servers
+
+  ## Returns
+
+  A list of capability atoms.
+
+  ## Example
+
+      @impl true
+      def capabilities, do: [:tools, :hooks]
+  """
+  @callback capabilities() :: [atom()]
+
+  @doc """
+  Returns the configuration schema for this extension.
+
+  The schema is a map describing configuration options that this
+  extension accepts, enabling UIs to render settings forms and
+  validate configuration.
+
+  ## Schema Format
+
+  The returned map should follow a JSON Schema-like format:
+
+      %{
+        "type" => "object",
+        "properties" => %{
+          "api_key" => %{
+            "type" => "string",
+            "description" => "API key for the service",
+            "secret" => true
+          },
+          "timeout" => %{
+            "type" => "integer",
+            "description" => "Request timeout in milliseconds",
+            "default" => 5000
+          }
+        },
+        "required" => ["api_key"]
+      }
+
+  ## Returns
+
+  A map describing the configuration schema, or an empty map if
+  the extension has no configuration options.
+
+  ## Example
+
+      @impl true
+      def config_schema do
+        %{
+          "type" => "object",
+          "properties" => %{
+            "enabled" => %{"type" => "boolean", "default" => true}
+          }
+        }
+      end
+  """
+  @callback config_schema() :: map()
+
+  @typedoc """
+  A provider specification for registration.
+
+  ## Fields
+
+    * `:type` - The provider type atom (e.g., `:model`, `:tool_executor`, `:storage`)
+    * `:name` - A unique name for this provider instance
+    * `:module` - The module implementing the provider behaviour
+    * `:config` - Optional configuration map for the provider
+
+  """
+  @type provider_spec :: %{
+          type: atom(),
+          name: atom() | String.t(),
+          module: module(),
+          config: map()
+        }
+
+  @doc """
+  Returns a list of providers that this extension registers.
+
+  Providers are pluggable components that extensions can contribute to the
+  system. Common provider types include:
+
+    * `:model` - AI model providers
+    * `:tool_executor` - Custom tool execution backends
+    * `:storage` - Storage backends for sessions, etc.
+
+  The session will automatically register these providers during startup.
+
+  ## Returns
+
+  A list of provider specification maps.
+
+  ## Example
+
+      @impl true
+      def providers do
+        [
+          %{
+            type: :model,
+            name: :my_custom_model,
+            module: MyExtension.CustomModelProvider,
+            config: %{api_key_env: "MY_API_KEY"}
+          }
+        ]
+      end
+  """
+  @callback providers() :: [provider_spec()]
+
+  @optional_callbacks [tools: 1, hooks: 0, capabilities: 0, config_schema: 0, providers: 0]
 end

--- a/apps/coding_agent/lib/coding_agent/subagents.ex
+++ b/apps/coding_agent/lib/coding_agent/subagents.ex
@@ -116,11 +116,20 @@ defmodule CodingAgent.Subagents do
 
   defp normalize_agent(%{"id" => id, "prompt" => prompt} = agent)
        when is_binary(id) and is_binary(prompt) do
-    %{
-      id: id,
-      description: agent["description"] || "",
-      prompt: prompt
-    }
+    id = String.trim(id)
+    prompt = String.trim(prompt)
+
+    if id == "" or prompt == "" do
+      nil
+    else
+      description = agent["description"]
+
+      %{
+        id: id,
+        description: if(is_binary(description), do: description, else: ""),
+        prompt: prompt
+      }
+    end
   end
 
   defp normalize_agent(_), do: nil

--- a/apps/coding_agent/lib/coding_agent/tools/extensions_status.ex
+++ b/apps/coding_agent/lib/coding_agent/tools/extensions_status.ex
@@ -1,0 +1,341 @@
+defmodule CodingAgent.Tools.ExtensionsStatus do
+  @moduledoc """
+  Extensions status tool for the coding agent.
+
+  Returns the current extension status report for the running session,
+  allowing the agent to self-diagnose plugin loading issues and conflicts.
+  """
+
+  alias AgentCore.Types.{AgentTool, AgentToolResult}
+  alias AgentCore.AbortSignal
+  alias Ai.Types.TextContent
+
+  @doc """
+  Returns the ExtensionsStatus tool definition.
+  """
+  @spec tool(cwd :: String.t(), opts :: keyword()) :: AgentTool.t()
+  def tool(cwd, opts \\ []) do
+    session_id = Keyword.get(opts, :session_id, "")
+
+    %AgentTool{
+      name: "extensions_status",
+      description: """
+      Get the extension status report for the current session.
+
+      Returns information about:
+      - Loaded extensions (name, version, capabilities, source path)
+      - Extension load errors (syntax errors, compile errors)
+      - Tool conflicts (which tools were shadowed and by what)
+
+      Use this tool to diagnose plugin loading issues or understand which
+      extensions and tools are active in the current session.
+      """,
+      label: "Extensions Status",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "include_details" => %{
+            "type" => "boolean",
+            "description" =>
+              "Include full details like source paths and config schemas. Defaults to false for a summary view.",
+            "default" => false
+          }
+        },
+        "required" => []
+      },
+      execute: &execute(&1, &2, &3, &4, session_id, cwd)
+    }
+  end
+
+  @spec execute(
+          tool_call_id :: String.t(),
+          params :: map(),
+          signal :: reference() | nil,
+          on_update :: (AgentToolResult.t() -> :ok) | nil,
+          session_id :: String.t(),
+          cwd :: String.t()
+        ) :: AgentToolResult.t() | {:error, term()}
+  def execute(_tool_call_id, params, signal, _on_update, session_id, cwd) do
+    if AbortSignal.aborted?(signal) do
+      {:error, "Operation aborted"}
+    else
+      include_details = Map.get(params, "include_details", false)
+      get_status_report(session_id, include_details, cwd)
+    end
+  end
+
+  @spec get_status_report(String.t(), boolean(), String.t()) ::
+          AgentToolResult.t() | {:error, term()}
+  defp get_status_report("", include_details, cwd) do
+    # No session_id - fall back to listing all loaded extensions with tool conflicts
+    extensions = CodingAgent.Extensions.list_extensions()
+    tool_conflicts = CodingAgent.ToolRegistry.tool_conflict_report(cwd)
+
+    output = format_fallback_report(extensions, tool_conflicts, include_details)
+
+    %AgentToolResult{
+      content: [%TextContent{text: output}],
+      details: %{
+        title: format_fallback_title(extensions, tool_conflicts, "no session context"),
+        extensions: extensions,
+        tool_conflicts: tool_conflicts
+      }
+    }
+  end
+
+  defp get_status_report(session_id, include_details, cwd) do
+    # Try to get the session from the registry
+    case get_session_pid(session_id) do
+      {:ok, session_pid} ->
+        report = CodingAgent.Session.get_extension_status_report(session_pid)
+        format_report(report, include_details)
+
+      {:error, :not_found} ->
+        # Fall back to listing all loaded extensions with tool conflicts
+        extensions = CodingAgent.Extensions.list_extensions()
+        tool_conflicts = CodingAgent.ToolRegistry.tool_conflict_report(cwd)
+
+        output = format_fallback_report(extensions, tool_conflicts, include_details)
+
+        %AgentToolResult{
+          content: [%TextContent{text: output}],
+          details: %{
+            title: format_fallback_title(extensions, tool_conflicts, "session not found"),
+            extensions: extensions,
+            tool_conflicts: tool_conflicts
+          }
+        }
+    end
+  end
+
+  @spec get_session_pid(String.t()) :: {:ok, pid()} | {:error, :not_found}
+  defp get_session_pid(session_id) do
+    case Process.whereis(CodingAgent.SessionRegistry) do
+      nil ->
+        {:error, :not_found}
+
+      _pid ->
+        case Registry.lookup(CodingAgent.SessionRegistry, session_id) do
+          [{pid, _value}] -> {:ok, pid}
+          [] -> {:error, :not_found}
+        end
+    end
+  end
+
+  @spec format_report(map() | nil, boolean()) :: AgentToolResult.t()
+  defp format_report(nil, _include_details) do
+    %AgentToolResult{
+      content: [%TextContent{text: "No extension status report available."}],
+      details: %{title: "No report"}
+    }
+  end
+
+  defp format_report(report, include_details) do
+    sections = []
+
+    # Summary section
+    summary =
+      "# Extension Status Report\n\n" <>
+        "- **Extensions loaded:** #{report.total_loaded}\n" <>
+        "- **Load errors:** #{report.total_errors}\n" <>
+        "- **Loaded at:** #{format_timestamp(report.loaded_at)}\n"
+
+    sections = [summary | sections]
+
+    # Extensions section
+    sections =
+      if report.total_loaded > 0 do
+        ext_section = format_extensions_section(report.extensions, include_details)
+        [ext_section | sections]
+      else
+        sections
+      end
+
+    # Load errors section
+    sections =
+      if report.total_errors > 0 do
+        error_section = format_errors_section(report.load_errors)
+        [error_section | sections]
+      else
+        sections
+      end
+
+    # Tool conflicts section
+    sections =
+      if report.tool_conflicts != nil do
+        conflict_section = format_conflicts_section(report.tool_conflicts)
+        [conflict_section | sections]
+      else
+        sections
+      end
+
+    output = sections |> Enum.reverse() |> Enum.join("\n")
+
+    title =
+      cond do
+        report.total_errors > 0 ->
+          "#{report.total_loaded} loaded, #{report.total_errors} errors"
+
+        report.tool_conflicts != nil and report.tool_conflicts.shadowed_count > 0 ->
+          "#{report.total_loaded} loaded, #{report.tool_conflicts.shadowed_count} conflicts"
+
+        true ->
+          "#{report.total_loaded} extensions loaded"
+      end
+
+    %AgentToolResult{
+      content: [%TextContent{text: output}],
+      details: %{
+        title: title,
+        total_loaded: report.total_loaded,
+        total_errors: report.total_errors,
+        tool_conflicts: report.tool_conflicts
+      }
+    }
+  end
+
+  @spec format_extensions_section([map()], boolean()) :: String.t()
+  defp format_extensions_section(extensions, include_details) do
+    header = "\n## Loaded Extensions\n"
+
+    ext_list =
+      Enum.map(extensions, fn ext ->
+        base = "- **#{ext.name}** v#{ext.version}"
+
+        capabilities =
+          if ext.capabilities != [] do
+            " (#{Enum.join(ext.capabilities, ", ")})"
+          else
+            ""
+          end
+
+        details =
+          if include_details do
+            source =
+              if ext.source_path do
+                "\n  - Source: `#{ext.source_path}`"
+              else
+                ""
+              end
+
+            module = "\n  - Module: `#{inspect(ext.module)}`"
+
+            config_schema =
+              if ext.config_schema != %{} do
+                "\n  - Has config schema: yes"
+              else
+                ""
+              end
+
+            source <> module <> config_schema
+          else
+            ""
+          end
+
+        base <> capabilities <> details
+      end)
+
+    header <> Enum.join(ext_list, "\n")
+  end
+
+  @spec format_errors_section([map()]) :: String.t()
+  defp format_errors_section(errors) do
+    header = "\n## Load Errors\n"
+
+    error_list =
+      Enum.map(errors, fn error ->
+        "- `#{error.source_path}`\n  - #{error.error_message}"
+      end)
+
+    header <> Enum.join(error_list, "\n")
+  end
+
+  @spec format_conflicts_section(map()) :: String.t()
+  defp format_conflicts_section(conflicts) do
+    header =
+      "\n## Tool Registry\n" <>
+        "- **Total tools:** #{conflicts.total_tools}\n" <>
+        "- **Built-in:** #{conflicts.builtin_count}\n" <>
+        "- **From extensions:** #{conflicts.extension_count}\n" <>
+        "- **Shadowed:** #{conflicts.shadowed_count}\n"
+
+    if conflicts.conflicts != [] do
+      conflict_details =
+        "\n### Conflicts\n" <>
+          (conflicts.conflicts
+           |> Enum.map(fn c ->
+             winner =
+               case c.winner do
+                 :builtin -> "built-in"
+                 {:extension, mod} -> "extension `#{inspect(mod)}`"
+               end
+
+             shadowed =
+               c.shadowed
+               |> Enum.map(fn {:extension, mod} -> "`#{inspect(mod)}`" end)
+               |> Enum.join(", ")
+
+             "- **#{c.tool_name}**: winner is #{winner}, shadowed: #{shadowed}"
+           end)
+           |> Enum.join("\n"))
+
+      header <> conflict_details
+    else
+      header
+    end
+  end
+
+  @spec format_fallback_report([map()], map(), boolean()) :: String.t()
+  defp format_fallback_report(extensions, tool_conflicts, include_details) do
+    sections = []
+
+    # Summary section
+    summary =
+      "# Extension Status Report\n\n" <>
+        "- **Extensions loaded:** #{length(extensions)}\n" <>
+        "- **Total tools:** #{tool_conflicts.total_tools}\n"
+
+    sections = [summary | sections]
+
+    # Extensions section
+    sections =
+      if extensions != [] do
+        ext_section = format_extensions_section(extensions, include_details)
+        [ext_section | sections]
+      else
+        sections
+      end
+
+    # Tool conflicts section
+    sections =
+      if tool_conflicts != nil do
+        conflict_section = format_conflicts_section(tool_conflicts)
+        [conflict_section | sections]
+      else
+        sections
+      end
+
+    sections |> Enum.reverse() |> Enum.join("\n")
+  end
+
+  @spec format_fallback_title([map()], map(), String.t()) :: String.t()
+  defp format_fallback_title(extensions, tool_conflicts, context) do
+    ext_count = length(extensions)
+
+    cond do
+      tool_conflicts != nil and tool_conflicts.shadowed_count > 0 ->
+        "#{ext_count} loaded, #{tool_conflicts.shadowed_count} conflicts (#{context})"
+
+      true ->
+        "#{ext_count} extensions loaded (#{context})"
+    end
+  end
+
+  @spec format_timestamp(integer()) :: String.t()
+  defp format_timestamp(ms) when is_integer(ms) do
+    datetime = DateTime.from_unix!(div(ms, 1000))
+    Calendar.strftime(datetime, "%Y-%m-%d %H:%M:%S UTC")
+  end
+
+  defp format_timestamp(_), do: "unknown"
+end

--- a/apps/coding_agent/lib/coding_agent/tools/todo_store.ex
+++ b/apps/coding_agent/lib/coding_agent/tools/todo_store.ex
@@ -59,6 +59,48 @@ defmodule CodingAgent.Tools.TodoStore do
     :ok
   end
 
+  @doc """
+  Deletes the todo list for a session.
+
+  Returns :ok even if the session has no stored todos.
+  """
+  @spec delete(String.t()) :: :ok
+  def delete(session_id) when is_binary(session_id) do
+    case :ets.whereis(@table) do
+      :undefined ->
+        :ok
+
+      _tid ->
+        :ets.delete(@table, session_id)
+        :ok
+    end
+  rescue
+    ArgumentError ->
+      :ok
+  end
+
+  @doc """
+  Clears all todos from the store.
+
+  Primarily used by tests to ensure isolation.
+
+  If the ETS table has not been created yet, this is a no-op.
+  """
+  @spec clear() :: :ok
+  def clear do
+    case :ets.whereis(@table) do
+      :undefined ->
+        :ok
+
+      _tid ->
+        :ets.delete_all_objects(@table)
+        :ok
+    end
+  rescue
+    ArgumentError ->
+      :ok
+  end
+
   defp ensure_table do
     case :ets.whereis(@table) do
       :undefined ->

--- a/apps/coding_agent/lib/coding_agent/tools/todowrite.ex
+++ b/apps/coding_agent/lib/coding_agent/tools/todowrite.ex
@@ -75,16 +75,103 @@ defmodule CodingAgent.Tools.TodoWrite do
           {:error, "Session id not available"}
 
         true ->
-          TodoStore.put(session_id, todos)
+          with :ok <- validate_todos(todos) do
+            TodoStore.put(session_id, todos)
 
-          output = Jason.encode!(todos, pretty: true)
-          open_count = Enum.count(todos, fn todo -> todo["status"] != "completed" end)
+            output = Jason.encode!(todos, pretty: true)
+            open_count = Enum.count(todos, fn todo -> Map.get(todo, "status") != "completed" end)
 
-          %AgentToolResult{
-            content: [%TextContent{text: output}],
-            details: %{title: "#{open_count} todos", todos: todos}
-          }
+            %AgentToolResult{
+              content: [%TextContent{text: output}],
+              details: %{title: "#{open_count} todos", todos: todos}
+            }
+          end
       end
+    end
+  end
+
+  defp validate_todos(todos) when is_list(todos) do
+    with :ok <- validate_entries(todos),
+         :ok <- validate_unique_ids(todos) do
+      :ok
+    end
+  end
+
+  defp validate_entries(todos) do
+    Enum.reduce_while(Enum.with_index(todos, 1), :ok, fn
+      {todo, idx}, :ok when is_map(todo) ->
+        case validate_todo(todo, idx) do
+          :ok -> {:cont, :ok}
+          {:error, _} = err -> {:halt, err}
+        end
+
+      {_todo, idx}, :ok ->
+        {:halt, {:error, "Todo #{idx} must be an object"}}
+    end)
+  end
+
+  defp validate_todo(todo, idx) do
+    with :ok <- validate_non_empty_string(todo, "id", idx),
+         :ok <- validate_non_empty_string(todo, "content", idx),
+         :ok <- validate_status(todo, idx),
+         :ok <- validate_priority(todo, idx) do
+      :ok
+    end
+  end
+
+  defp validate_non_empty_string(todo, key, idx) do
+    case Map.get(todo, key) do
+      value when is_binary(value) ->
+        if byte_size(String.trim(value)) > 0 do
+          :ok
+        else
+          {:error, "Todo #{idx} #{key} must be a non-empty string"}
+        end
+
+      _ ->
+        {:error, "Todo #{idx} #{key} must be a non-empty string"}
+    end
+  end
+
+  defp validate_status(todo, idx) do
+    allowed = ["pending", "in_progress", "completed"]
+
+    case Map.get(todo, "status") do
+      value when is_binary(value) ->
+        if value in allowed do
+          :ok
+        else
+          {:error, "Todo #{idx} status must be pending, in_progress, or completed"}
+        end
+
+      _ ->
+        {:error, "Todo #{idx} status must be pending, in_progress, or completed"}
+    end
+  end
+
+  defp validate_priority(todo, idx) do
+    allowed = ["high", "medium", "low"]
+
+    case Map.get(todo, "priority") do
+      value when is_binary(value) ->
+        if value in allowed do
+          :ok
+        else
+          {:error, "Todo #{idx} priority must be high, medium, or low"}
+        end
+
+      _ ->
+        {:error, "Todo #{idx} priority must be high, medium, or low"}
+    end
+  end
+
+  defp validate_unique_ids(todos) do
+    ids = Enum.map(todos, &Map.get(&1, "id"))
+
+    if Enum.uniq(ids) == ids do
+      :ok
+    else
+      {:error, "todo ids must be unique"}
     end
   end
 end

--- a/apps/coding_agent/test/coding_agent/extensions_test.exs
+++ b/apps/coding_agent/test/coding_agent/extensions_test.exs
@@ -201,5 +201,485 @@ defmodule CodingAgent.ExtensionsTest do
       :code.purge(InfoExtension)
       :code.delete(InfoExtension)
     end
+
+    test "includes source_path for loaded extensions", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule SourcePathExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "source-path-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+      """
+
+      ext_path = Path.join(tmp_dir, "source_path_extension.ex")
+      File.write!(ext_path, extension_code)
+      {:ok, extensions} = Extensions.load_extensions([tmp_dir])
+
+      info = Extensions.get_info(extensions)
+      ext_info = hd(info)
+
+      assert ext_info.source_path == ext_path
+
+      # Cleanup
+      :code.purge(SourcePathExtension)
+      :code.delete(SourcePathExtension)
+    end
+
+    test "includes capabilities and config_schema for extensions", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule RichMetadataExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "rich-metadata-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def capabilities, do: [:tools, :hooks]
+
+        @impl true
+        def config_schema do
+          %{
+            "type" => "object",
+            "properties" => %{
+              "api_key" => %{"type" => "string", "description" => "API key", "secret" => true},
+              "timeout" => %{"type" => "integer", "default" => 5000}
+            },
+            "required" => ["api_key"]
+          }
+        end
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "rich_metadata_extension.ex"), extension_code)
+      {:ok, extensions} = Extensions.load_extensions([tmp_dir])
+
+      info = Extensions.get_info(extensions)
+      ext_info = hd(info)
+
+      assert ext_info.name == "rich-metadata-ext"
+      assert ext_info.capabilities == [:tools, :hooks]
+      assert ext_info.config_schema["type"] == "object"
+      assert ext_info.config_schema["properties"]["api_key"]["secret"] == true
+      assert ext_info.config_schema["required"] == ["api_key"]
+
+      # Cleanup
+      :code.purge(RichMetadataExtension)
+      :code.delete(RichMetadataExtension)
+    end
+
+    test "returns empty defaults for extensions without capabilities/config_schema", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule MinimalExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "minimal-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "minimal_extension.ex"), extension_code)
+      {:ok, extensions} = Extensions.load_extensions([tmp_dir])
+
+      info = Extensions.get_info(extensions)
+      ext_info = hd(info)
+
+      assert ext_info.capabilities == []
+      assert ext_info.config_schema == %{}
+
+      # Cleanup
+      :code.purge(MinimalExtension)
+      :code.delete(MinimalExtension)
+    end
+  end
+
+  describe "get_source_path/1" do
+    test "returns source path for loaded extension", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule PathTrackExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "path-track-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+      """
+
+      ext_path = Path.join(tmp_dir, "path_track_extension.ex")
+      File.write!(ext_path, extension_code)
+      {:ok, _extensions} = Extensions.load_extensions([tmp_dir])
+
+      assert Extensions.get_source_path(PathTrackExtension) == ext_path
+
+      # Cleanup
+      :code.purge(PathTrackExtension)
+      :code.delete(PathTrackExtension)
+    end
+
+    test "returns nil for unknown module" do
+      assert Extensions.get_source_path(UnknownModule) == nil
+    end
+  end
+
+  describe "list_extensions/0" do
+    test "returns all loaded extensions", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule ListExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "list-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "list_extension.ex"), extension_code)
+      {:ok, _extensions} = Extensions.load_extensions([tmp_dir])
+
+      all = Extensions.list_extensions()
+      list_ext = Enum.find(all, fn e -> e.name == "list-ext" end)
+
+      assert list_ext != nil
+      assert list_ext.version == "1.0.0"
+      assert list_ext.module == ListExtension
+      assert list_ext.source_path != nil
+
+      # Cleanup
+      :code.purge(ListExtension)
+      :code.delete(ListExtension)
+    end
+
+    test "does not include non-extension modules from extension files", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule ListMainExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "list-main-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+
+      defmodule ListHelperModule do
+        def ok, do: :ok
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "list_main_extension.ex"), extension_code)
+      {:ok, _extensions} = Extensions.load_extensions([tmp_dir])
+
+      all = Extensions.list_extensions()
+
+      assert Enum.any?(all, fn e -> e.module == ListMainExtension end)
+      refute Enum.any?(all, fn e -> e.module == ListHelperModule end)
+
+      # Cleanup
+      :code.purge(ListMainExtension)
+      :code.delete(ListMainExtension)
+      :code.purge(ListHelperModule)
+      :code.delete(ListHelperModule)
+    end
+  end
+
+  describe "find_duplicate_tools/2" do
+    test "returns empty map for no duplicates", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule NoDuplicatesExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "no-dups-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "unique_tool_a",
+              description: "Unique A",
+              parameters: %{},
+              label: "Unique A",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "no_duplicates_extension.ex"), extension_code)
+      {:ok, extensions} = Extensions.load_extensions([tmp_dir])
+
+      duplicates = Extensions.find_duplicate_tools(extensions, tmp_dir)
+      assert duplicates == %{}
+
+      # Cleanup
+      :code.purge(NoDuplicatesExtension)
+      :code.delete(NoDuplicatesExtension)
+    end
+
+    test "detects duplicate tool names across extensions", %{tmp_dir: tmp_dir} do
+      ext_a_code = """
+      defmodule DupToolExtA do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "dup-tool-a"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "dup_tool",
+              description: "From A",
+              parameters: %{},
+              label: "Dup A",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      ext_b_code = """
+      defmodule DupToolExtB do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "dup-tool-b"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "dup_tool",
+              description: "From B",
+              parameters: %{},
+              label: "Dup B",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "dup_tool_ext_a.ex"), ext_a_code)
+      File.write!(Path.join(tmp_dir, "dup_tool_ext_b.ex"), ext_b_code)
+      {:ok, extensions} = Extensions.load_extensions([tmp_dir])
+
+      duplicates = Extensions.find_duplicate_tools(extensions, tmp_dir)
+      assert Map.has_key?(duplicates, "dup_tool")
+      assert length(duplicates["dup_tool"]) == 2
+      assert DupToolExtA in duplicates["dup_tool"]
+      assert DupToolExtB in duplicates["dup_tool"]
+
+      # Cleanup
+      :code.purge(DupToolExtA)
+      :code.delete(DupToolExtA)
+      :code.purge(DupToolExtB)
+      :code.delete(DupToolExtB)
+    end
+
+    test "returns empty map for no extensions" do
+      duplicates = Extensions.find_duplicate_tools([], "/tmp")
+      assert duplicates == %{}
+    end
+  end
+
+  describe "load_extensions_with_errors/1" do
+    test "returns ok with empty lists for non-existent paths" do
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors(["/nonexistent/path"])
+      assert extensions == []
+      assert errors == []
+    end
+
+    test "loads extensions and returns empty errors for valid files", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule ValidExtensionWithErrors do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "valid-ext-errors"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "valid_extension.ex"), extension_code)
+
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors([tmp_dir])
+      assert ValidExtensionWithErrors in extensions
+      assert errors == []
+
+      # Cleanup
+      :code.purge(ValidExtensionWithErrors)
+      :code.delete(ValidExtensionWithErrors)
+    end
+
+    test "captures compile errors for invalid files", %{tmp_dir: tmp_dir} do
+      # Create a file with a syntax error
+      invalid_code = """
+      defmodule BadExtension do
+        def foo do
+          # Missing end
+      """
+
+      bad_path = Path.join(tmp_dir, "bad_extension.ex")
+      File.write!(bad_path, invalid_code)
+
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors([tmp_dir])
+      assert extensions == []
+      assert length(errors) == 1
+
+      error = hd(errors)
+      assert error.source_path == bad_path
+      assert is_binary(error.error_message)
+
+      # The error should mention the issue
+      assert error.error_message =~ "error" or error.error_message =~ "end"
+    end
+
+    test "returns both valid extensions and errors", %{tmp_dir: tmp_dir} do
+      valid_code = """
+      defmodule MixedValidExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "mixed-valid"
+
+        @impl true
+        def version, do: "1.0.0"
+      end
+      """
+
+      invalid_code = """
+      defmodule MixedBadExtension do
+        # Syntax error - unclosed string
+        def foo, do: "unclosed
+      """
+
+      File.write!(Path.join(tmp_dir, "valid.ex"), valid_code)
+      File.write!(Path.join(tmp_dir, "invalid.ex"), invalid_code)
+
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors([tmp_dir])
+      assert MixedValidExtension in extensions
+      assert length(errors) == 1
+
+      # Cleanup
+      :code.purge(MixedValidExtension)
+      :code.delete(MixedValidExtension)
+    end
+  end
+
+  describe "build_status_report/3" do
+    test "builds a complete status report", %{tmp_dir: tmp_dir} do
+      extension_code = """
+      defmodule StatusReportExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "status-report-ext"
+
+        @impl true
+        def version, do: "2.0.0"
+
+        @impl true
+        def capabilities, do: [:tools]
+      end
+      """
+
+      File.write!(Path.join(tmp_dir, "status_report_extension.ex"), extension_code)
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors([tmp_dir])
+
+      report = Extensions.build_status_report(extensions, errors, cwd: tmp_dir)
+
+      assert is_map(report)
+      assert report.total_loaded == 1
+      assert report.total_errors == 0
+      assert is_integer(report.loaded_at)
+      assert is_list(report.extensions)
+      assert is_list(report.load_errors)
+
+      # Check extension metadata
+      ext_info = hd(report.extensions)
+      assert ext_info.name == "status-report-ext"
+      assert ext_info.version == "2.0.0"
+      assert ext_info.capabilities == [:tools]
+
+      # Cleanup
+      :code.purge(StatusReportExtension)
+      :code.delete(StatusReportExtension)
+    end
+
+    test "includes load errors in report", %{tmp_dir: tmp_dir} do
+      # Create an invalid extension
+      bad_code = """
+      defmodule ReportBadExtension do
+        def missing_end
+      """
+
+      File.write!(Path.join(tmp_dir, "bad.ex"), bad_code)
+      {:ok, extensions, errors} = Extensions.load_extensions_with_errors([tmp_dir])
+
+      report = Extensions.build_status_report(extensions, errors, cwd: tmp_dir)
+
+      assert report.total_loaded == 0
+      assert report.total_errors == 1
+      assert length(report.load_errors) == 1
+
+      error = hd(report.load_errors)
+      assert String.ends_with?(error.source_path, "bad.ex")
+      assert is_binary(error.error_message)
+    end
+
+    test "includes tool conflicts when cwd provided", %{tmp_dir: tmp_dir} do
+      report = Extensions.build_status_report([], [], cwd: tmp_dir)
+
+      assert is_map(report.tool_conflicts)
+      assert Map.has_key?(report.tool_conflicts, :conflicts)
+      assert Map.has_key?(report.tool_conflicts, :total_tools)
+    end
+
+    test "tool_conflicts is nil when no cwd provided" do
+      report = Extensions.build_status_report([], [], [])
+
+      assert report.tool_conflicts == nil
+    end
+
+    test "accepts precomputed tool_conflict_report" do
+      fake_conflict_report = %{
+        conflicts: [],
+        total_tools: 5,
+        builtin_count: 5,
+        extension_count: 0,
+        shadowed_count: 0
+      }
+
+      report = Extensions.build_status_report([], [], tool_conflict_report: fake_conflict_report)
+
+      assert report.tool_conflicts == fake_conflict_report
+    end
   end
 end

--- a/apps/coding_agent/test/coding_agent/tool_registry_test.exs
+++ b/apps/coding_agent/test/coding_agent/tool_registry_test.exs
@@ -123,4 +123,464 @@ defmodule CodingAgent.ToolRegistryTest do
       assert Enum.all?(names, &is_atom/1)
     end
   end
+
+  describe "extension_paths option" do
+    test "loads extensions from specified paths", %{tmp_dir: tmp_dir} do
+      # Create a custom extension path
+      custom_ext_dir = Path.join(tmp_dir, "custom_extensions")
+      File.mkdir_p!(custom_ext_dir)
+
+      # Create an extension in the custom path
+      extension_code = """
+      defmodule CustomPathExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "custom-path-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "custom_path_tool",
+              description: "A tool from custom path",
+              parameters: %{},
+              label: "Custom Path Tool",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(custom_ext_dir, "custom_path_extension.ex"), extension_code)
+
+      # Load tools with custom extension_paths
+      tools = ToolRegistry.get_tools(tmp_dir, extension_paths: [custom_ext_dir])
+
+      names = Enum.map(tools, & &1.name)
+      assert "custom_path_tool" in names
+
+      # Cleanup
+      :code.purge(CustomPathExtension)
+      :code.delete(CustomPathExtension)
+    end
+
+    test "ignores default paths when extension_paths is provided", %{tmp_dir: tmp_dir} do
+      # Create extension in default .lemon/extensions path
+      default_ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(default_ext_dir)
+
+      extension_code = """
+      defmodule DefaultPathExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "default-path-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "default_path_tool",
+              description: "A tool from default path",
+              parameters: %{},
+              label: "Default Path Tool",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(default_ext_dir, "default_path_extension.ex"), extension_code)
+
+      # Create a different custom path (empty)
+      custom_ext_dir = Path.join(tmp_dir, "other_extensions")
+      File.mkdir_p!(custom_ext_dir)
+
+      # Load tools with custom extension_paths (not the default .lemon/extensions)
+      tools = ToolRegistry.get_tools(tmp_dir, extension_paths: [custom_ext_dir])
+
+      names = Enum.map(tools, & &1.name)
+      # Should NOT include tool from default path
+      refute "default_path_tool" in names
+
+      # But should include built-in tools
+      assert "read" in names
+
+      # Cleanup
+      :code.purge(DefaultPathExtension)
+      :code.delete(DefaultPathExtension)
+    end
+  end
+
+  describe "tool conflict detection" do
+    import ExUnit.CaptureLog
+
+    test "warns when extension tool shadows builtin tool", %{tmp_dir: tmp_dir} do
+      # Create extension dir
+      ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(ext_dir)
+
+      # Create an extension with a tool named "read" (conflicts with builtin)
+      extension_code = """
+      defmodule ConflictBuiltinExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "conflict-builtin-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "read",
+              description: "A conflicting read tool",
+              parameters: %{},
+              label: "Conflict Read",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "conflict_builtin_extension.ex"), extension_code)
+
+      log =
+        capture_log(fn ->
+          tools = ToolRegistry.get_tools(tmp_dir)
+          # Builtin tool should win - verify only one "read" tool
+          read_tools = Enum.filter(tools, fn t -> t.name == "read" end)
+          assert length(read_tools) == 1
+          # The description should be from builtin, not the extension
+          refute hd(read_tools).description == "A conflicting read tool"
+        end)
+
+      assert log =~ "Tool name conflict"
+      assert log =~ "read"
+      assert log =~ "ConflictBuiltinExtension"
+      assert log =~ "shadowed by built-in tool"
+
+      # Cleanup
+      :code.purge(ConflictBuiltinExtension)
+      :code.delete(ConflictBuiltinExtension)
+    end
+
+    test "warns when extension tool shadows another extension tool", %{tmp_dir: tmp_dir} do
+      # Create extension dir
+      ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(ext_dir)
+
+      # Create two extensions with the same tool name
+      # Extensions are loaded alphabetically, so "a_extension" loads before "b_extension"
+      extension_a_code = """
+      defmodule AConflictExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "a-conflict-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "custom_tool",
+              description: "Tool from A extension",
+              parameters: %{},
+              label: "Custom A",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      extension_b_code = """
+      defmodule BConflictExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "b-conflict-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "custom_tool",
+              description: "Tool from B extension",
+              parameters: %{},
+              label: "Custom B",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "a_conflict_extension.ex"), extension_a_code)
+      File.write!(Path.join(ext_dir, "b_conflict_extension.ex"), extension_b_code)
+
+      log =
+        capture_log(fn ->
+          tools = ToolRegistry.get_tools(tmp_dir)
+          # First extension should win - verify only one "custom_tool"
+          custom_tools = Enum.filter(tools, fn t -> t.name == "custom_tool" end)
+          assert length(custom_tools) == 1
+          # The description should be from A extension (loaded first)
+          assert hd(custom_tools).description == "Tool from A extension"
+        end)
+
+      assert log =~ "Tool name conflict"
+      assert log =~ "custom_tool"
+      assert log =~ "BConflictExtension"
+      assert log =~ "shadowed by earlier extension"
+
+      # Cleanup
+      :code.purge(AConflictExtension)
+      :code.delete(AConflictExtension)
+      :code.purge(BConflictExtension)
+      :code.delete(BConflictExtension)
+    end
+
+    test "no warning when tools have unique names", %{tmp_dir: tmp_dir} do
+      # Create extension dir
+      ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(ext_dir)
+
+      # Create an extension with a unique tool name
+      extension_code = """
+      defmodule UniqueToolExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "unique-tool-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "my_unique_tool",
+              description: "A unique tool",
+              parameters: %{},
+              label: "Unique Tool",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "unique_tool_extension.ex"), extension_code)
+
+      log =
+        capture_log(fn ->
+          tools = ToolRegistry.get_tools(tmp_dir)
+          # Should have the unique tool
+          names = Enum.map(tools, & &1.name)
+          assert "my_unique_tool" in names
+        end)
+
+      refute log =~ "Tool name conflict"
+
+      # Cleanup
+      :code.purge(UniqueToolExtension)
+      :code.delete(UniqueToolExtension)
+    end
+  end
+
+  describe "tool_conflict_report/2" do
+    test "returns empty conflicts for no extensions", %{tmp_dir: tmp_dir} do
+      report = ToolRegistry.tool_conflict_report(tmp_dir, include_extensions: false)
+
+      assert report.conflicts == []
+      assert report.shadowed_count == 0
+      assert report.builtin_count == length(ToolRegistry.builtin_tool_names())
+      assert report.extension_count == 0
+      assert report.total_tools == report.builtin_count
+    end
+
+    test "detects builtin shadowing conflicts", %{tmp_dir: tmp_dir} do
+      ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(ext_dir)
+
+      extension_code = """
+      defmodule ConflictReportBuiltinExt do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "conflict-report-builtin"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "read",
+              description: "Conflicting read",
+              parameters: %{},
+              label: "Read",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "conflict_report_builtin_ext.ex"), extension_code)
+
+      report = ToolRegistry.tool_conflict_report(tmp_dir)
+
+      assert length(report.conflicts) == 1
+      conflict = hd(report.conflicts)
+      assert conflict.tool_name == "read"
+      assert conflict.winner == :builtin
+      assert length(conflict.shadowed) == 1
+      assert {:extension, ConflictReportBuiltinExt} in conflict.shadowed
+      assert report.shadowed_count == 1
+
+      # Cleanup
+      :code.purge(ConflictReportBuiltinExt)
+      :code.delete(ConflictReportBuiltinExt)
+    end
+
+    test "detects extension-to-extension conflicts", %{tmp_dir: tmp_dir} do
+      ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(ext_dir)
+
+      extension_a_code = """
+      defmodule ConflictReportExtA do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "conflict-report-a"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "shared_tool",
+              description: "From A",
+              parameters: %{},
+              label: "Shared A",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      extension_b_code = """
+      defmodule ConflictReportExtB do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "conflict-report-b"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "shared_tool",
+              description: "From B",
+              parameters: %{},
+              label: "Shared B",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "conflict_report_ext_a.ex"), extension_a_code)
+      File.write!(Path.join(ext_dir, "conflict_report_ext_b.ex"), extension_b_code)
+
+      report = ToolRegistry.tool_conflict_report(tmp_dir)
+
+      assert length(report.conflicts) == 1
+      conflict = hd(report.conflicts)
+      assert conflict.tool_name == "shared_tool"
+      # Winner should be extension (first one loaded)
+      assert {:extension, _winner_module} = conflict.winner
+      assert length(conflict.shadowed) == 1
+      assert report.shadowed_count == 1
+
+      # Cleanup
+      :code.purge(ConflictReportExtA)
+      :code.delete(ConflictReportExtA)
+      :code.purge(ConflictReportExtB)
+      :code.delete(ConflictReportExtB)
+    end
+
+    test "returns correct counts", %{tmp_dir: tmp_dir} do
+      ext_dir = Path.join(tmp_dir, ".lemon/extensions")
+      File.mkdir_p!(ext_dir)
+
+      extension_code = """
+      defmodule ConflictReportCountExt do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "count-ext"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def tools(_cwd) do
+          [
+            %AgentCore.Types.AgentTool{
+              name: "unique_count_tool",
+              description: "Unique tool",
+              parameters: %{},
+              label: "Unique",
+              execute: fn _, _, _, _ -> %AgentCore.Types.AgentToolResult{content: []} end
+            }
+          ]
+        end
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "conflict_report_count_ext.ex"), extension_code)
+
+      report = ToolRegistry.tool_conflict_report(tmp_dir)
+
+      assert report.conflicts == []
+      assert report.builtin_count == length(ToolRegistry.builtin_tool_names())
+      assert report.extension_count == 1
+      assert report.total_tools == report.builtin_count + report.extension_count
+      assert report.shadowed_count == 0
+
+      # Cleanup
+      :code.purge(ConflictReportCountExt)
+      :code.delete(ConflictReportCountExt)
+    end
+  end
 end

--- a/apps/coding_agent/test/coding_agent/tools/extensions_status_test.exs
+++ b/apps/coding_agent/test/coding_agent/tools/extensions_status_test.exs
@@ -1,0 +1,160 @@
+defmodule CodingAgent.Tools.ExtensionsStatusTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAgent.Tools.ExtensionsStatus
+  alias AgentCore.Types.AgentToolResult
+
+  @moduletag :tmp_dir
+
+  describe "tool/2" do
+    test "returns a valid AgentTool struct", %{tmp_dir: tmp_dir} do
+      tool = ExtensionsStatus.tool(tmp_dir)
+
+      assert tool.name == "extensions_status"
+      assert is_binary(tool.description)
+      assert tool.label == "Extensions Status"
+      assert is_function(tool.execute, 4)
+      assert is_map(tool.parameters)
+    end
+
+    test "tool has include_details parameter" do
+      tool = ExtensionsStatus.tool("/tmp")
+
+      props = tool.parameters["properties"]
+      assert Map.has_key?(props, "include_details")
+      assert props["include_details"]["type"] == "boolean"
+    end
+  end
+
+  describe "execute/6" do
+    test "returns result without session_id", %{tmp_dir: tmp_dir} do
+      tool = ExtensionsStatus.tool(tmp_dir, session_id: "")
+      result = tool.execute.("call-1", %{}, nil, nil)
+
+      assert %AgentToolResult{} = result
+      assert is_list(result.content)
+      assert length(result.content) >= 1
+
+      text = hd(result.content).text
+      assert is_binary(text)
+    end
+
+    test "returns result with non-existent session_id", %{tmp_dir: tmp_dir} do
+      tool = ExtensionsStatus.tool(tmp_dir, session_id: "nonexistent-session-id")
+      result = tool.execute.("call-1", %{}, nil, nil)
+
+      assert %AgentToolResult{} = result
+      assert is_list(result.content)
+
+      text = hd(result.content).text
+      assert is_binary(text)
+    end
+
+    test "respects include_details parameter", %{tmp_dir: tmp_dir} do
+      tool = ExtensionsStatus.tool(tmp_dir, session_id: "")
+
+      # Without details
+      result_simple = tool.execute.("call-1", %{"include_details" => false}, nil, nil)
+      # With details
+      result_detailed = tool.execute.("call-2", %{"include_details" => true}, nil, nil)
+
+      # Both should return valid results
+      assert %AgentToolResult{} = result_simple
+      assert %AgentToolResult{} = result_detailed
+    end
+
+    test "returns error when aborted" do
+      tool = ExtensionsStatus.tool("/tmp", session_id: "test-session")
+
+      # Create a signal and abort it
+      signal = make_ref()
+      AgentCore.AbortSignal.abort(signal)
+
+      result = tool.execute.("call-1", %{}, signal, nil)
+
+      assert {:error, "Operation aborted"} = result
+    end
+
+    test "includes tool conflict info without session_id", %{tmp_dir: tmp_dir} do
+      tool = ExtensionsStatus.tool(tmp_dir, session_id: "")
+      result = tool.execute.("call-1", %{}, nil, nil)
+
+      assert %AgentToolResult{} = result
+      # Details should include tool_conflicts computed from cwd
+      assert Map.has_key?(result.details, :tool_conflicts)
+      conflicts = result.details.tool_conflicts
+
+      # Should have the standard conflict report structure
+      assert is_map(conflicts)
+      assert Map.has_key?(conflicts, :total_tools)
+      assert Map.has_key?(conflicts, :builtin_count)
+      assert Map.has_key?(conflicts, :extension_count)
+      assert Map.has_key?(conflicts, :shadowed_count)
+      assert Map.has_key?(conflicts, :conflicts)
+
+      # Output should include Tool Registry section
+      text = hd(result.content).text
+      assert text =~ "Tool Registry"
+    end
+
+    test "includes tool conflict info with non-existent session_id", %{tmp_dir: tmp_dir} do
+      tool = ExtensionsStatus.tool(tmp_dir, session_id: "nonexistent-session-id")
+      result = tool.execute.("call-1", %{}, nil, nil)
+
+      assert %AgentToolResult{} = result
+      # Details should include tool_conflicts computed from cwd
+      assert Map.has_key?(result.details, :tool_conflicts)
+      conflicts = result.details.tool_conflicts
+
+      # Should have the standard conflict report structure
+      assert is_map(conflicts)
+      assert conflicts.total_tools > 0
+
+      # Output should include Tool Registry section
+      text = hd(result.content).text
+      assert text =~ "Tool Registry"
+    end
+  end
+
+  describe "integration with extensions" do
+    test "shows loaded extensions", %{tmp_dir: tmp_dir} do
+      # Create an extension
+      ext_dir = Path.join(tmp_dir, "extensions")
+      File.mkdir_p!(ext_dir)
+
+      extension_code = """
+      defmodule ExtStatusTestExtension do
+        @behaviour CodingAgent.Extensions.Extension
+
+        @impl true
+        def name, do: "ext-status-test"
+
+        @impl true
+        def version, do: "1.0.0"
+
+        @impl true
+        def capabilities, do: [:tools]
+      end
+      """
+
+      File.write!(Path.join(ext_dir, "ext_status_test.ex"), extension_code)
+
+      # Load the extension
+      {:ok, _extensions} = CodingAgent.Extensions.load_extensions([ext_dir])
+
+      # Now check extensions_status
+      tool = ExtensionsStatus.tool(tmp_dir, session_id: "")
+      result = tool.execute.("call-1", %{}, nil, nil)
+
+      assert %AgentToolResult{} = result
+      text = hd(result.content).text
+
+      # Should mention the extension
+      assert text =~ "ext-status-test" or text =~ "ExtStatusTestExtension"
+
+      # Cleanup
+      :code.purge(ExtStatusTestExtension)
+      :code.delete(ExtStatusTestExtension)
+    end
+  end
+end

--- a/clients/lemon-tui/src/index.ts
+++ b/clients/lemon-tui/src/index.ts
@@ -1872,9 +1872,12 @@ ${ansi.bold('Shortcuts:')}
       this.updateStreamingMessage(state.streamingMessage);
     }
 
-    // Update loader
+    // Update loader + input submit disabling
     if (state.busy !== prevState.busy) {
       this.updateLoader(state.busy);
+      // Prevent accidental submits while the agent is streaming/processing.
+      // (We still guard in onSubmit, but this improves UX by disabling submit at the component level.)
+      this.inputEditor.disableSubmit = state.busy;
     }
 
     // Update terminal title using pi-tui's terminal interface

--- a/docs/agent-loop/GOALS.md
+++ b/docs/agent-loop/GOALS.md
@@ -1,0 +1,23 @@
+# Lemon — Goals (living)
+
+## North star
+Build Lemon into a fully featured **agent harness** (Pi / OpenCode-ish) with an Elixir/BEAM core for:
+- coordination
+- communication
+- cooperation
+- modular extensibility (plugins)
+
+## Near-term themes
+- Clear modular architecture boundaries (core vs plugins vs clients)
+- Plugin system targeting the **Elixir backend** first
+- Strong harness primitives: sessions, tools, memory, files, subprocess, streaming
+- Good DX: docs, examples, tests, reproducible dev setup
+
+## Stretch goals
+- Plugins in multiple languages (defined by a stable RPC/ABI)
+- Multi-agent orchestration patterns (plans, roles, delegations, consensus)
+
+## Current big idea: plugin system
+- First-class backend plugin API (Elixir behaviours + supervised processes)
+- Define plugin capabilities (tools, hooks, providers)
+- Consider language-agnostic plugin RPC as a later layer (gRPC/stdio JSON-RPC/etc)

--- a/docs/agent-loop/README.md
+++ b/docs/agent-loop/README.md
@@ -1,0 +1,16 @@
+# Lemon — Continuous Improvement Loop
+
+Every ~30 minutes we run:
+1) **Codex**: review + brainstorm + plan next steps
+2) **Claude Code**: implement the highest-leverage slice, update docs/tests
+
+Outputs are written to `docs/agent-loop/runs/` and summarized back to z80.
+
+## Working rules
+- Prefer small, mergeable increments.
+- Always leave a paper trail:
+  - what we observed
+  - what we decided
+  - what changed (diff)
+  - what’s next
+- Keep architecture modular; avoid hard-coding client-specific behavior into the core.

--- a/docs/agent-loop/RUN_LOG.md
+++ b/docs/agent-loop/RUN_LOG.md
@@ -1,0 +1,45 @@
+# Lemon — Agent Loop Run Log
+
+This is an append-only log of scheduled improvement runs.
+
+- Each run produces:
+  - `docs/agent-loop/runs/<timestamp>-codex.md`
+  - `docs/agent-loop/runs/<timestamp>-claude.md`
+  - `docs/agent-loop/runs/<timestamp>-diff.patch` (optional)
+
+---
+## 2026-02-01T22-42-38Z
+- Codex: docs/agent-loop/runs/2026-02-01T22-42-38Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-01T22-42-38Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-01T22-42-38Z-diff.patch
+
+## 2026-02-01T23-16-37Z
+- Codex: docs/agent-loop/runs/2026-02-01T23-16-37Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-01T23-16-37Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-01T23-16-37Z-diff.patch
+
+## 2026-02-01T23-52-48Z
+- Codex: docs/agent-loop/runs/2026-02-01T23-52-48Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-01T23-52-48Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-01T23-52-48Z-diff.patch
+
+## 2026-02-02T00-14-02Z
+- Codex: docs/agent-loop/runs/2026-02-02T00-14-02Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-02T00-14-02Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-02T00-14-02Z-diff.patch
+
+## 2026-02-02T00-13-34Z
+- Codex: docs/agent-loop/runs/2026-02-02T00-13-34Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-02T00-13-34Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-02T00-13-34Z-diff.patch
+
+## 2026-02-02T00-44-59Z
+- Codex: docs/agent-loop/runs/2026-02-02T00-44-59Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-02T00-44-59Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-02T00-44-59Z-diff.patch
+
+## 2026-02-02T01-21-17Z
+- Codex: docs/agent-loop/runs/2026-02-02T01-21-17Z-codex.md
+- Claude: docs/agent-loop/runs/2026-02-02T01-21-17Z-claude.md
+- Diff: docs/agent-loop/runs/2026-02-02T01-21-17Z-diff.patch
+

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,495 @@
+# Extensions
+
+Extensions are the plugin system for Lemon. They allow you to add custom tools, hooks, and capabilities to the coding agent without modifying the core codebase.
+
+## Quick Start
+
+1. Create a file in `~/.lemon/agent/extensions/` (global) or `.lemon/extensions/` (project-local)
+2. Implement the `CodingAgent.Extensions.Extension` behaviour
+3. The extension will be automatically loaded on session start
+
+## Extension Behaviour
+
+Every extension must implement the `CodingAgent.Extensions.Extension` behaviour with at least `name/0` and `version/0`:
+
+```elixir
+defmodule MyExtension do
+  @behaviour CodingAgent.Extensions.Extension
+
+  @impl true
+  def name, do: "my-extension"
+
+  @impl true
+  def version, do: "1.0.0"
+
+  # Optional: provide custom tools
+  @impl true
+  def tools(_cwd), do: []
+
+  # Optional: register hooks
+  @impl true
+  def hooks, do: []
+end
+```
+
+## Callbacks
+
+| Callback | Required | Description |
+|----------|----------|-------------|
+| `name/0` | Yes | Returns the extension's unique name (lowercase with hyphens) |
+| `version/0` | Yes | Returns the semantic version string |
+| `tools/1` | No | Returns a list of `AgentCore.Types.AgentTool` structs |
+| `hooks/0` | No | Returns a keyword list of event hooks |
+| `capabilities/0` | No | Returns a list of capability atoms (e.g., `[:tools, :hooks]`) |
+| `config_schema/0` | No | Returns a JSON Schema-like map for configuration options |
+
+## Providing Tools
+
+Extensions can provide custom tools that the agent can use:
+
+```elixir
+@impl true
+def tools(_cwd) do
+  [
+    %AgentCore.Types.AgentTool{
+      name: "my_tool",
+      description: "What the tool does",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "input" => %{
+            "type" => "string",
+            "description" => "The input parameter"
+          }
+        },
+        "required" => ["input"]
+      },
+      label: "My Tool",
+      execute: fn _id, %{"input" => input}, _signal, _on_update ->
+        %AgentCore.Types.AgentToolResult{
+          content: [%{type: "text", text: "Result: #{input}"}]
+        }
+      end
+    }
+  ]
+end
+```
+
+### Tool Parameters
+
+- `name` - The tool identifier (used in LLM tool calls)
+- `description` - What the tool does (shown to the LLM)
+- `parameters` - JSON Schema for tool parameters
+- `label` - Human-readable display name
+- `execute` - Function with signature `(tool_use_id, args, abort_signal, on_update) -> AgentToolResult`
+
+### Tool Execute Function
+
+The execute function receives:
+- `tool_use_id` - Unique ID for this tool invocation
+- `args` - Map of parsed arguments matching your parameters schema
+- `abort_signal` - An `AbortSignal` for checking if execution should stop
+- `on_update` - Callback for streaming partial updates
+
+Return an `AgentCore.Types.AgentToolResult`:
+
+```elixir
+%AgentCore.Types.AgentToolResult{
+  content: [%{type: "text", text: "output"}],
+  is_error: false  # optional, defaults to false
+}
+```
+
+## Registering Hooks
+
+Hooks allow extensions to respond to agent lifecycle events:
+
+```elixir
+@impl true
+def hooks do
+  [
+    on_agent_start: fn -> :ok end,
+    on_agent_end: fn messages -> :ok end,
+    on_turn_start: fn -> :ok end,
+    on_turn_end: fn message, tool_results -> :ok end,
+    on_message_start: fn message -> :ok end,
+    on_message_end: fn message -> :ok end,
+    on_tool_execution_start: fn id, name, args -> :ok end,
+    on_tool_execution_end: fn id, name, result, is_error -> :ok end
+  ]
+end
+```
+
+### Available Hooks
+
+| Hook | Arguments | Description |
+|------|-----------|-------------|
+| `on_agent_start` | none | Called when agent run starts |
+| `on_agent_end` | `messages` | Called when agent run ends |
+| `on_turn_start` | none | Called when a new turn starts |
+| `on_turn_end` | `message, tool_results` | Called when turn ends |
+| `on_message_start` | `message` | Called when message processing starts |
+| `on_message_end` | `message` | Called when message processing ends |
+| `on_tool_execution_start` | `id, name, args` | Called when tool starts |
+| `on_tool_execution_end` | `id, name, result, is_error` | Called when tool ends |
+
+Hook errors are caught and logged but don't stop other hooks or the agent.
+
+## Declaring Capabilities
+
+Extensions can declare their capabilities for discovery and filtering:
+
+```elixir
+@impl true
+def capabilities, do: [:tools, :hooks]
+```
+
+### Common Capability Atoms
+
+| Capability | Description |
+|------------|-------------|
+| `:tools` | Extension provides custom tools |
+| `:hooks` | Extension provides event hooks |
+| `:prompts` | Extension provides custom prompts/skills |
+| `:resources` | Extension provides resources (CLAUDE.md, etc.) |
+| `:mcp` | Extension connects to MCP servers |
+
+UIs can use capabilities to filter extensions by functionality.
+
+## Configuration Schema
+
+Extensions can declare a configuration schema to enable UIs to render settings forms:
+
+```elixir
+@impl true
+def config_schema do
+  %{
+    "type" => "object",
+    "properties" => %{
+      "api_key" => %{
+        "type" => "string",
+        "description" => "API key for the service",
+        "secret" => true
+      },
+      "timeout" => %{
+        "type" => "integer",
+        "description" => "Request timeout in milliseconds",
+        "default" => 5000
+      },
+      "enabled" => %{
+        "type" => "boolean",
+        "description" => "Enable this extension",
+        "default" => true
+      }
+    },
+    "required" => ["api_key"]
+  }
+end
+```
+
+The schema follows JSON Schema conventions with optional extensions:
+- `secret: true` - Indicates the field should be masked in UIs
+- `default` - Default value for the field
+
+## Extension Discovery
+
+Extensions are discovered from:
+
+1. **Global directory**: `~/.lemon/agent/extensions/`
+2. **Project-local directory**: `.lemon/extensions/` (relative to working directory)
+
+Supported file patterns:
+- `*.ex` and `*.exs` files in the extensions directory
+- `*/lib/**/*.ex` files for complex extensions with subdirectories
+
+## Example Extension
+
+See `examples/extensions/hello_world_extension.ex` for a complete working example.
+
+```elixir
+defmodule HelloWorldExtension do
+  @behaviour CodingAgent.Extensions.Extension
+
+  @impl true
+  def name, do: "hello-world"
+
+  @impl true
+  def version, do: "1.0.0"
+
+  @impl true
+  def tools(_cwd) do
+    [
+      %AgentCore.Types.AgentTool{
+        name: "hello",
+        description: "Says hello to someone",
+        parameters: %{
+          "type" => "object",
+          "properties" => %{
+            "name" => %{"type" => "string", "description" => "Name to greet"}
+          },
+          "required" => ["name"]
+        },
+        label: "Hello",
+        execute: fn _id, %{"name" => name}, _signal, _on_update ->
+          %AgentCore.Types.AgentToolResult{
+            content: [%{type: "text", text: "Hello, #{name}!"}]
+          }
+        end
+      }
+    ]
+  end
+
+  @impl true
+  def hooks do
+    [
+      on_agent_start: fn -> IO.puts("Agent started!") end
+    ]
+  end
+end
+```
+
+## Tool Precedence
+
+All tools (built-in and extension) are assembled through `CodingAgent.ToolRegistry`, which provides:
+- Centralized conflict detection
+- Per-session enable/disable via `:disabled` and `:enabled_only` options
+- Extension path customization via `:extension_paths` option
+
+When multiple tools share the same name, the following precedence rules apply:
+
+1. **Built-in tools always win** - Core tools (read, write, edit, bash, etc.) take priority over extension tools
+2. **First loaded extension wins** - Extensions are loaded in alphabetical order by module name, so earlier modules take precedence
+
+When a conflict is detected, a warning is logged that includes:
+- The conflicting tool name
+- The module that was shadowed
+- Whether it was shadowed by a built-in or an earlier extension
+
+Example warning:
+```
+[warning] Tool name conflict: extension tool 'read' from MyExtension is shadowed by built-in tool
+```
+
+This ensures deterministic tool resolution across sessions while allowing extensions to add new tools without risking silent conflicts.
+
+## Extension Metadata API
+
+For UIs and diagnostics, the extension system provides functions to query loaded extension metadata:
+
+```elixir
+# Get metadata for specific extensions
+info = CodingAgent.Extensions.get_info(extensions)
+# => [%{name: "my-ext", version: "1.0.0", module: MyExt, source_path: "/path/to/ext.ex",
+#       capabilities: [:tools, :hooks], config_schema: %{"type" => "object", ...}}]
+
+# Get source path for a specific extension module
+path = CodingAgent.Extensions.get_source_path(MyExtension)
+# => "/home/user/.lemon/agent/extensions/my_extension.ex"
+
+# List all loaded extensions (global view)
+all_extensions = CodingAgent.Extensions.list_extensions()
+# => [%{name: "ext1", version: "1.0.0", module: Ext1, source_path: "...", ...}, ...]
+
+# Find duplicate tool names across extensions (before merging with built-ins)
+duplicates = CodingAgent.Extensions.find_duplicate_tools(extensions, cwd)
+# => %{"my_tool" => [ExtensionA, ExtensionB]}
+```
+
+Each extension metadata map includes:
+- `name` - The extension's name (from `name/0` callback)
+- `version` - The extension's version (from `version/0` callback)
+- `module` - The Elixir module implementing the extension
+- `source_path` - The file path from which the extension was loaded
+- `capabilities` - List of capability atoms (defaults to `[]` if not implemented)
+- `config_schema` - JSON Schema-like map for configuration (defaults to `%{}` if not implemented)
+
+## Tool Conflict Report API
+
+For plugin observability, the `ToolRegistry` provides a structured conflict report that shows how tool name conflicts are resolved:
+
+```elixir
+report = CodingAgent.ToolRegistry.tool_conflict_report(cwd)
+# => %{
+#   conflicts: [
+#     %{
+#       tool_name: "read",
+#       winner: :builtin,
+#       shadowed: [{:extension, MyExtension}]
+#     },
+#     %{
+#       tool_name: "custom_tool",
+#       winner: {:extension, ExtensionA},
+#       shadowed: [{:extension, ExtensionB}]
+#     }
+#   ],
+#   total_tools: 16,
+#   builtin_count: 15,
+#   extension_count: 1,
+#   shadowed_count: 2
+# }
+```
+
+The report includes:
+- `conflicts` - List of conflict entries, each containing:
+  - `tool_name` - The conflicting tool name
+  - `winner` - Source that won (`:builtin` or `{:extension, module()}`)
+  - `shadowed` - List of `{:extension, module()}` tuples that were shadowed
+- `total_tools` - Total number of tools available after conflict resolution
+- `builtin_count` - Number of built-in tools
+- `extension_count` - Number of extension tools (after shadowing)
+- `shadowed_count` - Total number of shadowed tools
+
+This is useful for:
+- Debugging why a custom tool isn't appearing
+- Building UIs that show plugin health/status
+- Detecting extension conflicts before they cause issues
+
+## Extension Status Report
+
+At session startup, a comprehensive extension status report is built and published as an event. This provides a single source of truth for UI/CLI consumption about extension health.
+
+### Getting the Status Report
+
+```elixir
+# From the session state
+state = Session.get_state(session)
+report = state.extension_status_report
+
+# Or via the dedicated API
+report = Session.get_extension_status_report(session)
+```
+
+### Subscribing to the Status Report Event
+
+The report is also published as an event after session initialization:
+
+```elixir
+# Subscribe to session events
+unsub = Session.subscribe(session)
+
+receive do
+  {:session_event, _session_id, {:extension_status_report, report}} ->
+    IO.inspect(report, label: "Extension Status")
+end
+```
+
+### Status Report Structure
+
+```elixir
+%{
+  # Successfully loaded extensions with metadata
+  extensions: [
+    %{
+      name: "my-extension",
+      version: "1.0.0",
+      module: MyExtension,
+      source_path: "/path/to/extension.ex",
+      capabilities: [:tools, :hooks],
+      config_schema: %{...}
+    }
+  ],
+
+  # Extensions that failed to load
+  load_errors: [
+    %{
+      source_path: "/path/to/bad_extension.ex",
+      error: %CompileError{...},
+      error_message: "Compile error: unexpected token"
+    }
+  ],
+
+  # Tool conflict report from ToolRegistry
+  tool_conflicts: %{
+    conflicts: [...],
+    total_tools: 16,
+    builtin_count: 15,
+    extension_count: 1,
+    shadowed_count: 0
+  },
+
+  # Summary counts
+  total_loaded: 2,
+  total_errors: 1,
+  loaded_at: 1706745600000
+}
+```
+
+### Loading Extensions with Error Tracking
+
+For programmatic use, you can load extensions and capture errors:
+
+```elixir
+{:ok, extensions, errors} = CodingAgent.Extensions.load_extensions_with_errors([
+  "~/.lemon/agent/extensions",
+  "/path/to/project/.lemon/extensions"
+])
+
+# Build a status report manually
+report = CodingAgent.Extensions.build_status_report(extensions, errors, cwd: "/project")
+```
+
+This is useful for:
+- CLI status displays showing extension health
+- Web UIs rendering extension management panels
+- Diagnostic tools troubleshooting extension issues
+- Build systems validating extension configurations
+
+## Extensions Status Tool
+
+The agent has access to a built-in `extensions_status` tool that allows it to self-diagnose plugin loading issues and conflicts during a session. This is useful for debugging when:
+- An expected tool isn't available
+- Extensions fail to load with syntax or compile errors
+- Tool name conflicts prevent extension tools from being used
+
+### Using the Tool
+
+The agent can call the tool with an optional `include_details` parameter:
+
+```
+# Summary view (default)
+extensions_status {}
+
+# Detailed view with source paths and modules
+extensions_status {"include_details": true}
+```
+
+### Output Format
+
+The tool returns a markdown-formatted report including:
+
+```markdown
+# Extension Status Report
+
+- **Extensions loaded:** 2
+- **Load errors:** 1
+- **Loaded at:** 2024-01-31 15:30:00 UTC
+
+## Loaded Extensions
+- **my-extension** v1.0.0 (tools, hooks)
+- **another-ext** v2.0.0
+
+## Load Errors
+- `/path/to/bad_extension.ex`
+  - Compile error: unexpected token at line 15
+
+## Tool Registry
+- **Total tools:** 17
+- **Built-in:** 16
+- **From extensions:** 1
+- **Shadowed:** 0
+```
+
+When `include_details: true`, extension entries also show:
+- Source file path
+- Module name
+- Whether the extension has a config schema
+
+## Best Practices
+
+1. **Use descriptive names** - Tool names should clearly indicate what they do
+2. **Provide helpful descriptions** - The LLM uses descriptions to decide when to use tools
+3. **Validate inputs** - Check arguments before processing
+4. **Handle errors gracefully** - Return `is_error: true` with a helpful message
+5. **Keep hooks lightweight** - Don't block the agent with slow hook processing
+6. **Use the `cwd` parameter** - Make tools context-aware when needed
+7. **Use unique tool names** - Avoid naming tools the same as built-ins or other extensions

--- a/examples/extensions/hello_world_extension.ex
+++ b/examples/extensions/hello_world_extension.ex
@@ -1,0 +1,77 @@
+# Example Extension for Lemon
+#
+# This is a minimal example extension demonstrating the Extension behaviour.
+# Extensions can provide custom tools and hooks to the coding agent.
+#
+# To install this extension:
+#   1. Copy this file to ~/.lemon/agent/extensions/hello_world_extension.ex
+#   2. Or copy to your project's .lemon/extensions/ directory
+#
+# The extension will be automatically discovered and loaded on session start.
+
+defmodule HelloWorldExtension do
+  @moduledoc """
+  A simple example extension that provides a "hello" tool.
+
+  This extension demonstrates:
+  - Implementing the Extension behaviour
+  - Providing a custom tool with parameters
+  - Registering hooks for agent events
+  """
+
+  @behaviour CodingAgent.Extensions.Extension
+
+  @impl true
+  def name, do: "hello-world"
+
+  @impl true
+  def version, do: "1.0.0"
+
+  @impl true
+  def tools(_cwd) do
+    [
+      %AgentCore.Types.AgentTool{
+        name: "hello",
+        description: "Says hello to someone. Use this to greet users.",
+        parameters: %{
+          "type" => "object",
+          "properties" => %{
+            "name" => %{
+              "type" => "string",
+              "description" => "The name of the person to greet"
+            }
+          },
+          "required" => ["name"]
+        },
+        label: "Hello",
+        execute: &execute_hello/4
+      }
+    ]
+  end
+
+  @impl true
+  def hooks do
+    [
+      on_agent_start: fn ->
+        # Called when the agent run starts
+        :ok
+      end,
+      on_tool_execution_end: fn _id, name, _result, _is_error ->
+        # Called after any tool finishes executing
+        if name == "hello" do
+          # You could log, send metrics, etc.
+          :ok
+        end
+      end
+    ]
+  end
+
+  # Tool implementation
+  defp execute_hello(_tool_use_id, %{"name" => name}, _abort_signal, _on_update) do
+    greeting = "Hello, #{name}! 👋"
+
+    %AgentCore.Types.AgentToolResult{
+      content: [%{type: "text", text: greeting}]
+    }
+  end
+end

--- a/scripts/cron_lemon_loop.sh
+++ b/scripts/cron_lemon_loop.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+TS="$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+RUN_DIR="docs/agent-loop/runs"
+mkdir -p "$RUN_DIR"
+
+# Best-effort cleanup from previously killed runs (stale tmux sockets)
+# Avoids accumulating /tmp/lemon-tmux-*.sock files and wedged tmux servers.
+if command -v tmux >/dev/null 2>&1; then
+  for sock in /tmp/lemon-tmux-*.sock; do
+    [ -S "$sock" ] || continue
+    # If the server is dead, tmux will error; ignore.
+    tmux -S "$sock" kill-server 2>/dev/null || true
+    rm -f "$sock" 2>/dev/null || true
+  done
+fi
+
+
+CODEX_OUT="$RUN_DIR/${TS}-codex.md"
+CLAUDE_OUT="$RUN_DIR/${TS}-claude.md"
+DIFF_OUT="$RUN_DIR/${TS}-diff.patch"
+
+run_with_timeout() {
+  # Usage: run_with_timeout <seconds> <outfile> <command...>
+  local seconds="$1"; shift
+  local outfile="$1"; shift
+
+  python3 - "$seconds" "$outfile" "$@" <<'PY'
+import subprocess, sys, time
+
+timeout_s = int(sys.argv[1])
+outfile = sys.argv[2]
+cmd = sys.argv[3:]
+
+start = time.time()
+with open(outfile, 'a', encoding='utf-8', errors='ignore') as f:
+    f.write(f"\n---\nCommand: {' '.join(cmd)}\nStarted: {time.strftime('%Y-%m-%d %H:%M:%SZ', time.gmtime())}\nTimeout: {timeout_s}s\n---\n")
+    f.flush()
+    try:
+        p = subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, text=True, timeout=timeout_s)
+        f.write(f"\n---\nExit: {p.returncode}\nDuration: {time.time()-start:.1f}s\n---\n")
+    except subprocess.TimeoutExpired:
+        f.write(f"\n---\nTIMEOUT after {timeout_s}s\nDuration: {time.time()-start:.1f}s\n---\n")
+        sys.exit(124)
+PY
+}
+
+# --- 1) Codex: review + plan ---
+cat > "$CODEX_OUT" <<'EOF'
+# Codex review/plan
+
+EOF
+
+CODEX_PROMPT=$'You are working in the Lemon repo (Elixir/BEAM agent harness).\n\nTasks:\n1) Review architecture quickly (module boundaries + extensibility).\n2) Propose 3–7 concrete next improvements toward a fully featured agent harness (Pi/OpenCode-ish), prioritizing a backend plugin system.\n3) Choose ONE smallest-scope, highest-leverage change implementable in <= 20 minutes.\n4) Output markdown with these sections EXACTLY (and do not add extra headings):\n\n## Findings\n- ...\n\n## Proposed next steps (prioritized)\n1. ...\n\n## Chosen task for this run\n...\n\n## Acceptance criteria\n- ...\n\nBe concise; avoid big refactors.'
+
+# NOTE: `codex --yolo` is interactive/TUI and does not terminate reliably in non-interactive cron runs.
+# For cron we use the equivalent non-interactive mode:
+#   codex exec --dangerously-bypass-approvals-and-sandbox
+# 12 min budget for Codex planning
+run_with_timeout 720 "$CODEX_OUT" codex exec --dangerously-bypass-approvals-and-sandbox "$CODEX_PROMPT" || true
+
+# Extract chosen task (best effort) — pick the LAST occurrence
+CHOSEN_TASK="$(python3 - <<PY
+import re
+lines=open('$CODEX_OUT','r',encoding='utf-8',errors='ignore').read().splitlines()
+idxs=[i for i,l in enumerate(lines) if re.match(r'^##\s*Chosen task for this run\s*$', l.strip(), re.I)]
+chosen=None
+if idxs:
+    i=idxs[-1]
+    for j in range(i+1, min(i+50, len(lines))):
+        t=lines[j].strip()
+        if not t: 
+            continue
+        if t.startswith('---') or t.lower().startswith('command:'):
+            continue
+        # stop if we hit another heading
+        if re.match(r'^##\s+', t):
+            break
+        chosen=t.lstrip('-* ').strip()
+        break
+print(chosen or "(see codex output)")
+PY
+)"
+
+# --- 2) Claude: implement ---
+cat > "$CLAUDE_OUT" <<EOF
+# Claude implementation
+
+Chosen task (from Codex): $CHOSEN_TASK
+
+EOF
+
+# Save diff before
+git diff > /tmp/lemon-pre.diff 2>/dev/null || true
+
+read -r -d '' CLAUDE_PROMPT <<EOF || true
+Implement the chosen task from the latest Codex run.
+
+Chosen task: $CHOSEN_TASK
+
+Instructions:
+- If the chosen task is unclear, implement a small, safe scaffolding step toward a backend plugin system (behaviours/interfaces + minimal example).
+- Keep changes small (no big refactors).
+- Update docs/tests as appropriate.
+
+At the end, output markdown:
+## Summary
+## Files touched
+## How to verify
+## Next step
+EOF
+
+# z80 requested: --dangerously-skip-permissions
+# Claude appears to require a real PTY to run reliably here.
+# Run Claude inside tmux (Option B), then capture the pane output to $CLAUDE_OUT.
+run_claude_tmux() {
+  local out="$1"; shift
+  local prompt="$1"; shift
+
+  local sock="/tmp/lemon-tmux-${TS}.sock"
+  local session="lemon-${TS}"
+  local token="LEMON_DONE_${TS}"
+  local prompt_file="/tmp/lemon-claude-prompt-${TS}.txt"
+
+  printf "%s" "$prompt" > "$prompt_file"
+
+  # Fresh server per run
+  tmux -S "$sock" kill-server 2>/dev/null || true
+  tmux -S "$sock" new-session -d -s "$session" "bash"
+
+  # Run Claude, then signal completion via tmux wait-for.
+  # Read prompt from file to avoid quoting hell.
+  tmux -S "$sock" send-keys -t "$session" "PROMPT=\"\$(cat '$prompt_file')\"; claude --dangerously-skip-permissions -p \"\$PROMPT\"; EC=\$?; echo; echo \"__LEMON_CLAUDE_EXIT:\$EC__\"; tmux -S '$sock' wait-for -S '$token'" Enter
+
+  # Wait for completion and capture output regardless (18 minutes)
+  python3 - "$sock" "$token" "$session" "$out" <<'PY' || true
+import subprocess, sys, time
+sock, token, session, out = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+start=time.time()
+timeout=1080
+try:
+    subprocess.run(["tmux","-S",sock,"wait-for",token], timeout=timeout, check=False)
+except subprocess.TimeoutExpired:
+    pass
+cap = subprocess.run(["tmux","-S",sock,"capture-pane","-p","-t",f"{session}:0.0"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+with open(out,'a',encoding='utf-8',errors='ignore') as f:
+    f.write("\n---\nTMUX CAPTURE\n---\n")
+    f.write(cap.stdout)
+    f.write(f"\n---\nDuration: {time.time()-start:.1f}s\n---\n")
+PY
+
+  tmux -S "$sock" kill-server 2>/dev/null || true
+  rm -f "$prompt_file" 2>/dev/null || true
+}
+
+# 18 min budget for implementation.
+run_claude_tmux "$CLAUDE_OUT" "$CLAUDE_PROMPT" || true
+
+# Save diff
+git diff > "$DIFF_OUT" 2>/dev/null || true
+
+# Append to run log
+{
+  echo "## $TS";
+  echo "- Codex: $CODEX_OUT";
+  echo "- Claude: $CLAUDE_OUT";
+  echo "- Diff: $DIFF_OUT";
+  echo;
+} >> docs/agent-loop/RUN_LOG.md
+
+# Print a short summary to stdout (cron delivery uses this)
+echo "Lemon loop run $TS"
+echo "Chosen task: $CHOSEN_TASK"
+echo "Codex output: $CODEX_OUT"
+echo "Claude output: $CLAUDE_OUT"
+echo "Diff: $DIFF_OUT"

--- a/worklog.md
+++ b/worklog.md
@@ -23,3 +23,10 @@
 - Tests:
   - `mix test apps/coding_agent/test/coding_agent/tools/webfetch_test.exs` (pass)
 - Commit: (see git log; branch: auto/lemon-20260131-1408)
+
+## 2026-01-31 14:12 ET
+- Change: Fix `AgentCore.Proxy.complete_json/1` to close `]` before `}` so partial JSON like `{ "items": [1,2` completes to `]}` (fixes `parse_streaming_json/1` for partial arrays). (apps/agent_core/lib/agent_core/proxy.ex)
+- Tests:
+  - `mix test apps/agent_core/test/agent_core/proxy_test.exs` (pass)
+- Commit: c144e4a (branch: auto/lemon-20260131-1408)
+- Next: Run full umbrella `mix test` and pick the next single failure to knock down (lots currently failing on main).

--- a/worklog.md
+++ b/worklog.md
@@ -30,3 +30,8 @@
   - `mix test apps/agent_core/test/agent_core/proxy_test.exs` (pass)
 - Commit: c144e4a (branch: auto/lemon-20260131-1408)
 - Next: Run full umbrella `mix test` and pick the next single failure to knock down (lots currently failing on main).
+
+## 2026-01-31 14:35 ET
+- Change: AgentCore.EventStream now demonitors the previously attached task when re-attaching, stores task_ref, and clears task_pid/task_ref on cancel/termination. Added regression test ensuring old task crash doesn't terminate stream after re-attach.
+- Tests: mix test apps/agent_core (exit 0).
+- Next: consider adding telemetry events for stream overflow/cancel/complete or integrating EventStream stats into agent-level metrics.

--- a/worklog.md
+++ b/worklog.md
@@ -2,3 +2,11 @@
 
 ## 2026-01-30
 - Initialized worklog and prepared to consolidate existing uncommitted changes.
+
+## 2026-01-31 13:26 ET
+- Change: lemon-tui now sets `inputEditor.disableSubmit = state.busy` when busy state changes, preventing accidental submits while the agent is streaming/processing. (clients/lemon-tui/src/index.ts)
+- Tests:
+  - clients/lemon-tui: `npm test` (pass), `npm run build` (pass)
+  - repo root: `mix test` currently failing on main branch state (1557 tests, 76 failures; e.g. CodingAgent.SubagentsTest `filters invalid entries and merges overrides`). Not touched by this change.
+- Commit: 076409e (branch: auto/lemon-20260131-1322)
+- Next: Investigate/fix the failing `CodingAgent.SubagentsTest` (likely whitespace/blank prompt handling) and then re-run `mix test` until green.

--- a/worklog.md
+++ b/worklog.md
@@ -10,3 +10,10 @@
   - repo root: `mix test` currently failing on main branch state (1557 tests, 76 failures; e.g. CodingAgent.SubagentsTest `filters invalid entries and merges overrides`). Not touched by this change.
 - Commit: 076409e (branch: auto/lemon-20260131-1322)
 - Next: Investigate/fix the failing `CodingAgent.SubagentsTest` (likely whitespace/blank prompt handling) and then re-run `mix test` until green.
+
+## 2026-01-31 13:48 ET
+- Change: `CodingAgent.Subagents` now trims and rejects subagent entries with blank/whitespace `id` or `prompt`, and sanitizes non-binary `description` to "". This fixes `Subagents.get/2` returning a "custom" subagent whose prompt was only whitespace. (apps/coding_agent/lib/coding_agent/subagents.ex)
+- Tests:
+  - `mix test apps/coding_agent/test/coding_agent/subagents_test.exs` (pass)
+- Commit: 6104417 (branch: auto/lemon-20260131-1346)
+- Next: run the full umbrella `mix test` and pick off the next single failure (there were many earlier; this removes one of the named failures from the worklog).

--- a/worklog.md
+++ b/worklog.md
@@ -45,3 +45,8 @@
   - `mix test apps/coding_agent/test/coding_agent/tools/todo_test.exs` (pass)
 - Commit: dec3437 (branch: auto/lemon-20260131-1458)
 - Next: Add `CodingAgent.Tools.WebSearch.reset_rate_limit/0` (no-op or ETS reset) to unbreak `WebSearchTest` setup, then tackle remaining `coding_agent` failures bucket-by-bucket.
+
+## 2026-01-31 15:31 ET
+- Change: Ai.Error.extract_provider_message/1 now prefers Google-style error.errors[0].message *only when* error.message is present (keeps legacy fallback when only errors[] exists).
+- Tests: mix test apps/ai/test/ai/error_edge_cases_test.exs (86 tests, 0 failures)
+- Next: Investigate remaining mix test failures in Ai.CircuitBreaker tests (timing/half-open transition) and AgentCore Loop tool telemetry ordering.

--- a/worklog.md
+++ b/worklog.md
@@ -17,3 +17,9 @@
   - `mix test apps/coding_agent/test/coding_agent/subagents_test.exs` (pass)
 - Commit: 6104417 (branch: auto/lemon-20260131-1346)
 - Next: run the full umbrella `mix test` and pick off the next single failure (there were many earlier; this removes one of the named failures from the worklog).
+
+## 2026-01-31 14:10 ET
+- Change: Fix WebFetch to use supported Req connect options and add explicit format/timeout validation (prevents Req option crash and matches tool schema). (apps/coding_agent/lib/coding_agent/tools/webfetch.ex)
+- Tests:
+  - `mix test apps/coding_agent/test/coding_agent/tools/webfetch_test.exs` (pass)
+- Commit: (see git log; branch: auto/lemon-20260131-1408)

--- a/worklog.md
+++ b/worklog.md
@@ -35,3 +35,13 @@
 - Change: AgentCore.EventStream now demonitors the previously attached task when re-attaching, stores task_ref, and clears task_pid/task_ref on cancel/termination. Added regression test ensuring old task crash doesn't terminate stream after re-attach.
 - Tests: mix test apps/agent_core (exit 0).
 - Next: consider adding telemetry events for stream overflow/cancel/complete or integrating EventStream stats into agent-level metrics.
+
+## 2026-01-31 14:58 ET
+- Change: Harden Todo tools to match schema + tests:
+  - Added `CodingAgent.Tools.TodoStore.delete/1` and `clear/0` (safe no-op if ETS table is missing).
+  - `CodingAgent.Tools.TodoWrite` now validates todo entries (object shape, non-empty `id`/`content`, allowed `status`/`priority`, unique ids) before writing.
+  - Prevents crashes from non-map todo entries and returns helpful error tuples.
+- Tests:
+  - `mix test apps/coding_agent/test/coding_agent/tools/todo_test.exs` (pass)
+- Commit: dec3437 (branch: auto/lemon-20260131-1458)
+- Next: Add `CodingAgent.Tools.WebSearch.reset_rate_limit/0` (no-op or ETS reset) to unbreak `WebSearchTest` setup, then tackle remaining `coding_agent` failures bucket-by-bucket.


### PR DESCRIPTION
Adds structured extension status reporting (loaded extensions + load errors + tool conflict report) and exposes it via session state/event plus a new built-in tool (extensions_status) for self-diagnosis. Also extends extension metadata (capabilities/config_schema/providers), adds conflict reporting, lifecycle hook wiring, tests, docs, and cron loop script.