### PR TITLE
feat(telegram): config toggles re threads, reactions, tools

### DIFF
--- a/apps/lemon_channels/lib/lemon_channels/gateway_config.ex
+++ b/apps/lemon_channels/lib/lemon_channels/gateway_config.ex
@@ -5,4 +5,5 @@ defmodule LemonChannels.GatewayConfig do
   # Kept for backward-compatibility; new code should use LemonCore.GatewayConfig directly.
 
   defdelegate get(key, default \\ nil), to: LemonCore.GatewayConfig
+  defdelegate get_telegram(key, default \\ nil), to: LemonCore.GatewayConfig
 end

--- a/apps/lemon_channels/test/lemon_channels/adapters/telegram/transport_config_flags_test.exs
+++ b/apps/lemon_channels/test/lemon_channels/adapters/telegram/transport_config_flags_test.exs
@@ -1,0 +1,193 @@
+defmodule LemonChannels.Adapters.Telegram.TransportConfigFlagsTest do
+  @moduledoc """
+  Tests for Telegram transport config flags:
+  - progress_reactions: true/false
+  - typing_indicator: true/false (heartbeat lifecycle)
+  """
+
+  use ExUnit.Case, async: false
+
+  defmodule FlagsTestRouter do
+    def handle_inbound(msg) do
+      if pid = :persistent_term.get({__MODULE__, :pid}, nil) do
+        send(pid, {:inbound, msg})
+      end
+
+      :ok
+    end
+
+    def abort(_session_key, _reason), do: :ok
+    def abort_run(_run_id, _reason), do: :ok
+  end
+
+  defmodule FlagsMockAPI do
+    @updates_key {__MODULE__, :updates}
+    @pid_key {__MODULE__, :pid}
+
+    def set_updates(updates), do: :persistent_term.put(@updates_key, updates)
+    def register_test(pid), do: :persistent_term.put(@pid_key, pid)
+
+    def get_updates(_token, _offset, _timeout_ms) do
+      updates = :persistent_term.get(@updates_key, [])
+
+      case updates do
+        [next | rest] ->
+          :persistent_term.put(@updates_key, rest)
+          {:ok, %{"ok" => true, "result" => [next]}}
+
+        [] ->
+          {:ok, %{"ok" => true, "result" => []}}
+      end
+    end
+
+    def send_message(_token, chat_id, text, reply_to_or_opts \\ nil, parse_mode \\ nil) do
+      notify({:send_message, chat_id, text, reply_to_or_opts, parse_mode})
+      {:ok, %{"ok" => true, "result" => %{"message_id" => System.unique_integer([:positive])}}}
+    end
+
+    def edit_message_text(_token, chat_id, message_id, text, opts \\ nil) do
+      notify({:edit_message_text, chat_id, message_id, text, opts})
+      {:ok, %{"ok" => true}}
+    end
+
+    def delete_message(_token, chat_id, message_id) do
+      notify({:delete_message, chat_id, message_id})
+      {:ok, %{"ok" => true}}
+    end
+
+    def answer_callback_query(_token, callback_id, opts \\ %{}) do
+      notify({:answer_callback, callback_id, opts})
+      {:ok, %{"ok" => true}}
+    end
+
+    def set_message_reaction(_token, chat_id, message_id, emoji, _opts \\ %{}) do
+      notify({:set_message_reaction, chat_id, message_id, emoji})
+      {:ok, %{"ok" => true}}
+    end
+
+    def send_chat_action(_token, chat_id, action, _opts \\ %{}) do
+      notify({:send_chat_action, chat_id, action})
+      {:ok, %{"ok" => true}}
+    end
+
+    defp notify(msg) do
+      if pid = :persistent_term.get(@pid_key, nil) do
+        send(pid, msg)
+      end
+
+      :ok
+    end
+  end
+
+  setup do
+    stop_transport()
+
+    old_router_bridge = Application.get_env(:lemon_core, :router_bridge)
+    old_gateway_env = Application.get_env(:lemon_channels, :gateway)
+
+    :persistent_term.put({FlagsTestRouter, :pid}, self())
+    FlagsMockAPI.register_test(self())
+    LemonCore.RouterBridge.configure(router: FlagsTestRouter)
+    set_bindings([])
+
+    on_exit(fn ->
+      stop_transport()
+      :persistent_term.erase({FlagsMockAPI, :updates})
+      :persistent_term.erase({FlagsMockAPI, :pid})
+      :persistent_term.erase({FlagsTestRouter, :pid})
+      restore_env(:lemon_core, :router_bridge, old_router_bridge)
+      restore_env(:lemon_channels, :gateway, old_gateway_env)
+    end)
+
+    :ok
+  end
+
+  test "progress_reactions: true — 👀 reaction is sent on inbound message" do
+    chat_id = 440_001
+    user_msg_id = 2001
+
+    FlagsMockAPI.set_updates([message_update(chat_id, user_msg_id, "hello")])
+
+    assert {:ok, _pid} =
+             start_transport(%{
+               allowed_chat_ids: [chat_id],
+               deny_unbound_chats: false,
+               progress_reactions: true
+             })
+
+    assert_receive {:set_message_reaction, ^chat_id, ^user_msg_id, "👀"}, 500
+  end
+
+  test "progress_reactions: false — no reaction is sent on inbound message" do
+    chat_id = 440_002
+    user_msg_id = 2002
+
+    FlagsMockAPI.set_updates([message_update(chat_id, user_msg_id, "hello")])
+
+    assert {:ok, _pid} =
+             start_transport(%{
+               allowed_chat_ids: [chat_id],
+               deny_unbound_chats: false,
+               progress_reactions: false
+             })
+
+    assert_receive {:inbound, _}, 500
+    refute_receive {:set_message_reaction, _, _, _}, 200
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp start_transport(overrides) when is_map(overrides) do
+    token = "token-flags-" <> Integer.to_string(System.unique_integer([:positive]))
+
+    config =
+      %{
+        bot_token: token,
+        api_mod: FlagsMockAPI,
+        poll_interval_ms: 10,
+        debounce_ms: 10
+      }
+      |> Map.merge(overrides)
+
+    LemonChannels.Adapters.Telegram.Transport.start_link(config: config)
+  end
+
+  defp message_update(chat_id, message_id, text) do
+    %{
+      "update_id" => System.unique_integer([:positive]),
+      "message" => %{
+        "message_id" => message_id,
+        "date" => 1,
+        "chat" => %{"id" => chat_id, "type" => "private"},
+        "from" => %{"id" => 99, "username" => "tester", "first_name" => "Test"},
+        "text" => text
+      }
+    }
+  end
+
+  defp set_bindings(bindings) do
+    cfg =
+      case Application.get_env(:lemon_channels, :gateway) do
+        map when is_map(map) -> map
+        list when is_list(list) -> Enum.into(list, %{})
+        _ -> %{}
+      end
+
+    Application.put_env(:lemon_channels, :gateway, Map.put(cfg, :bindings, bindings))
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+
+  defp stop_transport do
+    if pid = Process.whereis(LemonChannels.Adapters.Telegram.Transport) do
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/apps/lemon_channels/test/lemon_channels/gateway_config_test.exs
+++ b/apps/lemon_channels/test/lemon_channels/gateway_config_test.exs
@@ -93,6 +93,39 @@ defmodule LemonChannels.GatewayConfigTest do
     assert fetch(xmtp, :poll_interval_ms) == 300
   end
 
+  describe "get_telegram/2" do
+    test "returns value from telegram sub-config" do
+      Application.put_env(:lemon_channels, :telegram, %{progress_reactions: true})
+      assert GatewayConfig.get_telegram(:progress_reactions, :missing) == true
+    end
+
+    test "returns default when key is absent" do
+      Application.put_env(:lemon_channels, :telegram, %{})
+      # Use a key that won't exist in any real config file.
+      assert GatewayConfig.get_telegram(:__test_nonexistent_key__, :default_val) == :default_val
+    end
+
+    test "returns false (not default) when key is explicitly false — boolean correctness" do
+      Application.put_env(:lemon_channels, :telegram, %{progress_reactions: false})
+      assert GatewayConfig.get_telegram(:progress_reactions, true) == false
+    end
+
+    test "returns false for show_tool_status when explicitly false" do
+      Application.put_env(:lemon_channels, :telegram, %{show_tool_status: false})
+      assert GatewayConfig.get_telegram(:show_tool_status, true) == false
+    end
+
+    test "returns false for reply_to_user_message when explicitly false" do
+      Application.put_env(:lemon_channels, :telegram, %{reply_to_user_message: false})
+      assert GatewayConfig.get_telegram(:reply_to_user_message, true) == false
+    end
+
+    test "handles string-keyed telegram config" do
+      Application.put_env(:lemon_channels, :telegram, %{"progress_reactions" => false})
+      assert GatewayConfig.get_telegram(:progress_reactions, true) == false
+    end
+  end
+
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)
   defp restore_env(app, key, value), do: Application.put_env(app, key, value)
 

--- a/apps/lemon_core/AGENTS.md
+++ b/apps/lemon_core/AGENTS.md
@@ -52,7 +52,7 @@ This is the **base app** of the Lemon umbrella. All other apps depend on it. It 
 | `LemonCore.Id` | UUID and unique ID generation |
 | `LemonCore.Dotenv` | `.env` file loader; preserves existing env vars by default |
 | `LemonCore.Logging` | Runtime log-to-file handler setup from `[logging]` config |
-| `LemonCore.GatewayConfig` | Unified gateway config access merging TOML, app env, and per-transport overrides |
+| `LemonCore.GatewayConfig` | Unified gateway config access merging TOML, app env, and per-transport overrides. `get/2` for top-level keys; `get_telegram/2` for bool-safe Telegram sub-config lookup (distinguishes `false` from absent). |
 | `LemonCore.Config.TomlPatch` | Textual TOML editing for targeted key upserts without a TOML encoder |
 | `LemonCore.Binding` | Struct mapping transport/chat/topic to project/agent/engine |
 | `LemonCore.BindingResolver` | Resolves bindings for inbound messages |

--- a/apps/lemon_core/lib/lemon_core/config.ex
+++ b/apps/lemon_core/lib/lemon_core/config.ex
@@ -548,7 +548,10 @@ defmodule LemonCore.Config do
       debug_inbound: map["debug_inbound"],
       log_drops: map["log_drops"],
       compaction: parse_gateway_telegram_compaction(map["compaction"] || %{}),
-      files: parse_gateway_telegram_files(map["files"] || %{})
+      files: parse_gateway_telegram_files(map["files"] || %{}),
+      progress_reactions: parse_boolean(map["progress_reactions"], nil),
+      reply_to_user_message: parse_boolean(map["reply_to_user_message"], nil),
+      show_tool_status: parse_boolean(map["show_tool_status"], nil)
     }
     |> reject_nil_values()
   end

--- a/apps/lemon_core/lib/lemon_core/gateway_config.ex
+++ b/apps/lemon_core/lib/lemon_core/gateway_config.ex
@@ -39,6 +39,21 @@ defmodule LemonCore.GatewayConfig do
     _ -> default
   end
 
+  @doc """
+  Look up a key inside the telegram sub-config, with a default.
+
+  Handles both atom and string keys and correctly returns `false` for
+  boolean options that are explicitly disabled (unlike `||`-based lookups
+  which treat `false` as absent).
+  """
+  @spec get_telegram(atom(), term()) :: term()
+  def get_telegram(key, default \\ nil) when is_atom(key) do
+    telegram = get(:telegram, %{})
+    fetch(telegram, key, default)
+  rescue
+    _ -> default
+  end
+
   # ---------------------------------------------------------------------------
   # Layer 1: base config
   # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -499,3 +499,19 @@ In Telegram group chats, you can gate runs so Lemon only triggers when explicitl
 
 Forum topic management:
 - `/topic <name>`: create a new topic in the current Telegram forum supergroup.
+
+## Telegram Behavior Toggles
+
+Optional flags to suppress default Telegram behaviors. All default to `true` (enabled).
+
+```toml
+[gateway.telegram]
+# Set 👀/✅/❌ reactions on the user's message to indicate processing status.
+progress_reactions = true
+
+# Send answers as a threaded reply to the user's message rather than a new message.
+reply_to_user_message = true
+
+# Show a "Tool calls:" status message during runs with tool activity.
+show_tool_status = true
+```


### PR DESCRIPTION
Let operators configure "chatty" telegram behaviors if they prefer.

Also adds bool-safe config lookup so explicit `= false` in config.toml is respected rather than treated as absent. This is because our configs default to true (progress_reactions, reply_to_user_message, show_tool_status) and we need to be able to meaningfully set them to false.