### PR TITLE
feat(telegram): typing indicator

### DIFF
--- a/apps/lemon_channels/AGENTS.md
+++ b/apps/lemon_channels/AGENTS.md
@@ -75,7 +75,7 @@ share a group and are never delivered concurrently to prevent reordering.
 |------|-------------|
 | `adapters/telegram.ex` | Plugin impl. id: `"telegram"`, chunk_limit: 4096, rate_limit: 30, full capability set. |
 | `adapters/telegram/supervisor.ex` | Starts AsyncSupervisor (Task.Supervisor) + Transport. |
-| `adapters/telegram/transport.ex` | **Largest file (~1200 lines)**. Long-polling GenServer via getUpdates. Command handling, inbound routing, session management. State includes message indices, active runs, picker state. |
+| `adapters/telegram/transport.ex` | **Largest file (~1200 lines)**. Long-polling GenServer via getUpdates. Command handling, inbound routing, session management. State includes message indices, active runs, picker state, typing heartbeat timers. |
 | `adapters/telegram/transport/commands.ex` | Pure command detection functions. `scope_key/3`, `join_messages/1`. No side effects. |
 | `adapters/telegram/transport/file_operations.ex` | `/file put`/`get`, auto-put for document uploads, media group file handling. |
 | `adapters/telegram/transport/media_groups.ex` | Coalescence of media group messages with debounce timer. |
@@ -89,7 +89,7 @@ share a group and are never delivered concurrently to prevent reordering.
 
 | File | What It Does |
 |------|-------------|
-| `telegram/api.ex` | Raw Bot API calls: send_message, edit_message_text, get_updates, send_document, send_photo, send_media_group, etc. |
+| `telegram/api.ex` | Raw Bot API calls: send_message, edit_message_text, get_updates, send_document, send_photo, send_media_group, send_chat_action, etc. |
 | `telegram/delivery.ex` | High-level enqueue helpers (`enqueue_send/3`, `enqueue_edit/3`) backed by Outbox. |
 | `telegram/formatter.ex` | Markdown to plain text + Telegram entities. Avoids MarkdownV2 escaping entirely. |
 | `telegram/markdown.ex` | EarmarkParser AST renderer. Produces `{text, [entity]}` with correct UTF-16 offsets. |

--- a/apps/lemon_channels/lib/lemon_channels/telegram/api.ex
+++ b/apps/lemon_channels/lib/lemon_channels/telegram/api.ex
@@ -182,6 +182,16 @@ defmodule LemonChannels.Telegram.API do
     request(token, "setMessageReaction", params, @default_timeout)
   end
 
+  def send_chat_action(token, chat_id, action, opts \\ %{}) do
+    opts = if is_map(opts), do: opts, else: Enum.into(opts, %{})
+
+    params =
+      %{"chat_id" => chat_id, "action" => action}
+      |> maybe_put("message_thread_id", opts[:message_thread_id] || opts["message_thread_id"])
+
+    request(token, "sendChatAction", params, @default_timeout)
+  end
+
   def get_file(token, file_id) when is_binary(file_id) do
     params = %{"file_id" => file_id}
     request(token, "getFile", params, @default_timeout)

--- a/apps/lemon_channels/test/lemon_channels/adapters/telegram/typing_indicator_test.exs
+++ b/apps/lemon_channels/test/lemon_channels/adapters/telegram/typing_indicator_test.exs
@@ -1,0 +1,193 @@
+defmodule LemonChannels.Adapters.Telegram.TypingIndicatorTest do
+  @moduledoc """
+  Tests for the Telegram typing indicator heartbeat lifecycle.
+  """
+
+  use ExUnit.Case, async: false
+
+  defmodule TypingTestRouter do
+    def handle_inbound(msg) do
+      if pid = :persistent_term.get({__MODULE__, :pid}, nil) do
+        send(pid, {:inbound, msg})
+      end
+
+      :ok
+    end
+
+    def abort(_session_key, _reason), do: :ok
+    def abort_run(_run_id, _reason), do: :ok
+  end
+
+  defmodule TypingMockAPI do
+    @updates_key {__MODULE__, :updates}
+    @pid_key {__MODULE__, :pid}
+
+    def set_updates(updates), do: :persistent_term.put(@updates_key, updates)
+    def register_test(pid), do: :persistent_term.put(@pid_key, pid)
+
+    def get_updates(_token, _offset, _timeout_ms) do
+      updates = :persistent_term.get(@updates_key, [])
+
+      case updates do
+        [next | rest] ->
+          :persistent_term.put(@updates_key, rest)
+          {:ok, %{"ok" => true, "result" => [next]}}
+
+        [] ->
+          {:ok, %{"ok" => true, "result" => []}}
+      end
+    end
+
+    def send_message(_token, chat_id, text, reply_to_or_opts \\ nil, parse_mode \\ nil) do
+      notify({:send_message, chat_id, text, reply_to_or_opts, parse_mode})
+      {:ok, %{"ok" => true, "result" => %{"message_id" => System.unique_integer([:positive])}}}
+    end
+
+    def set_message_reaction(_token, chat_id, message_id, emoji, _opts \\ %{}) do
+      notify({:set_message_reaction, chat_id, message_id, emoji})
+      {:ok, %{"ok" => true}}
+    end
+
+    def send_chat_action(_token, chat_id, action, _opts \\ %{}) do
+      notify({:send_chat_action, chat_id, action})
+      {:ok, %{"ok" => true}}
+    end
+
+    defp notify(msg) do
+      if pid = :persistent_term.get(@pid_key, nil) do
+        send(pid, msg)
+      end
+
+      :ok
+    end
+  end
+
+  setup do
+    stop_transport()
+
+    old_router_bridge = Application.get_env(:lemon_core, :router_bridge)
+    old_gateway_env = Application.get_env(:lemon_channels, :gateway)
+
+    :persistent_term.put({TypingTestRouter, :pid}, self())
+    TypingMockAPI.register_test(self())
+    LemonCore.RouterBridge.configure(router: TypingTestRouter)
+    set_bindings([])
+
+    on_exit(fn ->
+      stop_transport()
+      :persistent_term.erase({TypingMockAPI, :updates})
+      :persistent_term.erase({TypingMockAPI, :pid})
+      :persistent_term.erase({TypingTestRouter, :pid})
+      restore_env(:lemon_core, :router_bridge, old_router_bridge)
+      restore_env(:lemon_channels, :gateway, old_gateway_env)
+    end)
+
+    :ok
+  end
+
+  test "sendChatAction(typing) is sent on inbound message" do
+    chat_id = 550_001
+    user_msg_id = 3001
+
+    TypingMockAPI.set_updates([message_update(chat_id, user_msg_id, "hello")])
+
+    assert {:ok, _pid} =
+             start_transport(%{
+               allowed_chat_ids: [chat_id],
+               deny_unbound_chats: false
+             })
+
+    assert_receive {:send_chat_action, ^chat_id, "typing"}, 500
+  end
+
+  test "typing_timers populated after inbound, cleared after run_completed" do
+    chat_id = 550_002
+    user_msg_id = 3002
+
+    TypingMockAPI.set_updates([message_update(chat_id, user_msg_id, "hello")])
+
+    assert {:ok, pid} =
+             start_transport(%{
+               allowed_chat_ids: [chat_id],
+               deny_unbound_chats: false
+             })
+
+    assert_receive {:send_chat_action, ^chat_id, "typing"}, 500
+
+    state = :sys.get_state(pid)
+    assert map_size(state.typing_timers) == 1
+
+    session_key = hd(Map.keys(state.typing_timers))
+
+    send(
+      pid,
+      %LemonCore.Event{
+        type: :run_completed,
+        ts_ms: System.monotonic_time(:millisecond),
+        meta: %{session_key: session_key},
+        payload: %{ok: true}
+      }
+    )
+
+    :sys.get_state(pid)
+
+    state = :sys.get_state(pid)
+    assert map_size(state.typing_timers) == 0
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp start_transport(overrides) when is_map(overrides) do
+    token = "token-typing-" <> Integer.to_string(System.unique_integer([:positive]))
+
+    config =
+      %{
+        bot_token: token,
+        api_mod: TypingMockAPI,
+        poll_interval_ms: 10,
+        debounce_ms: 10
+      }
+      |> Map.merge(overrides)
+
+    LemonChannels.Adapters.Telegram.Transport.start_link(config: config)
+  end
+
+  defp message_update(chat_id, message_id, text) do
+    %{
+      "update_id" => System.unique_integer([:positive]),
+      "message" => %{
+        "message_id" => message_id,
+        "date" => 1,
+        "chat" => %{"id" => chat_id, "type" => "private"},
+        "from" => %{"id" => 99, "username" => "tester", "first_name" => "Test"},
+        "text" => text
+      }
+    }
+  end
+
+  defp set_bindings(bindings) do
+    cfg =
+      case Application.get_env(:lemon_channels, :gateway) do
+        map when is_map(map) -> map
+        list when is_list(list) -> Enum.into(list, %{})
+        _ -> %{}
+      end
+
+    Application.put_env(:lemon_channels, :gateway, Map.put(cfg, :bindings, bindings))
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+
+  defp stop_transport do
+    if pid = Process.whereis(LemonChannels.Adapters.Telegram.Transport) do
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/docs/config.md
+++ b/docs/config.md
@@ -499,3 +499,7 @@ In Telegram group chats, you can gate runs so Lemon only triggers when explicitl
 
 Forum topic management:
 - `/topic <name>`: create a new topic in the current Telegram forum supergroup.
+
+## Telegram Typing Indicator
+
+Lemon sends a "typing…" chat action while a run is in progress, refreshing every 4 seconds (Telegram actions expire after ~5 seconds). The indicator is cancelled automatically when the run completes.


### PR DESCRIPTION
Keeps the \"typing…\" indicator alive for the full duration of a run. Telegram chat actions expire after ~5 s, so the transport reschedules every 4 s and cancels automatically on `run_completed`.

Note that OpenClaw has this configurable, https://docs.openclaw.ai/concepts/typing-indicators#modes, with four options. This is basically the \"instant\" option, which is the default.

I could submit this as configurable (in fact there's a branch here: https://github.com/woahdae/lemon/tree/feat/telegram-typing-indicator), but I already have a configuration-heavy PR in flight and I wanted this to be parallel.

## Bug fixes (added in follow-up commit)

Three edge cases caused the typing indicator to spin indefinitely:

**1. Subscription gated behind `progress_reactions`**
`maybe_subscribe_to_session` was only called when the 👀 reaction succeeded. With `progress_reactions` disabled (or the emoji API call failing), the transport never subscribed to the session topic and never received `:run_completed`. Fixed by subscribing unconditionally when the typing timer starts.

**2. Crash path not covered**
`RunProcess.terminate/2` broadcast `run_failed` on the *run topic*, but channel adapters subscribe to the *session topic*. A crashed run left the typing indicator looping forever. Fixed by also broadcasting a synthetic `%LemonCore.Event{type: :run_completed, ok: false}` on the session topic from `terminate/2`, reusing the existing cleanup path without a new event type.

**3. No hard cap**
As a last-resort watchdog, `typing_timers` now stores `{timer_ref, started_at_ms}` and ticks auto-cancel after 5 minutes if neither of the above paths fires.