### PR TITLE
(fix): Telegram getMe identity resolution

### DIFF
--- a/apps/lemon_channels/test/lemon_channels/adapters/telegram/outbound_test.exs
+++ b/apps/lemon_channels/test/lemon_channels/adapters/telegram/outbound_test.exs
@@ -148,6 +148,27 @@ defmodule LemonChannels.Adapters.Telegram.OutboundTest do
     assert Enum.any?(opts[:entities], &(&1["type"] == "bold"))
   end
 
+  test "text: accepts api_mod configured as module path string" do
+    put_telegram_config(%{
+      bot_token: "token",
+      api_mod: "LemonChannels.Adapters.Telegram.OutboundTest.MockApiCapture",
+      use_markdown: false
+    })
+
+    payload =
+      %OutboundPayload{
+        channel_id: "telegram",
+        account_id: "acct",
+        peer: %{kind: :dm, id: "123", thread_id: nil},
+        kind: :text,
+        content: "string api mod"
+      }
+
+    assert {:ok, _} = Outbound.deliver(payload)
+    assert_receive {:send_message, 123, "string api mod", opts, nil}
+    assert is_map(opts)
+  end
+
   test "text: respects use_markdown = false and sends literal markdown" do
     put_telegram_config(%{
       bot_token: "token",

--- a/apps/lemon_gateway/test/telegram/outbox_test.exs
+++ b/apps/lemon_gateway/test/telegram/outbox_test.exs
@@ -117,6 +117,30 @@ defmodule LemonGateway.Telegram.OutboxTest do
     :ok
   end
 
+  describe "api_mod normalization" do
+    setup do
+      {:ok, _} = start_supervised({MockOutboxAPI, [notify_pid: self()]})
+      :ok
+    end
+
+    test "accepts api_mod configured as module path string" do
+      {:ok, _} =
+        start_supervised(
+          {Outbox,
+           [
+             bot_token: "token",
+             api_mod: "LemonGateway.Telegram.OutboxTest.MockOutboxAPI",
+             edit_throttle_ms: 0,
+             use_markdown: false
+           ]}
+        )
+
+      Outbox.enqueue({1, :send}, 0, {:send, 1, %{text: "string api mod"}})
+
+      assert_receive {:outbox_api_call, {:send, 1, "string api mod", %{}, nil}}, 200
+    end
+  end
+
   describe "coalescing" do
     setup do
       {:ok, _} = start_supervised({MockOutboxAPI, [notify_pid: self()]})


### PR DESCRIPTION
### Context

I was trying to run lemon and I couldn't get past this err

```
22:28:09.857 [warning] [Telegram] No getMe available and no config bot_id/bot_username; mention detection will be disabled
```

I've tried various config setups, but it always failed 

### Codex TL;DR

The change is a hardening of Telegram bot identity resolution.

Before:
- Startup used `config[:api_mod] || LemonChannels.Telegram.API` directly.
- If config came in with string keys (`"api_mod"`), `config[:api_mod]` was `nil`, so behavior could differ depending on config shape.
- `resolve_bot_identity/4` checked `function_exported?(api_mod, :get_me, 1)` without first ensuring the module was loaded.

After:
- Added `resolve_api_mod(config)` that reads both atom and string keys via `cfg_get/3`.
- Added `normalize_api_mod/1` to normalize `api_mod` values (atom/string/fallback).
- `init/1` now resolves `api_mod` once and uses it consistently for:
  - `state.api_mod`
  - `resolve_bot_identity/4`
- `resolve_bot_identity/4` now uses:
  - `Code.ensure_loaded?(api_mod) and function_exported?(api_mod, :get_me, 1)`
  so it won’t incorrectly conclude “no getMe available” due to module-load timing/config shape.
- Warning now includes `api_mod=...` so if it happens again, you can see exactly which module was checked.

Why this helps your case:
- You reported `api_mod: LemonChannels.Telegram.API` and `get_me? true` but still saw the warning.
- This patch removes the most likely mismatch path (inconsistent `api_mod` resolution) and improves observability if another path still triggers it.