### PR TITLE
feat(telegram): send video files inline via sendVideo

### DIFF
--- a/apps/lemon_channels/lib/lemon_channels/adapters/telegram/outbound.ex
+++ b/apps/lemon_channels/lib/lemon_channels/adapters/telegram/outbound.ex
@@ -549,6 +549,9 @@ defmodule LemonChannels.Adapters.Telegram.Outbound do
       image_file?(path) and function_exported?(api_mod, :send_photo, 4) ->
         api_mod.send_photo(token, chat_id, {:path, path}, opts)
 
+      video_file?(path) and function_exported?(api_mod, :send_video, 4) ->
+        api_mod.send_video(token, chat_id, {:path, path}, opts)
+
       function_exported?(api_mod, :send_document, 4) ->
         api_mod.send_document(token, chat_id, {:path, path}, opts)
 
@@ -599,6 +602,16 @@ defmodule LemonChannels.Adapters.Telegram.Outbound do
       ".tiff" -> true
       ".heic" -> true
       ".heif" -> true
+      _ -> false
+    end
+  end
+
+  defp video_file?(path) when is_binary(path) do
+    case Path.extname(path) |> String.downcase() do
+      ".mp4" -> true
+      ".mov" -> true
+      ".webm" -> true
+      ".avi" -> true
       _ -> false
     end
   end


### PR DESCRIPTION
## Summary

- `.mp4`, `.mov`, `.webm`, and `.avi` files now route to `sendVideo` instead of `sendDocument`, so they play inline in Telegram rather than arriving as file attachments
- Added `send_video/4` to `Telegram.API` following the same multipart upload pattern as `send_photo/4`
- Added `video_file?/1` predicate to `Outbound` and wired it into `send_file/5` between the image and document branches
- Video MIME types added to `mime_type_for_path/2` in the API module
- If `send_video` is not exported by the configured api_mod (e.g. a mock without it), falls through to `send_document` as before

## Test plan

- [x] `mix test apps/lemon_channels/test/lemon_channels/adapters/telegram/outbound_test.exs` — 14 tests, 0 failures
- [x] `mix test apps/lemon_channels` — 0 failures
- [x] `mix format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)