### PR TITLE
Fix games live update reliability and web launcher startup

### DIFF
--- a/apps/lemon_games/AGENTS.md
+++ b/apps/lemon_games/AGENTS.md
@@ -10,6 +10,7 @@ Core principles:
 - **Plain maps with string keys**: no Ecto schemas; storage via `LemonCore.Store` (ETS/JSONL/SQLite)
 - **Per-match global locks**: all mutating operations go through `:global.trans` for consistency
 - **Visibility policy**: match `visibility` must be one of `public`, `private`, or `unlisted`
+- **Dual broadcast on accepted moves**: `submit_move/4` publishes both per-match (`games:match:<id>`) and lobby (`games:lobby`) updates so spectator views can stay in sync.
 
 ## Key Files and Purposes
 

--- a/apps/lemon_games/README.md
+++ b/apps/lemon_games/README.md
@@ -142,6 +142,7 @@ A match progresses through these statuses: `pending_accept` -> `active` -> `fini
 - On success: appends `move_submitted` event, updates snapshot state, advances turn or finishes game
 - On failure: appends `move_rejected` event with the rejection reason
 - Broadcasts match event for real-time spectators
+- Broadcasts lobby change event on every accepted move (`reason: "move_submitted"` for active matches, `"game_over"` for terminal matches)
 - Triggers bot turn worker if the next player is a bot
 
 ### 4. Terminal States

--- a/apps/lemon_games/lib/lemon_games/matches/service.ex
+++ b/apps/lemon_games/lib/lemon_games/matches/service.ex
@@ -277,9 +277,9 @@ defmodule LemonGames.Matches.Service do
                 "turn_number" => match["turn_number"]
               })
 
-              if terminal do
-                Bus.broadcast_lobby_changed(match_id, "finished", "game_over")
-              end
+              lobby_status = if terminal, do: "finished", else: match["status"]
+              lobby_reason = if terminal, do: "game_over", else: "move_submitted"
+              Bus.broadcast_lobby_changed(match_id, lobby_status, lobby_reason)
 
               # Trigger bot turn if next player is a bot
               Task.start(fn -> LemonGames.Bot.TurnWorker.maybe_play_bot_turn(match) end)

--- a/apps/lemon_games/test/lemon_games/matches/service_test.exs
+++ b/apps/lemon_games/test/lemon_games/matches/service_test.exs
@@ -86,6 +86,24 @@ defmodule LemonGames.Matches.ServiceTest do
     assert updated["turn_number"] > match["turn_number"]
   end
 
+  test "submit_move broadcasts lobby change event for active match" do
+    params = %{"game_type" => "connect4", "visibility" => "public"}
+    {:ok, pending} = Service.create_match(params, @actor)
+    {:ok, match} = Service.accept_match(pending["id"], @actor2)
+
+    :ok = LemonGames.Bus.subscribe_lobby()
+
+    move = %{"kind" => "drop", "column" => 3}
+
+    assert {:ok, _updated, _seq, false} =
+             Service.submit_move(match["id"], @actor, move, "key-lobby-1")
+
+    assert_receive %LemonCore.Event{type: :game_lobby_changed, payload: payload}, 500
+    assert payload["match_id"] == match["id"]
+    assert payload["status"] == "active"
+    assert payload["reason"] == "move_submitted"
+  end
+
   test "submit_move rejects illegal move" do
     {:ok, match} = create_bot_match("connect4")
 

--- a/apps/lemon_web/AGENTS.md
+++ b/apps/lemon_web/AGENTS.md
@@ -84,8 +84,8 @@ live "/sessions/:session_key", SessionLive, :show  # Uses the provided session k
 
 ### Games LiveViews
 
-- `LemonWeb.GamesLobbyLive` (`/games`) shows public matches and live lobby refreshes via `LemonGames.Bus.subscribe_lobby/0`.
-- `LemonWeb.GameMatchLive` (`/games/:id`) renders match state + event timeline and subscribes to per-match events via `LemonGames.Bus.subscribe_match/1`.
+- `LemonWeb.Games.LobbyLive` (`/games`) shows public matches via `LemonGames.Bus.subscribe_lobby/0` and also performs a periodic refresh tick (1.5s) as a fallback.
+- `LemonWeb.Games.MatchLive` (`/games/:id`) renders match state + event timeline via `LemonGames.Bus.subscribe_match/1`, tracks a `last_event_seq` cursor, and performs catch-up via `LemonGames.Matches.Service.list_events/4` (`after_seq`) on each event and on a periodic refresh tick (1s).
 
 ### Message Structure
 

--- a/apps/lemon_web/README.md
+++ b/apps/lemon_web/README.md
@@ -103,11 +103,11 @@ The primary dashboard page. Provides a chat-style interface for sending prompts 
 
 ### GamesLobbyLive (`/games`)
 
-Displays a live list of public game matches. Subscribes to `LemonGames.Bus` lobby events and refreshes the match list automatically when matches are created, updated, or expire. Each match entry shows game type, status badge, and a "Watch" link.
+Displays a live list of public game matches. Subscribes to `LemonGames.Bus` lobby events and refreshes the match list automatically when matches are created, updated, or expire. Also runs a periodic refresh tick every 1.5 seconds as a fallback so the lobby still updates if an event is missed. Each match entry shows game type, status badge, and a "Watch" link.
 
 ### GameMatchLive (`/games/:id`)
 
-Spectator view for a single game match. Shows the current board state, match metadata, and a scrolling event timeline. Subscribes to per-match events via `LemonGames.Bus` and fetches incremental events in batches of 100.
+Spectator view for a single game match. Shows the current board state, match metadata, and a scrolling event timeline. Subscribes to per-match events via `LemonGames.Bus` and maintains a `last_event_seq` cursor. On each game event (and on a 1-second refresh tick), it calls `list_events/4` with `after_seq` to replay missed events from the persisted event log, then refreshes the projected match state. This gives reconnect-safe catch-up even when PubSub delivery is transient.
 
 This route is intentionally spectator-only in the current release. Move submission remains an API/client responsibility.
 

--- a/apps/lemon_web/lib/lemon_web/live/games/components/board_component.ex
+++ b/apps/lemon_web/lib/lemon_web/live/games/components/board_component.ex
@@ -3,8 +3,8 @@ defmodule LemonWeb.Games.Components.BoardComponent do
 
   use Phoenix.Component
 
-  attr :game_type, :string, required: true
-  attr :game_state, :map, required: true
+  attr(:game_type, :string, required: true)
+  attr(:game_state, :map, required: true)
 
   def board(%{game_type: "connect4"} = assigns) do
     rows = Map.get(assigns.game_state, "board", [])
@@ -111,17 +111,19 @@ defmodule LemonWeb.Games.Components.BoardComponent do
   end
 
   def rps_throw(assigns) do
-    icon = case @throw do
-      "rock" -> "✊"
-      "paper" -> "✋"
-      "scissors" -> "✌️"
-      _ -> "❓"
-    end
+    icon =
+      case assigns.throw do
+        "rock" -> "✊"
+        "paper" -> "✋"
+        "scissors" -> "✌️"
+        _ -> "❓"
+      end
 
-    color = case @throw do
-      nil -> "bg-slate-200 text-slate-400"
-      _ -> "bg-white text-slate-900 shadow-md"
-    end
+    color =
+      case assigns.throw do
+        nil -> "bg-slate-200 text-slate-400"
+        _ -> "bg-white text-slate-900 shadow-md"
+      end
 
     assigns = assign(assigns, icon: icon, color: color)
 
@@ -137,17 +139,27 @@ defmodule LemonWeb.Games.Components.BoardComponent do
   defp connect4_cell_class(2), do: "block h-10 w-10 rounded-full bg-yellow-400 shadow-md"
   defp connect4_cell_class(_), do: "block h-10 w-10 rounded-full bg-slate-400"
 
-  defp tictactoe_cell_class(nil), do: "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold text-slate-600 transition-all hover:bg-slate-600"
-  defp tictactoe_cell_class("X"), do: "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold text-blue-400 shadow-lg"
-  defp tictactoe_cell_class("O"), do: "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold text-rose-400 shadow-lg"
-  defp tictactoe_cell_class(_), do: "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold"
+  defp tictactoe_cell_class(nil),
+    do:
+      "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold text-slate-600 transition-all hover:bg-slate-600"
+
+  defp tictactoe_cell_class("X"),
+    do:
+      "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold text-blue-400 shadow-lg"
+
+  defp tictactoe_cell_class("O"),
+    do:
+      "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold text-rose-400 shadow-lg"
+
+  defp tictactoe_cell_class(_),
+    do: "flex h-16 w-16 items-center justify-center rounded-lg bg-slate-700 text-2xl font-bold"
 
   defp tictactoe_cell_content(nil), do: ""
   defp tictactoe_cell_content(cell), do: cell
 
   # Battleship grid component
-  attr :shots, :list, required: true
-  attr :ships, :list, required: true
+  attr(:shots, :list, required: true)
+  attr(:ships, :list, required: true)
 
   def battleship_grid(assigns) do
     # Build shot map: {r,c} -> :hit/:miss

--- a/apps/lemon_web/lib/lemon_web/live/games/lobby_live.ex
+++ b/apps/lemon_web/lib/lemon_web/live/games/lobby_live.ex
@@ -5,10 +5,14 @@ defmodule LemonWeb.Games.LobbyLive do
 
   alias LemonGames.{Bus, Matches.Service}
   alias LemonCore.Event
+  @refresh_ms 1_500
 
   @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: Bus.subscribe_lobby()
+    if connected?(socket) do
+      Bus.subscribe_lobby()
+      Process.send_after(self(), :refresh_lobby, @refresh_ms)
+    end
 
     {:ok,
      socket
@@ -18,6 +22,11 @@ defmodule LemonWeb.Games.LobbyLive do
 
   @impl true
   def handle_info(%Event{type: :game_lobby_changed}, socket) do
+    {:noreply, assign(socket, :matches, Service.list_lobby())}
+  end
+
+  def handle_info(:refresh_lobby, socket) do
+    Process.send_after(self(), :refresh_lobby, @refresh_ms)
     {:noreply, assign(socket, :matches, Service.list_lobby())}
   end
 
@@ -109,12 +118,13 @@ defmodule LemonWeb.Games.LobbyLive do
   end
 
   def status_badge(assigns) do
-    {bg, text, label} = case @status do
-      "active" -> {"bg-emerald-100", "text-emerald-700", "Live"}
-      "pending_accept" -> {"bg-amber-100", "text-amber-700", "Waiting"}
-      "finished" -> {"bg-slate-100", "text-slate-600", "Finished"}
-      _ -> {"bg-slate-100", "text-slate-600", @status}
-    end
+    {bg, text, label} =
+      case assigns.status do
+        "active" -> {"bg-emerald-100", "text-emerald-700", "Live"}
+        "pending_accept" -> {"bg-amber-100", "text-amber-700", "Waiting"}
+        "finished" -> {"bg-slate-100", "text-slate-600", "Finished"}
+        _ -> {"bg-slate-100", "text-slate-600", assigns.status}
+      end
 
     assigns = assign(assigns, bg: bg, text: text, label: label)
 
@@ -126,11 +136,12 @@ defmodule LemonWeb.Games.LobbyLive do
   end
 
   def player_avatar(assigns) do
-    {name, avatar, bot} = case @player do
-      %{"display_name" => name, "agent_type" => "lemon_bot"} -> {name, "🤖", true}
-      %{"display_name" => name} -> {name, "👤", false}
-      _ -> {"Waiting...", "⏳", false}
-    end
+    {name, avatar, bot} =
+      case assigns.player do
+        %{"display_name" => name, "agent_type" => "lemon_bot"} -> {name, "🤖", true}
+        %{"display_name" => name} -> {name, "👤", false}
+        _ -> {"Waiting...", "⏳", false}
+      end
 
     assigns = assign(assigns, name: name, avatar: avatar, bot: bot)
 

--- a/apps/lemon_web/lib/lemon_web/live/games/match_live.ex
+++ b/apps/lemon_web/lib/lemon_web/live/games/match_live.ex
@@ -7,20 +7,33 @@ defmodule LemonWeb.Games.MatchLive do
   alias LemonGames.{Bus, Matches.Service}
   alias LemonWeb.Games.Components.BoardComponent
 
+  @refresh_ms 1_000
+  @event_batch_limit 200
+  @max_catch_up_batches 5
+
   @impl true
   def mount(%{"match_id" => match_id}, _session, socket) do
-    if connected?(socket), do: Bus.subscribe_match(match_id)
+    if connected?(socket) do
+      Bus.subscribe_match(match_id)
+      Process.send_after(self(), :refresh_match, @refresh_ms)
+    end
 
     {:ok,
      socket
      |> assign(:page_title, "Game Match")
      |> assign(:match_id, match_id)
+     |> assign(:last_event_seq, 0)
      |> load_match()}
   end
 
   @impl true
   def handle_info(%Event{type: :game_match_event}, socket) do
-    {:noreply, load_match(socket)}
+    {:noreply, catch_up_match(socket)}
+  end
+
+  def handle_info(:refresh_match, socket) do
+    Process.send_after(self(), :refresh_match, @refresh_ms)
+    {:noreply, catch_up_match(socket)}
   end
 
   def handle_info(_, socket), do: {:noreply, socket}
@@ -91,12 +104,13 @@ defmodule LemonWeb.Games.MatchLive do
   end
 
   def status_indicator(assigns) do
-    {color, label} = case @status do
-      "active" -> {"bg-emerald-500", "Live"}
-      "pending_accept" -> {"bg-amber-500", "Waiting"}
-      "finished" -> {"bg-slate-400", "Finished"}
-      _ -> {"bg-slate-400", "Unknown"}
-    end
+    {color, label} =
+      case assigns.status do
+        "active" -> {"bg-emerald-500", "Live"}
+        "pending_accept" -> {"bg-amber-500", "Waiting"}
+        "finished" -> {"bg-slate-400", "Finished"}
+        _ -> {"bg-slate-400", "Unknown"}
+      end
 
     assigns = assign(assigns, color: color, label: label)
 
@@ -109,11 +123,12 @@ defmodule LemonWeb.Games.MatchLive do
   end
 
   def player_card(assigns) do
-    {name, avatar, bot} = case @player do
-      %{"display_name" => name, "agent_type" => "lemon_bot"} -> {name, "🤖", true}
-      %{"display_name" => name} -> {name, "👤", false}
-      _ -> {"Unknown", "❓", false}
-    end
+    {name, avatar, bot} =
+      case assigns.player do
+        %{"display_name" => name, "agent_type" => "lemon_bot"} -> {name, "🤖", true}
+        %{"display_name" => name} -> {name, "👤", false}
+        _ -> {"Unknown", "❓", false}
+      end
 
     assigns = assign(assigns, name: name, avatar: avatar, bot: bot)
 
@@ -158,12 +173,87 @@ defmodule LemonWeb.Games.MatchLive do
 
     case Service.get_match(match_id, "spectator") do
       {:ok, match} ->
-        {:ok, events, _next, _more} = Service.list_events(match_id, 0, 200, "spectator")
-        assign(socket, :match, match) |> assign(:events, events)
+        case fetch_events_since(match_id, 0, "spectator") do
+          {:ok, events, next_after_seq} ->
+            socket
+            |> assign(:match, match)
+            |> assign(:events, events)
+            |> assign(:last_event_seq, next_after_seq)
+
+          {:error, :not_found, _} ->
+            assign(socket, :match, nil)
+            |> assign(:events, [])
+            |> assign(:last_event_seq, 0)
+        end
 
       {:error, :not_found, _} ->
-        assign(socket, :match, nil) |> assign(:events, [])
+        assign(socket, :match, nil)
+        |> assign(:events, [])
+        |> assign(:last_event_seq, 0)
     end
+  end
+
+  defp catch_up_match(socket) do
+    match_id = socket.assigns.match_id
+    after_seq = socket.assigns.last_event_seq || 0
+
+    case fetch_events_since(match_id, after_seq, "spectator") do
+      {:ok, [], _next_after_seq} ->
+        socket
+
+      {:ok, new_events, next_after_seq} ->
+        case Service.get_match(match_id, "spectator") do
+          {:ok, match} ->
+            socket
+            |> assign(:match, match)
+            |> assign(:events, append_events(socket.assigns.events || [], new_events))
+            |> assign(:last_event_seq, next_after_seq)
+
+          {:error, :not_found, _} ->
+            socket
+            |> assign(:match, nil)
+            |> assign(:events, [])
+            |> assign(:last_event_seq, 0)
+        end
+
+      {:error, :not_found, _} ->
+        socket
+        |> assign(:match, nil)
+        |> assign(:events, [])
+        |> assign(:last_event_seq, 0)
+    end
+  end
+
+  defp fetch_events_since(match_id, after_seq, viewer, depth \\ 0, acc \\ [])
+
+  defp fetch_events_since(_match_id, after_seq, _viewer, depth, acc)
+       when depth >= @max_catch_up_batches do
+    {:ok, acc, after_seq}
+  end
+
+  defp fetch_events_since(match_id, after_seq, viewer, depth, acc) do
+    case Service.list_events(match_id, after_seq, @event_batch_limit, viewer) do
+      {:ok, events, next_after_seq, true} ->
+        fetch_events_since(match_id, next_after_seq, viewer, depth + 1, acc ++ events)
+
+      {:ok, events, next_after_seq, false} ->
+        {:ok, acc ++ events, next_after_seq}
+
+      {:error, _code, _message} = error ->
+        error
+    end
+  end
+
+  defp append_events(existing, new_events) do
+    existing_seqs = existing |> Enum.map(& &1["seq"]) |> MapSet.new()
+
+    merged =
+      existing ++
+        Enum.reject(new_events, fn event -> MapSet.member?(existing_seqs, event["seq"]) end)
+
+    keep = 400
+    drop_count = max(length(merged) - keep, 0)
+    Enum.drop(merged, drop_count)
   end
 
   defp players_label(players) when is_map(players) do

--- a/apps/lemon_web/test/lemon_web/live/games_live_test.exs
+++ b/apps/lemon_web/test/lemon_web/live/games_live_test.exs
@@ -39,6 +39,18 @@ defmodule LemonWeb.Live.GamesLiveTest do
     assert render(view) =~ "Connect 4"
   end
 
+  test "lobby updates on refresh tick without lobby bus event" do
+    {:ok, view, html} = live(build_conn(), "/games")
+    assert html =~ "No active matches"
+
+    {:ok, match} =
+      Service.create_match(%{"game_type" => "connect4", "visibility" => "public"}, @actor1)
+
+    send(view.pid, :refresh_lobby)
+
+    assert render(view) =~ match["id"]
+  end
+
   test "GET /games/:match_id renders match details" do
     {:ok, match_id} = create_active_match()
 
@@ -59,11 +71,62 @@ defmodule LemonWeb.Live.GamesLiveTest do
     assert html =~ "Turn #1"
 
     assert {:ok, _updated, _seq, false} =
-             Service.submit_move(match_id, @actor1, %{"kind" => "drop", "column" => 0}, "lv-move-1")
+             Service.submit_move(
+               match_id,
+               @actor1,
+               %{"kind" => "drop", "column" => 0},
+               "lv-move-1"
+             )
 
     send(view.pid, Event.new(:game_match_event, %{}))
 
     assert render(view) =~ "Turn #2"
+  end
+
+  test "match live updates on refresh tick without match bus event" do
+    {:ok, match_id} = create_active_match()
+    {:ok, view, html} = live(build_conn(), "/games/#{match_id}")
+
+    assert html =~ "Turn #1"
+
+    assert {:ok, _updated, _seq, false} =
+             Service.submit_move(
+               match_id,
+               @actor1,
+               %{"kind" => "drop", "column" => 0},
+               "lv-move-2"
+             )
+
+    send(view.pid, :refresh_match)
+
+    assert render(view) =~ "Turn #2"
+  end
+
+  test "match live catches up multiple missed events from event log cursor" do
+    {:ok, match_id} = create_active_match()
+    {:ok, view, html} = live(build_conn(), "/games/#{match_id}")
+
+    assert html =~ "Turn #1"
+
+    assert {:ok, _updated, _seq, false} =
+             Service.submit_move(
+               match_id,
+               @actor1,
+               %{"kind" => "drop", "column" => 0},
+               "lv-move-catchup-1"
+             )
+
+    assert {:ok, _updated, _seq, false} =
+             Service.submit_move(
+               match_id,
+               @actor2,
+               %{"kind" => "drop", "column" => 1},
+               "lv-move-catchup-2"
+             )
+
+    send(view.pid, :refresh_match)
+
+    assert render(view) =~ "Turn #3"
   end
 
   test "unknown match shows not found message" do
@@ -72,7 +135,8 @@ defmodule LemonWeb.Live.GamesLiveTest do
   end
 
   defp create_active_match do
-    with {:ok, pending} <- Service.create_match(%{"game_type" => "connect4", "visibility" => "public"}, @actor1),
+    with {:ok, pending} <-
+           Service.create_match(%{"game_type" => "connect4", "visibility" => "public"}, @actor1),
          {:ok, active} <- Service.accept_match(pending["id"], @actor2) do
       {:ok, active["id"]}
     end

--- a/bin/lemon
+++ b/bin/lemon
@@ -195,7 +195,10 @@ case System.get_env("LEMON_WEB_PORT") do
         Application.put_env(:lemon_web, LemonWeb.Endpoint,
           Keyword.merge(
             Application.get_env(:lemon_web, LemonWeb.Endpoint, []),
-            http: [ip: {127, 0, 0, 1}, port: port]
+            [
+              server: true,
+              http: [ip: {127, 0, 0, 1}, port: port]
+            ]
           )
         )
       _ -> :ok

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,7 @@ config :lemon_core, LemonCore.Store,
   backend_opts: []
 
 config :lemon_web, LemonWeb.Endpoint,
+  adapter: Bandit.PhoenixAdapter,
   url: [host: "localhost"],
   render_errors: [
     formats: [html: LemonWeb.ErrorHTML, json: LemonWeb.ErrorJSON],


### PR DESCRIPTION
## Summary
- fix `bin/lemon` web startup so `lemon_web` starts in this launcher path (`server: true`) and configure Phoenix endpoint adapter to Bandit
- fix games UI rendering bugs caused by module-attribute lookups instead of runtime assigns
- make lobby updates consistent by broadcasting `game_lobby_changed` on every accepted move (not only terminal transitions)
- implement durable match catch-up in LiveView using `last_event_seq` + `list_events(after_seq)` replay
- keep periodic refresh fallback for lobby/match views and update docs accordingly
- add regression tests for lobby broadcast, refresh fallback, and multi-event catch-up

## Validation
- `mix test apps/lemon_games/test/lemon_games/matches/service_test.exs apps/lemon_web/test/lemon_web/live/games_live_test.exs`
- Result: all tests passed (`20 + 8`)
