### PR TITLE
feat(lemon_router): add async task surface ownership scaffold

### DIFF
--- a/apps/lemon_channels/lib/lemon_channels/presentation_state.ex
+++ b/apps/lemon_channels/lib/lemon_channels/presentation_state.ex
@@ -15,7 +15,7 @@ defmodule LemonChannels.PresentationState do
 
   @notify_tag :presentation_delivery
 
-  @type surface :: :answer | :status
+  @type surface :: term()
   @type entry :: %{
           route: DeliveryRoute.t(),
           run_id: binary(),
@@ -39,11 +39,20 @@ defmodule LemonChannels.PresentationState do
   def notify_tag, do: @notify_tag
 
   @spec get(DeliveryRoute.t(), binary(), surface()) :: entry()
-  def get(%DeliveryRoute{} = route, run_id, surface) when is_binary(run_id) and is_atom(surface) do
+  def get(%DeliveryRoute{} = route, run_id, surface)
+      when is_binary(run_id) and not is_nil(surface) do
     GenServer.call(__MODULE__, {:get, key(route, run_id, surface), route, run_id, surface})
   end
 
-  @spec register_pending_create(DeliveryRoute.t(), binary(), surface(), reference(), non_neg_integer(), integer() | nil, term() | nil) ::
+  @spec register_pending_create(
+          DeliveryRoute.t(),
+          binary(),
+          surface(),
+          reference(),
+          non_neg_integer(),
+          integer() | nil,
+          term() | nil
+        ) ::
           :ok
   def register_pending_create(
         %DeliveryRoute{} = route,
@@ -54,7 +63,7 @@ defmodule LemonChannels.PresentationState do
         text_hash,
         pending_resume \\ nil
       )
-      when is_binary(run_id) and is_atom(surface) and is_reference(ref) and is_integer(seq) do
+      when is_binary(run_id) and not is_nil(surface) and is_reference(ref) and is_integer(seq) do
     GenServer.call(
       __MODULE__,
       {:register_pending_create, key(route, run_id, surface), route, run_id, surface, ref, seq,
@@ -62,10 +71,26 @@ defmodule LemonChannels.PresentationState do
     )
   end
 
-  @spec defer_text(DeliveryRoute.t(), binary(), surface(), binary(), non_neg_integer(), integer() | nil, map()) ::
+  @spec defer_text(
+          DeliveryRoute.t(),
+          binary(),
+          surface(),
+          binary(),
+          non_neg_integer(),
+          integer() | nil,
+          map()
+        ) ::
           :ok
-  def defer_text(%DeliveryRoute{} = route, run_id, surface, text, seq, text_hash, deferred_meta \\ %{})
-      when is_binary(run_id) and is_atom(surface) and is_binary(text) and is_integer(seq) and
+  def defer_text(
+        %DeliveryRoute{} = route,
+        run_id,
+        surface,
+        text,
+        seq,
+        text_hash,
+        deferred_meta \\ %{}
+      )
+      when is_binary(run_id) and not is_nil(surface) and is_binary(text) and is_integer(seq) and
              is_map(deferred_meta) do
     GenServer.call(
       __MODULE__,
@@ -74,20 +99,38 @@ defmodule LemonChannels.PresentationState do
     )
   end
 
-  @spec mark_sent(DeliveryRoute.t(), binary(), surface(), non_neg_integer(), integer() | nil, integer() | binary() | nil) ::
+  @spec mark_sent(
+          DeliveryRoute.t(),
+          binary(),
+          surface(),
+          non_neg_integer(),
+          integer() | nil,
+          integer() | binary() | nil
+        ) ::
           :ok
   def mark_sent(%DeliveryRoute{} = route, run_id, surface, seq, text_hash, message_id \\ nil)
-      when is_binary(run_id) and is_atom(surface) and is_integer(seq) do
+      when is_binary(run_id) and not is_nil(surface) and is_integer(seq) do
     GenServer.call(
       __MODULE__,
-      {:mark_sent, key(route, run_id, surface), route, run_id, surface, seq, text_hash, message_id}
+      {:mark_sent, key(route, run_id, surface), route, run_id, surface, seq, text_hash,
+       message_id}
     )
   end
 
   @spec clear(DeliveryRoute.t(), binary(), surface()) :: :ok
   def clear(%DeliveryRoute{} = route, run_id, surface)
-      when is_binary(run_id) and is_atom(surface) do
+      when is_binary(run_id) and not is_nil(surface) do
     GenServer.call(__MODULE__, {:clear, key(route, run_id, surface)})
+  end
+
+  @spec move(DeliveryRoute.t(), binary(), surface(), surface()) :: :ok
+  def move(%DeliveryRoute{} = route, run_id, from_surface, to_surface)
+      when is_binary(run_id) and not is_nil(from_surface) and not is_nil(to_surface) do
+    GenServer.call(
+      __MODULE__,
+      {:move, key(route, run_id, from_surface), key(route, run_id, to_surface), route, run_id,
+       to_surface}
+    )
   end
 
   @impl true
@@ -143,14 +186,19 @@ defmodule LemonChannels.PresentationState do
     {:reply, :ok, put_entry(state, key, entry)}
   end
 
-  def handle_call({:mark_sent, key, route, run_id, surface, seq, text_hash, message_id}, _from, state) do
+  def handle_call(
+        {:mark_sent, key, route, run_id, surface, seq, text_hash, message_id},
+        _from,
+        state
+      ) do
     entry =
       state.entries
       |> Map.get(key, new_entry(route, run_id, surface))
       |> Map.merge(%{
         last_seq: seq,
         last_text_hash: text_hash,
-        platform_message_id: message_id || Map.get(state.entries[key] || %{}, :platform_message_id),
+        platform_message_id:
+          message_id || Map.get(state.entries[key] || %{}, :platform_message_id),
         pending_create_ref: nil,
         deferred_text: nil,
         deferred_seq: nil,
@@ -170,6 +218,25 @@ defmodule LemonChannels.PresentationState do
 
     entries = Map.delete(state.entries, key)
     {:reply, :ok, %{state | entries: entries, refs: refs}}
+  end
+
+  def handle_call({:move, from_key, to_key, route, run_id, to_surface}, _from, state) do
+    {entry, entries} =
+      case Map.pop(state.entries, from_key) do
+        {nil, entries} -> {new_entry(route, run_id, to_surface), entries}
+        {entry, entries} -> {%{entry | surface: to_surface}, entries}
+      end
+
+    refs =
+      state.refs
+      |> Enum.map(fn
+        {ref, ^from_key} -> {ref, to_key}
+        other -> other
+      end)
+      |> Map.new()
+
+    state = %{state | entries: Map.put(entries, to_key, entry), refs: refs}
+    {:reply, :ok, state}
   end
 
   @impl true
@@ -226,13 +293,14 @@ defmodule LemonChannels.PresentationState do
 
       _ = Outbox.enqueue(payload)
 
-      %{entry |
-        last_seq: entry.deferred_seq || entry.last_seq,
-        last_text_hash: entry.deferred_hash || entry.last_text_hash,
-        deferred_text: nil,
-        deferred_seq: nil,
-        deferred_hash: nil,
-        deferred_meta: %{}
+      %{
+        entry
+        | last_seq: entry.deferred_seq || entry.last_seq,
+          last_text_hash: entry.deferred_hash || entry.last_text_hash,
+          deferred_text: nil,
+          deferred_seq: nil,
+          deferred_hash: nil,
+          deferred_meta: %{}
       }
     else
       _ -> entry
@@ -252,7 +320,13 @@ defmodule LemonChannels.PresentationState do
       msg_id = parse_int(message_id)
 
       if is_integer(chat_id) and is_integer(msg_id) do
-        ResumeIndexStore.put_resume(route.account_id || "default", chat_id, thread_id, msg_id, pending_resume)
+        ResumeIndexStore.put_resume(
+          route.account_id || "default",
+          chat_id,
+          thread_id,
+          msg_id,
+          pending_resume
+        )
       end
     end
 

--- a/apps/lemon_router/AGENTS.md
+++ b/apps/lemon_router/AGENTS.md
@@ -47,6 +47,7 @@ Inbound transport
 | `lib/lemon_router/conversation_key.ex` | canonical conversation-key selection |
 | `lib/lemon_router/resume_resolver.ex` | structured resume resolution before gateway submission |
 | `lib/lemon_router/run_process.ex` | active-run lifecycle shell |
+| `lib/lemon_router/async_task_surface.ex` | router-owned async task surface lifecycle scaffold for the redesign |
 | `lib/lemon_router/run_process/compaction_trigger.ex` | overflow detection and pending-compaction marking |
 | `lib/lemon_router/stream_coalescer.ex` | semantic answer coalescing |
 | `lib/lemon_router/tool_status_coalescer.ex` | semantic tool-status coalescing |
@@ -136,6 +137,58 @@ Use `LemonCore.EngineCatalog` for engine ID validation/normalization and `LemonC
 
 If the change is semantic, update router coalescers or `RunProcess.OutputTracker`.
 If the change is platform UX, change `lemon_channels` renderers instead.
+`ToolStatusRenderer` may use parent-child metadata already present in action `detail`
+such as Claude's `parent_tool_use_id`; preserve that metadata in upstream runners instead
+of re-deriving hierarchy in channel adapters.
+`ToolStatusCoalescer` also expands embedded subagent progress from
+`detail.partial_result.details.current_action` into child actions so task-tool updates can show
+inner CLI steps over Telegram and similar channels.
+When a tool phase starts immediately after streamed assistant text, `RunProcess.OutputTracker`
+hands the finalized `:answer` message over to the tool-status surface so the next status edits
+append under that assistant text instead of reusing an older standalone status message.
+`ToolStatusCoalescer` then prefixes the rendered status block with that text until the next
+assistant delta starts, at which point the segment is finalized in place and reset.
+Task roots use dedicated status surfaces keyed by the task-root surface id, so child actions with
+`detail.parent_tool_use_id` keep editing the parent task message even after later assistant text
+or unrelated top-level tool calls create newer answer/status turns.
+Async task followups (`task action=poll`) are also rebound onto the original task surface by
+`task_id` when upstream runners preserve that metadata in action `detail`, `detail.args`, or
+`detail.result_meta`, so
+background Codex/Claude task progress stays attached to the originating `task(...)` line instead
+of creating blank standalone `task:` status entries.
+The redesign also has a router-owned `AsyncTaskSurface` process per surface/root key with
+`pending_root -> bound -> live -> terminal_grace -> reaped` lifecycle semantics.
+`RunProcess.OutputTracker` now seeds and reuses that router-owned identity from task-root start
+events and task poll rebinding, but the existing LiveBridge / projected-child tool-status path
+remains the active rendering behavior until later migration steps wire them together.
+Explicit projected-child `surface` / `root_action_id` metadata must seed that reusable identity too,
+and terminal task poll/result statuses drive `AsyncTaskSurface` to `:terminal_grace`; only a later
+task-surface coalescer reap should advance an already-terminal surface to `:reaped`.
+When an async task surface transitions to `:reaped`, it replies once with the terminal snapshot,
+then drops its public registration before stopping so an immediate `ensure_started(surface_id)`
+creates a fresh `:pending_root` surface instead of surfacing the stale pid; invalid surface
+metadata now returns an explicit `{:invalid_metadata, ...}` error instead
+of crashing the GenServer.
+`AsyncTaskSurfaceSupervisor.ensure_started/2` must also treat
+`DynamicSupervisor.start_child(...)= {:error, {:already_started, pid}}` as provisional during
+that unregister-before-exit window: only a pid that is still registered for the surface and not
+marked `:reaped` in the registry-owned public state is usable; stale reaping pids must be awaited
+and retried until a fresh surface wins, but temporarily busy live surfaces must still be reused.
+Repeated embedded-only `current_action` updates for the same parent/title reuse the same child row
+until the embedded title changes, so repeated task polls do not duplicate inner status lines.
+Projected child events may also carry explicit `surface` / `root_action_id` metadata; prefer that
+binding when present instead of relying only on previously seen parent actions in the run process.
+Task-scoped status coalescers are reaped after they go idle with no running task actions, so
+per-task router processes do not accumulate indefinitely; later updates recreate the surface if
+needed, but parent run finalization must not recreate a task surface that has already reaped, and
+the run process now drops stale task-surface bindings as soon as that task coalescer exits.
+Aborted runs that never bind to a live gateway run must still synthesize `:run_completed`; otherwise
+`SessionCoordinator` will retain the session as busy forever.
+Started runs that lose their gateway process before the router binds a monitor must also synthesize
+`:run_completed`, but only after a short completion grace window so a real late `:run_completed`
+from the bus can win over the synthetic fallback.
+Watchdog keepalive prompts increment their semantic sequence on each idle cycle so repeated prompts
+remain visible through channel renderer and outbox dedupe.
 
 ### Change compaction behavior
 

--- a/apps/lemon_router/lib/lemon_router/application.ex
+++ b/apps/lemon_router/lib/lemon_router/application.ex
@@ -22,6 +22,7 @@ defmodule LemonRouter.Application do
         {Registry, keys: :unique, name: LemonRouter.CoalescerRegistry},
         # Tool status coalescer registry
         {Registry, keys: :unique, name: LemonRouter.ToolStatusRegistry},
+        {Registry, keys: :unique, name: LemonRouter.AsyncTaskSurfaceRegistry},
         # Run supervisor (DynamicSupervisor for run processes)
         {
           DynamicSupervisor,
@@ -30,11 +31,13 @@ defmodule LemonRouter.Application do
           max_children: run_process_limit()
         },
         # Session coordinator supervisor (router-owned queue semantics)
-        {DynamicSupervisor, strategy: :one_for_one, name: LemonRouter.SessionCoordinatorSupervisor},
+        {DynamicSupervisor,
+         strategy: :one_for_one, name: LemonRouter.SessionCoordinatorSupervisor},
         # Stream coalescer supervisor
         {DynamicSupervisor, strategy: :one_for_one, name: LemonRouter.CoalescerSupervisor},
         # Tool status coalescer supervisor
         {DynamicSupervisor, strategy: :one_for_one, name: LemonRouter.ToolStatusSupervisor},
+        {DynamicSupervisor, strategy: :one_for_one, name: LemonRouter.AsyncTaskSurfaceSupervisor},
         # Run count telemetry tracker (must start before orchestrator)
         LemonRouter.RunCountTracker,
         # Run orchestrator

--- a/apps/lemon_router/lib/lemon_router/async_task_surface.ex
+++ b/apps/lemon_router/lib/lemon_router/async_task_surface.ex
@@ -1,0 +1,502 @@
+defmodule LemonRouter.AsyncTaskSurface do
+  @moduledoc """
+  Router-owned lifecycle surface for an async task.
+
+  This is a migration scaffold for the async task surface redesign. It only owns
+  per-task lifecycle state and discoverability; it does not replace the existing
+  projected-child tool-status path yet.
+  """
+
+  use GenServer, restart: :temporary
+
+  alias LemonCore.Clock
+
+  @statuses [:pending_root, :bound, :live, :terminal_grace, :reaped]
+  @registry LemonRouter.AsyncTaskSurfaceRegistry
+  @snapshot_keys [
+    :surface_id,
+    :status,
+    :metadata,
+    :result,
+    :error,
+    :inserted_at_ms,
+    :updated_at_ms,
+    :terminal_at_ms
+  ]
+
+  @type status :: :pending_root | :bound | :live | :terminal_grace | :reaped
+
+  @type snapshot :: %{
+          surface_id: binary(),
+          status: status(),
+          metadata: map(),
+          result: term(),
+          error: term(),
+          inserted_at_ms: non_neg_integer(),
+          updated_at_ms: non_neg_integer(),
+          terminal_at_ms: non_neg_integer() | nil
+        }
+
+  @allowed_transitions %{
+    pending_root: MapSet.new([:bound, :terminal_grace]),
+    bound: MapSet.new([:live, :terminal_grace]),
+    live: MapSet.new([:terminal_grace]),
+    terminal_grace: MapSet.new([:reaped]),
+    reaped: MapSet.new()
+  }
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    surface_id = surface_id_from_opts!(opts)
+    GenServer.start_link(__MODULE__, opts, name: via_tuple(surface_id))
+  end
+
+  def child_spec(opts) do
+    surface_id = surface_id_from_opts!(opts)
+
+    %{
+      id: {__MODULE__, surface_id},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :temporary,
+      shutdown: 5_000
+    }
+  end
+
+  @spec ensure_started(binary(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def ensure_started(surface_id, opts \\ []) when is_binary(surface_id) do
+    LemonRouter.AsyncTaskSurfaceSupervisor.ensure_started(surface_id, opts)
+  end
+
+  @spec whereis(binary()) :: pid() | nil
+  def whereis(surface_id) when is_binary(surface_id) do
+    case Registry.lookup(@registry, surface_id) do
+      [{pid, registry_value}] -> current_pid(pid, registry_value)
+      [] -> nil
+    end
+  end
+
+  @spec get(binary() | pid()) :: {:ok, snapshot()} | {:error, :not_found}
+  def get(surface_id_or_pid) do
+    with {:ok, pid} <- resolve_pid(surface_id_or_pid) do
+      safe_call(pid, :get)
+    end
+  end
+
+  @spec lookup_identity_by_task_id(binary()) ::
+          {:ok, %{surface_id: binary(), surface: term(), root_action_id: binary()}} | :error
+  def lookup_identity_by_task_id(task_id) when is_binary(task_id) and task_id != "" do
+    find_identity(fn snapshot -> identity_for_task_id(snapshot, task_id) end)
+  end
+
+  def lookup_identity_by_task_id(_task_id), do: :error
+
+  @spec lookup_identity_by_root_action_id(binary()) ::
+          {:ok, %{surface_id: binary(), surface: term(), root_action_id: binary()}} | :error
+  def lookup_identity_by_root_action_id(root_action_id)
+      when is_binary(root_action_id) and root_action_id != "" do
+    find_identity(fn snapshot -> identity_for_root_action_id(snapshot, root_action_id) end)
+  end
+
+  def lookup_identity_by_root_action_id(_root_action_id), do: :error
+
+  defp find_identity(fun) when is_function(fun, 1) do
+    LemonRouter.AsyncTaskSurfaceSupervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.map(fn {_, pid, _, _} -> pid end)
+    |> Enum.reduce([], fn pid, acc ->
+      case get(pid) do
+        {:ok, snapshot} ->
+          case fun.(snapshot) do
+            {:ok, _identity} = identity -> [{snapshot, identity} | acc]
+            _ -> acc
+          end
+
+        _ ->
+          acc
+      end
+    end)
+    |> Enum.max_by(&identity_match_rank/1, fn -> nil end)
+    |> case do
+      nil -> :error
+      {_snapshot, identity} -> identity
+    end
+  end
+
+  @spec lookup_identity(binary()) ::
+          {:ok, %{surface_id: binary(), surface: term(), root_action_id: binary()}} | :error
+  def lookup_identity(surface_id) when is_binary(surface_id) and surface_id != "" do
+    case get(surface_id) do
+      {:ok, snapshot} -> identity_from_snapshot(snapshot)
+      _ -> :error
+    end
+  end
+
+  def lookup_identity(_surface_id), do: :error
+
+  @spec transition(binary() | pid(), status(), map()) ::
+          {:ok, snapshot()}
+          | {:error,
+             :not_found
+             | {:invalid_transition, status(), status()}
+             | {:invalid_metadata, :expected_map_or_key_value_list}}
+  def transition(surface_id_or_pid, next_status, attrs \\ %{})
+      when is_map(attrs) and next_status in @statuses do
+    with {:ok, pid} <- resolve_pid(surface_id_or_pid) do
+      safe_call(pid, {:transition, next_status, attrs})
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    now_ms = Clock.now_ms()
+    surface_id = surface_id_from_opts!(opts)
+
+    case normalize_metadata(Keyword.get(opts, :metadata, %{})) do
+      {:ok, metadata} ->
+        state = %{
+          surface_id: surface_id,
+          status: :pending_root,
+          metadata: metadata,
+          result: nil,
+          error: nil,
+          inserted_at_ms: now_ms,
+          updated_at_ms: now_ms,
+          terminal_at_ms: nil,
+          reap_test_hook: Keyword.get(opts, :reap_test_hook)
+        }
+
+        refresh_registration(state)
+        {:ok, state}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call(:get, _from, state) do
+    {:reply, {:ok, snapshot_from_state(state)}, state}
+  end
+
+  def handle_call({:transition, next_status, attrs}, _from, state) do
+    with :ok <- validate_transition(state.status, next_status),
+         {:ok, metadata_update} <- metadata_update(attrs) do
+      new_state = apply_transition(state, next_status, attrs, metadata_update)
+      refresh_registration(new_state)
+
+      if reap_transition?(state.status, next_status) do
+        maybe_pause_reap_for_test(new_state)
+        unregister_surface(state.surface_id)
+        {:stop, :normal, {:ok, snapshot_from_state(new_state)}, new_state}
+      else
+        {:reply, {:ok, snapshot_from_state(new_state)}, new_state}
+      end
+    else
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  defp via_tuple(surface_id) do
+    {:via, Registry, {@registry, surface_id}}
+  end
+
+  defp current_pid(pid, registry_value) do
+    cond do
+      not Process.alive?(pid) ->
+        nil
+
+      registry_status(registry_value) == :reaped ->
+        nil
+
+      true ->
+        pid
+    end
+  end
+
+  defp resolve_pid(pid) when is_pid(pid) do
+    if Process.alive?(pid), do: {:ok, pid}, else: {:error, :not_found}
+  end
+
+  defp resolve_pid(surface_id) when is_binary(surface_id) do
+    case whereis(surface_id) do
+      pid when is_pid(pid) -> {:ok, pid}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  defp safe_call(pid, message, timeout \\ 5_000) do
+    try do
+      GenServer.call(pid, message, timeout)
+    catch
+      :exit, _reason -> {:error, :not_found}
+    end
+  end
+
+  defp surface_id_from_opts!(opts) do
+    Keyword.get(opts, :surface_id) || Keyword.fetch!(opts, :task_id)
+  end
+
+  defp validate_transition(current, current), do: :ok
+
+  defp validate_transition(current, next_status) do
+    if MapSet.member?(@allowed_transitions[current], next_status) do
+      :ok
+    else
+      {:error, {:invalid_transition, current, next_status}}
+    end
+  end
+
+  defp apply_transition(state, next_status, attrs, metadata_update) do
+    metadata = merge_transition_metadata(state.metadata, metadata_update)
+
+    if duplicate_transition?(state.status, next_status) do
+      maybe_apply_duplicate_metadata(state, metadata)
+    else
+      now_ms = Clock.now_ms()
+      terminal_at_ms = terminal_at_ms(state, next_status, now_ms)
+
+      state
+      |> Map.put(:status, next_status)
+      |> Map.put(:metadata, metadata)
+      |> Map.put(:result, next_result(state.result, next_status, attrs))
+      |> Map.put(:error, next_error(state.error, next_status, attrs))
+      |> Map.put(:updated_at_ms, now_ms)
+      |> Map.put(:terminal_at_ms, terminal_at_ms)
+    end
+  end
+
+  defp reap_transition?(current_status, next_status) do
+    current_status != :reaped and next_status == :reaped
+  end
+
+  defp duplicate_transition?(current, next_status)
+       when current == next_status and current in @statuses,
+       do: true
+
+  defp duplicate_transition?(_, _), do: false
+
+  defp maybe_apply_duplicate_metadata(state, metadata) do
+    if metadata == state.metadata do
+      state
+    else
+      state
+      |> Map.put(:metadata, metadata)
+      |> Map.put(:updated_at_ms, Clock.now_ms())
+    end
+  end
+
+  defp metadata_update(attrs) do
+    attrs
+    |> Map.get(:metadata, Map.get(attrs, "metadata", %{}))
+    |> normalize_metadata()
+  end
+
+  defp merge_transition_metadata(existing, update)
+       when is_map(existing) and is_map(update) do
+    existing
+    |> Map.merge(update, fn key, existing_value, update_value ->
+      merge_transition_metadata_value(key, existing_value, update_value)
+    end)
+    |> merge_task_metadata(existing, update)
+  end
+
+  defp merge_transition_metadata(existing, _update), do: existing
+
+  defp merge_transition_metadata_value(key, existing_value, update_value)
+       when key in [:surface_id, :surface, :root_action_id, :parent_run_id, :session_key] do
+    existing_value || update_value
+  end
+
+  defp merge_transition_metadata_value(key, existing_value, update_value)
+       when key in ["surface_id", "surface", "root_action_id", "parent_run_id", "session_key"] do
+    existing_value || update_value
+  end
+
+  defp merge_transition_metadata_value(key, existing_value, update_value)
+       when key in [:task_ids, "task_ids"] do
+    merge_task_id_values(existing_value, update_value)
+  end
+
+  defp merge_transition_metadata_value(_key, existing_value, _update_value), do: existing_value
+
+  defp merge_task_metadata(metadata, existing, update) do
+    task_ids =
+      merge_task_id_values(task_ids_from_metadata(existing), task_ids_from_metadata(update))
+
+    task_id =
+      task_id_from_metadata(existing) || task_id_from_metadata(update) || List.first(task_ids)
+
+    metadata
+    |> put_task_metadata(:task_ids, "task_ids", task_ids)
+    |> put_task_metadata(:task_id, "task_id", task_id)
+  end
+
+  defp put_task_metadata(metadata, _atom_key, _string_key, []), do: metadata
+  defp put_task_metadata(metadata, _atom_key, _string_key, nil), do: metadata
+
+  defp put_task_metadata(metadata, atom_key, string_key, value) do
+    cond do
+      Map.has_key?(metadata, atom_key) -> Map.put(metadata, atom_key, value)
+      Map.has_key?(metadata, string_key) -> Map.put(metadata, string_key, value)
+      true -> Map.put(metadata, atom_key, value)
+    end
+  end
+
+  defp task_id_from_metadata(metadata) when is_map(metadata) do
+    metadata[:task_id] || metadata["task_id"]
+  end
+
+  defp task_id_from_metadata(_metadata), do: nil
+
+  defp task_ids_from_metadata(metadata) when is_map(metadata) do
+    merge_task_id_values(metadata[:task_ids], metadata["task_ids"])
+  end
+
+  defp task_ids_from_metadata(_metadata), do: []
+
+  defp merge_task_id_values(left, right) do
+    (normalize_task_ids(left) ++ normalize_task_ids(right))
+    |> Enum.uniq()
+  end
+
+  defp normalize_task_ids(task_ids) when is_list(task_ids) do
+    Enum.filter(task_ids, &(is_binary(&1) and &1 != ""))
+  end
+
+  defp normalize_task_ids(task_id) when is_binary(task_id) and task_id != "", do: [task_id]
+  defp normalize_task_ids(_task_ids), do: []
+
+  defp next_result(current_result, :terminal_grace, attrs) do
+    Map.get(attrs, :result, Map.get(attrs, "result", current_result))
+  end
+
+  defp next_result(current_result, _next_status, _attrs), do: current_result
+
+  defp next_error(current_error, :terminal_grace, attrs) do
+    Map.get(attrs, :error, Map.get(attrs, "error", current_error))
+  end
+
+  defp next_error(current_error, _next_status, _attrs), do: current_error
+
+  defp terminal_at_ms(state, next_status, now_ms)
+       when next_status in [:terminal_grace, :reaped] do
+    state.terminal_at_ms || now_ms
+  end
+
+  defp terminal_at_ms(_state, _next_status, _now_ms), do: nil
+
+  defp normalize_metadata(nil), do: {:ok, %{}}
+  defp normalize_metadata(metadata) when is_map(metadata), do: {:ok, Map.new(metadata)}
+
+  defp normalize_metadata(metadata) when is_list(metadata) do
+    if Enum.all?(metadata, &match?({_, _}, &1)) do
+      {:ok, Map.new(metadata)}
+    else
+      {:error, {:invalid_metadata, :expected_map_or_key_value_list}}
+    end
+  end
+
+  defp normalize_metadata(_metadata),
+    do: {:error, {:invalid_metadata, :expected_map_or_key_value_list}}
+
+  defp unregister_surface(surface_id) do
+    Registry.unregister(@registry, surface_id)
+  end
+
+  defp refresh_registration(state) do
+    Registry.update_value(@registry, state.surface_id, fn _value ->
+      %{status: state.status}
+    end)
+  end
+
+  defp registry_status(%{status: status}) when status in @statuses, do: status
+  defp registry_status(_registry_value), do: nil
+
+  defp snapshot_from_state(state) do
+    Map.take(state, @snapshot_keys)
+  end
+
+  defp identity_from_snapshot(%{status: :reaped}), do: :error
+
+  defp identity_from_snapshot(%{surface_id: surface_id, metadata: metadata})
+       when is_binary(surface_id) and is_map(metadata) do
+    root_action_id = metadata[:root_action_id] || metadata["root_action_id"]
+    surface = metadata[:surface] || metadata["surface"]
+
+    if is_binary(root_action_id) and not is_nil(surface) do
+      {:ok, %{surface_id: surface_id, surface: surface, root_action_id: root_action_id}}
+    else
+      :error
+    end
+  end
+
+  defp identity_from_snapshot(_snapshot), do: :error
+
+  defp identity_for_task_id(%{status: :reaped}, _task_id), do: nil
+
+  defp identity_for_task_id(%{surface_id: surface_id, metadata: metadata}, task_id)
+       when is_binary(surface_id) and is_map(metadata) do
+    if task_id_matches?(metadata, task_id) do
+      identity_from_snapshot(%{surface_id: surface_id, metadata: metadata})
+    end
+  end
+
+  defp identity_for_task_id(_snapshot, _task_id), do: nil
+
+  defp identity_for_root_action_id(%{status: :reaped}, _root_action_id), do: nil
+
+  defp identity_for_root_action_id(%{surface_id: surface_id, metadata: metadata}, root_action_id)
+       when is_binary(surface_id) and is_map(metadata) do
+    if root_action_id_matches?(metadata, root_action_id) do
+      identity_from_snapshot(%{surface_id: surface_id, metadata: metadata})
+    end
+  end
+
+  defp identity_for_root_action_id(_snapshot, _root_action_id), do: nil
+
+  defp task_id_matches?(metadata, task_id) when is_map(metadata) and is_binary(task_id) do
+    direct_task_id = metadata[:task_id] || metadata["task_id"]
+    task_ids = metadata[:task_ids] || metadata["task_ids"] || []
+
+    direct_task_id == task_id or
+      (is_list(task_ids) and Enum.any?(task_ids, &(&1 == task_id)))
+  end
+
+  defp root_action_id_matches?(metadata, root_action_id)
+       when is_map(metadata) and is_binary(root_action_id) do
+    direct_root_action_id = metadata[:root_action_id] || metadata["root_action_id"]
+    direct_root_action_id == root_action_id
+  end
+
+  defp maybe_pause_reap_for_test(%{surface_id: surface_id, reap_test_hook: {notify_pid, ref}})
+       when is_pid(notify_pid) do
+    send(notify_pid, {:async_task_surface_reap_blocked, surface_id, self(), ref})
+
+    receive do
+      {:continue_async_task_surface_reap, ^ref} -> :ok
+    after
+      5_000 -> :ok
+    end
+  end
+
+  defp maybe_pause_reap_for_test(_state), do: :ok
+
+  defp identity_match_rank(
+         {snapshot,
+          {:ok, %{surface: surface, surface_id: surface_id, root_action_id: root_action_id}}}
+       ) do
+    explicit_override_bonus =
+      if explicit_surface_override?(surface, surface_id, root_action_id), do: 1, else: 0
+
+    {explicit_override_bonus, snapshot.updated_at_ms || 0, snapshot.inserted_at_ms || 0}
+  end
+
+  defp explicit_surface_override?(surface, surface_id, root_action_id)
+       when is_binary(surface_id) and surface_id != "" and is_binary(root_action_id) and
+              root_action_id != "" do
+    surface_id != root_action_id or surface != {:status_task, root_action_id}
+  end
+
+  defp explicit_surface_override?(_surface, _surface_id, _root_action_id), do: false
+end

--- a/apps/lemon_router/lib/lemon_router/async_task_surface_supervisor.ex
+++ b/apps/lemon_router/lib/lemon_router/async_task_surface_supervisor.ex
@@ -1,0 +1,87 @@
+defmodule LemonRouter.AsyncTaskSurfaceSupervisor do
+  @moduledoc """
+  Dynamic supervisor wrapper for router-owned async task surfaces.
+  """
+
+  @start_retry_wait_ms 20
+  @max_start_retries 50
+
+  @spec ensure_started(binary(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def ensure_started(surface_id, opts \\ []) when is_binary(surface_id) do
+    do_ensure_started(surface_id, opts, @max_start_retries)
+  end
+
+  defp do_ensure_started(surface_id, opts, retries_left) do
+    case LemonRouter.AsyncTaskSurface.whereis(surface_id) do
+      pid when is_pid(pid) ->
+        {:ok, pid}
+
+      nil ->
+        spec =
+          {LemonRouter.AsyncTaskSurface, Keyword.merge(opts, surface_id: surface_id)}
+
+        case DynamicSupervisor.start_child(__MODULE__, spec) do
+          {:ok, pid} ->
+            {:ok, pid}
+
+          {:error, {:already_started, pid}} ->
+            handle_existing_child(surface_id, pid, opts, retries_left)
+
+          {:error, {:already_present, _child_spec}} ->
+            handle_already_present(surface_id, opts, retries_left)
+
+          other ->
+            other
+        end
+    end
+  end
+
+  defp handle_existing_child(surface_id, pid, opts, retries_left) do
+    if reusable_surface_pid?(surface_id, pid) do
+      {:ok, pid}
+    else
+      wait_and_retry(surface_id, pid, opts, retries_left)
+    end
+  end
+
+  defp handle_already_present(surface_id, opts, retries_left) do
+    case LemonRouter.AsyncTaskSurface.whereis(surface_id) do
+      pid when is_pid(pid) ->
+        {:ok, pid}
+
+      nil ->
+        wait_and_retry(surface_id, nil, opts, retries_left)
+    end
+  end
+
+  defp reusable_surface_pid?(surface_id, pid),
+    do: Process.alive?(pid) and LemonRouter.AsyncTaskSurface.whereis(surface_id) == pid
+
+  defp wait_and_retry(surface_id, pid, opts, retries_left) when retries_left > 0 do
+    wait_for_surface_exit(pid)
+    do_ensure_started(surface_id, opts, retries_left - 1)
+  end
+
+  defp wait_and_retry(surface_id, _pid, _opts, 0) do
+    case LemonRouter.AsyncTaskSurface.whereis(surface_id) do
+      pid when is_pid(pid) -> {:ok, pid}
+      nil -> {:error, :surface_start_timeout}
+    end
+  end
+
+  defp wait_for_surface_exit(pid) when is_pid(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      @start_retry_wait_ms -> :ok
+    end
+
+    Process.demonitor(ref, [:flush])
+  end
+
+  defp wait_for_surface_exit(nil) do
+    Process.sleep(@start_retry_wait_ms)
+  end
+end

--- a/apps/lemon_router/lib/lemon_router/run_process.ex
+++ b/apps/lemon_router/lib/lemon_router/run_process.ex
@@ -27,6 +27,9 @@ defmodule LemonRouter.RunProcess do
 
   @gateway_submit_retry_base_ms 100
   @gateway_submit_retry_max_ms 2_000
+  @abort_completion_grace_ms 150
+  @gateway_bind_grace_ms 200
+  @gateway_missing_completion_grace_ms 1_500
 
   def start_link(opts) do
     run_id = opts[:run_id]
@@ -141,6 +144,7 @@ defmodule LemonRouter.RunProcess do
       run_watchdog_ref: nil,
       run_watchdog_confirmation_ref: nil,
       run_watchdog_awaiting_confirmation?: false,
+      run_watchdog_prompt_seq: 0,
       submit_to_gateway?: submit_to_gateway?,
       gateway_scheduler: gateway_scheduler,
       run_orchestrator: run_orchestrator,
@@ -153,7 +157,12 @@ defmodule LemonRouter.RunProcess do
         opts[:conversation_key] ||
           match_conversation_key(execution_request),
       generated_image_paths: [],
-      requested_send_files: []
+      requested_send_files: [],
+      task_status_surfaces: %{},
+      task_status_refs: %{},
+      task_status_surface_monitors: %{},
+      task_status_surface_monitor_refs: %{},
+      synthetic_completion_sent?: false
     }
 
     Logger.debug(
@@ -221,6 +230,10 @@ defmodule LemonRouter.RunProcess do
       state
       |> Watchdog.schedule_run_watchdog()
       |> maybe_monitor_gateway_run()
+
+    if is_nil(state.gateway_run_pid) do
+      Process.send_after(self(), :ensure_gateway_bound, @gateway_bind_grace_ms)
+    end
 
     {:noreply, state}
   end
@@ -304,9 +317,9 @@ defmodule LemonRouter.RunProcess do
     # Forward delta to session subscribers
     Bus.broadcast(Bus.session_topic(state.session_key), event)
 
-    # Ensure any pending tool-status output is emitted before we start streaming the answer.
+    # Finalize the previous tool-status segment before we start streaming a new answer chunk.
     if state.saw_delta == false do
-      OutputTracker.flush_tool_status(state)
+      OutputTracker.commit_tool_status_segment(state)
     end
 
     # Also ingest into StreamCoalescer for channel delivery
@@ -318,11 +331,12 @@ defmodule LemonRouter.RunProcess do
   def handle_info(%LemonCore.Event{type: :engine_action, payload: action_ev} = event, state) do
     state = Watchdog.touch_run_watchdog(state)
 
-    # Detect turn boundary: model was streaming text, now a tool has started.
-    # Commit the current answer so the next delta creates a fresh message.
+    {state, tool_status_surface, capture_current_turn?} =
+      OutputTracker.prepare_tool_status_action(state, action_ev)
+
     state =
-      if state.saw_delta and is_tool_start?(action_ev) do
-        OutputTracker.commit_stream_turn(state)
+      if state.saw_delta and is_tool_start?(action_ev) and capture_current_turn? do
+        OutputTracker.handoff_stream_turn_to_tool_status(state, tool_status_surface)
         %{state | saw_delta: false}
       else
         state
@@ -332,8 +346,41 @@ defmodule LemonRouter.RunProcess do
     Bus.broadcast(Bus.session_topic(state.session_key), event)
 
     # Also ingest into ToolStatusCoalescer for channel delivery
-    OutputTracker.ingest_action_to_tool_status_coalescer(state, action_ev)
+    OutputTracker.ingest_action_to_tool_status_coalescer(state, action_ev, tool_status_surface)
 
+    state = OutputTracker.maybe_track_task_surface_monitor(state, tool_status_surface)
+    state = OutputTracker.maybe_track_generated_images(state, action_ev)
+    state = OutputTracker.maybe_track_requested_send_files(state, action_ev)
+
+    {:noreply, state}
+  end
+
+  def handle_info(
+        %LemonCore.Event{type: :task_projected_child_action, payload: action_ev} = event,
+        state
+      ) do
+    state = Watchdog.touch_run_watchdog(state)
+
+    {state, tool_status_surface, capture_current_turn?} =
+      OutputTracker.prepare_projected_tool_status_action(state, event)
+
+    state =
+      if state.saw_delta and is_tool_start?(action_ev) and capture_current_turn? do
+        OutputTracker.handoff_stream_turn_to_tool_status(state, tool_status_surface)
+        %{state | saw_delta: false}
+      else
+        state
+      end
+
+    Bus.broadcast(Bus.session_topic(state.session_key), event)
+
+    OutputTracker.ingest_projected_child_action_to_tool_status_coalescer(
+      state,
+      event,
+      tool_status_surface
+    )
+
+    state = OutputTracker.maybe_track_task_surface_monitor(state, tool_status_surface)
     state = OutputTracker.maybe_track_generated_images(state, action_ev)
     state = OutputTracker.maybe_track_requested_send_files(state, action_ev)
 
@@ -395,6 +442,13 @@ defmodule LemonRouter.RunProcess do
     {:noreply, %{state | gateway_run_ref: nil, gateway_run_pid: nil}}
   end
 
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    case OutputTracker.cleanup_task_surface_monitor(state, ref, pid) do
+      {:ok, state} -> {:noreply, state}
+      :unknown -> {:noreply, state}
+    end
+  end
+
   def handle_info({:gateway_run_down, reason}, state) do
     if state.completed do
       {:noreply, state}
@@ -404,26 +458,80 @@ defmodule LemonRouter.RunProcess do
           "session_key=#{inspect(state.session_key)} reason=#{inspect(reason)}"
       )
 
-      event =
-        LemonCore.Event.new(
-          :run_completed,
-          %{
-            completed: %{
-              ok: false,
-              error: {:gateway_run_down, reason},
-              answer: ""
-            },
-            duration_ms: nil
-          },
-          %{
-            run_id: state.run_id,
-            session_key: state.session_key,
-            synthetic: true
-          }
+      {:noreply, emit_synthetic_completion_once(state, {:gateway_run_down, reason})}
+    end
+  rescue
+    _ -> {:noreply, state}
+  end
+
+  def handle_info({:finalize_aborted_run, reason}, state) do
+    cond do
+      state.completed or not state.aborted ->
+        {:noreply, state}
+
+      gateway_run_pid(state.run_id) != nil ->
+        LemonGateway.Runtime.cancel_by_run_id(state.run_id, reason)
+        {:noreply, maybe_monitor_gateway_run(state)}
+
+      true ->
+        Logger.warning(
+          "RunProcess finalizing aborted run without gateway pid run_id=#{inspect(state.run_id)} " <>
+            "session_key=#{inspect(state.session_key)} reason=#{inspect(reason)}"
         )
 
-      Bus.broadcast(Bus.run_topic(state.run_id), event)
-      {:noreply, state}
+        {:noreply, emit_synthetic_completion_once(state, reason)}
+    end
+  rescue
+    _ -> {:noreply, state}
+  end
+
+  def handle_info(:ensure_gateway_bound, state) do
+    cond do
+      state.completed ->
+        {:noreply, state}
+
+      not is_nil(state.gateway_run_pid) ->
+        {:noreply, state}
+
+      gateway_run_pid(state.run_id) != nil ->
+        {:noreply, maybe_monitor_gateway_run(state)}
+
+      true ->
+        Logger.warning(
+          "RunProcess started without gateway pid; awaiting completion grace run_id=#{inspect(state.run_id)} " <>
+            "session_key=#{inspect(state.session_key)}"
+        )
+
+        Process.send_after(
+          self(),
+          :finalize_missing_gateway_after_start,
+          @gateway_missing_completion_grace_ms
+        )
+
+        {:noreply, state}
+    end
+  rescue
+    _ -> {:noreply, state}
+  end
+
+  def handle_info(:finalize_missing_gateway_after_start, state) do
+    cond do
+      state.completed ->
+        {:noreply, state}
+
+      not is_nil(state.gateway_run_pid) ->
+        {:noreply, state}
+
+      gateway_run_pid(state.run_id) != nil ->
+        {:noreply, maybe_monitor_gateway_run(state)}
+
+      true ->
+        Logger.warning(
+          "RunProcess finalizing started run without gateway pid after completion grace " <>
+            "run_id=#{inspect(state.run_id)} session_key=#{inspect(state.session_key)}"
+        )
+
+        {:noreply, emit_synthetic_completion_once(state, :gateway_run_missing_after_start)}
     end
   rescue
     _ -> {:noreply, state}
@@ -443,6 +551,10 @@ defmodule LemonRouter.RunProcess do
       # Best-effort cancel of the gateway run. This does not currently remove
       # queued jobs for the same session_key; it only cancels the in-flight run.
       LemonGateway.Runtime.cancel_by_run_id(state.run_id, reason)
+
+      if is_nil(state.gateway_run_pid) do
+        Process.send_after(self(), {:finalize_aborted_run, reason}, @abort_completion_grace_ms)
+      end
 
       {:noreply, %{state | aborted: true}}
     end
@@ -555,6 +667,49 @@ defmodule LemonRouter.RunProcess do
   defp gateway_down_grace_ms(:shutdown), do: 200
   defp gateway_down_grace_ms({:shutdown, _}), do: 200
   defp gateway_down_grace_ms(_), do: 20
+
+  defp gateway_run_pid(run_id) when is_binary(run_id) do
+    case Registry.lookup(LemonGateway.RunRegistry, run_id) do
+      [{pid, _}] when is_pid(pid) -> pid
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp gateway_run_pid(_), do: nil
+
+  defp emit_synthetic_completion_once(state, error) do
+    cond do
+      state.completed ->
+        state
+
+      state.synthetic_completion_sent? ->
+        state
+
+      true ->
+        event =
+          LemonCore.Event.new(
+            :run_completed,
+            %{
+              completed: %{
+                ok: false,
+                error: error,
+                answer: ""
+              },
+              duration_ms: nil
+            },
+            %{
+              run_id: state.run_id,
+              session_key: state.session_key,
+              synthetic: true
+            }
+          )
+
+        Bus.broadcast(Bus.run_topic(state.run_id), event)
+        %{state | synthetic_completion_sent?: true}
+    end
+  end
 
   # ---------------------------------------------------------------------------
   # Utility helpers

--- a/apps/lemon_router/lib/lemon_router/run_process/output_tracker.ex
+++ b/apps/lemon_router/lib/lemon_router/run_process/output_tracker.ex
@@ -12,6 +12,7 @@ defmodule LemonRouter.RunProcess.OutputTracker do
   require Logger
 
   alias LemonCore.{DeliveryIntent, DeliveryRoute, SessionKey}
+  alias LemonRouter.AsyncTaskSurface
   alias LemonRouter.ChannelContext
   alias LemonRouter.RunProcess.CompactionTrigger
 
@@ -48,6 +49,36 @@ defmodule LemonRouter.RunProcess.OutputTracker do
     _ -> :ok
   end
 
+  @spec ingest_projected_child_action_to_tool_status_coalescer(map(), LemonCore.Event.t(), term()) ::
+          :ok
+  def ingest_projected_child_action_to_tool_status_coalescer(
+        state,
+        %LemonCore.Event{payload: action_ev, meta: event_meta},
+        surface
+      ) do
+    case ChannelContext.channel_id(state.session_key) do
+      {:ok, channel_id} ->
+        action_ev = normalize_projected_action(action_ev, event_meta, surface)
+
+        LemonRouter.ToolStatusCoalescer.ingest_projected_child_action(
+          state.session_key,
+          channel_id,
+          state.run_id,
+          surface,
+          action_ev,
+          meta: coalescer_meta(state),
+          surface_binding: surface_binding_for_surface(state, surface)
+        )
+
+      _ ->
+        :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  def ingest_projected_child_action_to_tool_status_coalescer(_state, _event, _surface), do: :ok
+
   # ---- Turn commit ----
 
   @spec commit_stream_turn(map()) :: :ok
@@ -58,6 +89,61 @@ defmodule LemonRouter.RunProcess.OutputTracker do
           state.session_key,
           channel_id,
           state.run_id
+        )
+
+      _ ->
+        :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  @spec handoff_stream_turn_to_tool_status(map(), term()) :: :ok
+  def handoff_stream_turn_to_tool_status(state, surface \\ :status) do
+    case ChannelContext.channel_id(state.session_key) do
+      {:ok, channel_id} ->
+        meta = coalescer_meta(state)
+        surface_binding = surface_binding_for_surface(state, surface)
+
+        case LemonRouter.StreamCoalescer.handoff_turn(
+               state.session_key,
+               channel_id,
+               state.run_id,
+               surface
+             ) do
+          {:ok, text} ->
+            LemonRouter.ToolStatusCoalescer.anchor_segment(
+              state.session_key,
+              channel_id,
+              state.run_id,
+              text,
+              meta: meta,
+              surface: surface,
+              surface_binding: surface_binding
+            )
+
+          :noop ->
+            :ok
+        end
+
+      _ ->
+        :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  @spec commit_tool_status_segment(map(), term()) :: :ok
+  def commit_tool_status_segment(state, surface \\ :status) do
+    case ChannelContext.channel_id(state.session_key) do
+      {:ok, channel_id} ->
+        LemonRouter.ToolStatusCoalescer.commit_segment(
+          state.session_key,
+          channel_id,
+          state.run_id,
+          meta: coalescer_meta(state),
+          surface: surface,
+          surface_binding: surface_binding_for_surface(state, surface)
         )
 
       _ ->
@@ -149,13 +235,18 @@ defmodule LemonRouter.RunProcess.OutputTracker do
 
         meta = coalescer_meta(state)
 
-        LemonRouter.ToolStatusCoalescer.finalize_run(
-          state.session_key,
-          channel_id,
-          state.run_id,
-          ok?,
-          meta: meta
-        )
+        Enum.each(tool_status_surfaces(state), fn surface ->
+          LemonRouter.ToolStatusCoalescer.finalize_run(
+            state.session_key,
+            channel_id,
+            state.run_id,
+            ok?,
+            meta: meta,
+            surface: surface,
+            surface_binding: surface_binding_for_surface(state, surface),
+            start?: false
+          )
+        end)
 
       _ ->
         :ok
@@ -166,18 +257,142 @@ defmodule LemonRouter.RunProcess.OutputTracker do
     _ -> :ok
   end
 
-  @spec ingest_action_to_tool_status_coalescer(map(), map()) :: :ok
-  def ingest_action_to_tool_status_coalescer(state, action_ev) do
+  @spec prepare_tool_status_action(map(), map()) :: {map(), term(), boolean()}
+  def prepare_tool_status_action(state, action_ev) do
+    state = prune_stale_task_surfaces(state)
+    task_surfaces = task_surface_bindings(state)
+    task_refs = Map.get(state, :task_status_refs, %{})
+    action = Map.get(action_ev, :action) || %{}
+    action_id = Map.get(action, :id)
+    parent_id = action_parent_tool_use_id(action)
+    mapped_ref = mapped_task_ref(task_refs, action)
+    persisted_ref = lookup_persisted_task_ref(action)
+    persisted_root_ref = lookup_persisted_root_ref(parent_id)
+
+    existing_root_ref =
+      task_surface_binding(task_surfaces, action_id) || lookup_persisted_root_ref(action_id)
+
+    cond do
+      is_map(task_surface_binding(task_surfaces, parent_id)) ->
+        identity = task_surface_binding(task_surfaces, parent_id)
+
+        state =
+          state
+          |> track_task_refs(action, identity)
+          |> ensure_task_root_surface(action_ev, identity)
+
+        {state, identity.surface, not tool_status_surface_alive?(state, identity.surface)}
+
+      persisted_root_ref != nil ->
+        state =
+          state
+          |> put_task_surface_binding(persisted_root_ref)
+          |> track_task_refs(action, persisted_root_ref)
+          |> ensure_task_root_surface(action_ev, persisted_root_ref)
+
+        {state, persisted_root_ref.surface,
+         not tool_status_surface_alive?(state, persisted_root_ref.surface)}
+
+      mapped_ref != nil ->
+        state =
+          state
+          |> put_task_surface_binding(mapped_ref)
+          |> ensure_task_root_surface(action_ev, mapped_ref)
+
+        {state, mapped_ref.surface, not task_surface_alive?(state, mapped_ref.surface)}
+
+      persisted_ref != nil ->
+        state =
+          state
+          |> put_task_surface_binding(persisted_ref)
+          |> track_task_refs(action, persisted_ref)
+          |> ensure_task_root_surface(action_ev, persisted_ref)
+
+        {state, persisted_ref.surface, not task_surface_alive?(state, persisted_ref.surface)}
+
+      existing_root_ref != nil ->
+        state =
+          state
+          |> put_task_surface_binding(existing_root_ref)
+          |> track_task_refs(action, existing_root_ref)
+          |> ensure_task_root_surface(action_ev, existing_root_ref)
+
+        {state, existing_root_ref.surface,
+         not tool_status_surface_alive?(state, existing_root_ref.surface)}
+
+      task_root_action?(action) and is_binary(action_id) and action_id != "" ->
+        surface = task_surface(action_id)
+        identity = task_surface_identity(surface, action_id)
+
+        state =
+          state
+          |> put_task_surface_binding(identity)
+          |> track_task_refs(action, identity)
+          |> ensure_task_root_surface(action_ev, identity)
+
+        {state, surface, true}
+
+      true ->
+        {state, :status, true}
+    end
+  end
+
+  @spec prepare_projected_tool_status_action(map(), LemonCore.Event.t()) ::
+          {map(), term(), boolean()}
+  def prepare_projected_tool_status_action(state, %LemonCore.Event{
+        payload: action_ev,
+        meta: event_meta
+      }) do
+    state = prune_stale_task_surfaces(state)
+    action = Map.get(action_ev, :action) || %{}
+    task_surfaces = task_surface_bindings(state)
+
+    case projected_task_surface_binding(action, event_meta) do
+      {surface, root_action_id} ->
+        projected_identity = projected_task_surface_identity(surface, root_action_id, action)
+
+        identity =
+          choose_projected_task_surface_identity(
+            task_surface_binding(task_surfaces, root_action_id),
+            lookup_persisted_root_ref(root_action_id),
+            projected_identity
+          )
+
+        state =
+          if is_map(identity) do
+            state
+            |> put_task_surface_binding(identity)
+            |> track_task_refs(action, identity)
+            |> ensure_task_root_surface(action_ev, identity)
+          else
+            state
+          end
+
+        surface = if is_map(identity), do: identity.surface, else: surface
+        capture_current_turn? = not tool_status_surface_alive?(state, surface)
+
+        {state, surface, capture_current_turn?}
+
+      nil ->
+        prepare_tool_status_action(state, action_ev)
+    end
+  end
+
+  @spec ingest_action_to_tool_status_coalescer(map(), map(), term()) :: :ok
+  def ingest_action_to_tool_status_coalescer(state, action_ev, surface) do
     case ChannelContext.channel_id(state.session_key) do
       {:ok, channel_id} ->
         meta = coalescer_meta(state)
+        action_ev = attach_task_parent(action_ev, state)
 
         LemonRouter.ToolStatusCoalescer.ingest_action(
           state.session_key,
           channel_id,
           state.run_id,
           action_ev,
-          meta: meta
+          meta: meta,
+          surface: surface,
+          surface_binding: surface_binding_for_surface(state, surface)
         )
 
       _ ->
@@ -187,12 +402,74 @@ defmodule LemonRouter.RunProcess.OutputTracker do
     _ -> :ok
   end
 
+  @spec maybe_track_task_surface_monitor(map(), term()) :: map()
+  def maybe_track_task_surface_monitor(state, surface) do
+    cond do
+      not task_surface?(surface) ->
+        state
+
+      true ->
+        case lookup_tool_status_surface_pid(state, surface) do
+          {:ok, pid} -> track_task_surface_monitor(state, surface, pid)
+          :error -> state
+        end
+    end
+  rescue
+    _ -> state
+  end
+
+  @spec cleanup_task_surface_monitor(map(), reference(), pid()) :: {:ok, map()} | :unknown
+  def cleanup_task_surface_monitor(state, ref, pid)
+      when is_reference(ref) and is_pid(pid) do
+    monitor_refs = Map.get(state, :task_status_surface_monitor_refs, %{})
+
+    case Map.pop(monitor_refs, ref) do
+      {nil, _} ->
+        :unknown
+
+      {surface, monitor_refs} ->
+        monitors = Map.get(state, :task_status_surface_monitors, %{})
+
+        monitors =
+          case Map.get(monitors, surface) do
+            %{pid: ^pid, ref: ^ref} -> Map.delete(monitors, surface)
+            _ -> monitors
+          end
+
+        task_surfaces =
+          state
+          |> Map.get(:task_status_surfaces, %{})
+          |> Enum.reject(fn {_root_action_id, identity} ->
+            binding_surface(identity) == surface
+          end)
+          |> Map.new()
+
+        {:ok,
+         state
+         |> Map.put(:task_status_surface_monitor_refs, monitor_refs)
+         |> Map.put(:task_status_surface_monitors, monitors)
+         |> Map.put(:task_status_surfaces, task_surfaces)}
+    end
+  rescue
+    _ -> :unknown
+  end
+
+  def cleanup_task_surface_monitor(_state, _ref, _pid), do: :unknown
+
   @spec flush_coalescer(map()) :: :ok
   def flush_coalescer(state) do
     case ChannelContext.channel_id(state.session_key) do
       {:ok, channel_id} ->
         LemonRouter.StreamCoalescer.flush(state.session_key, channel_id)
-        LemonRouter.ToolStatusCoalescer.flush(state.session_key, channel_id)
+
+        Enum.each(tool_status_surfaces(state), fn surface ->
+          LemonRouter.ToolStatusCoalescer.flush(
+            state.session_key,
+            channel_id,
+            surface: surface,
+            surface_binding: surface_binding_for_surface(state, surface)
+          )
+        end)
 
       _ ->
         :ok
@@ -205,7 +482,14 @@ defmodule LemonRouter.RunProcess.OutputTracker do
   def flush_tool_status(state) do
     case ChannelContext.channel_id(state.session_key) do
       {:ok, channel_id} ->
-        LemonRouter.ToolStatusCoalescer.flush(state.session_key, channel_id)
+        Enum.each(tool_status_surfaces(state), fn surface ->
+          LemonRouter.ToolStatusCoalescer.flush(
+            state.session_key,
+            channel_id,
+            surface: surface,
+            surface_binding: surface_binding_for_surface(state, surface)
+          )
+        end)
 
       _ ->
         :ok
@@ -302,6 +586,591 @@ defmodule LemonRouter.RunProcess.OutputTracker do
     do: ChannelContext.coalescer_meta_from_job(request)
 
   defp coalescer_meta(_), do: %{}
+
+  defp tool_status_surfaces(state) do
+    [:status | Enum.map(Map.values(task_surface_bindings(state)), &binding_surface/1)]
+    |> Enum.uniq()
+  end
+
+  defp task_surface_bindings(state), do: Map.get(state, :task_status_surfaces, %{})
+
+  defp task_surface_binding(bindings, root_action_id)
+       when is_map(bindings) and is_binary(root_action_id) and root_action_id != "" do
+    case Map.get(bindings, root_action_id) do
+      %{surface: _surface} = identity -> identity
+      _ -> nil
+    end
+  end
+
+  defp task_surface_binding(_, _), do: nil
+
+  defp put_task_surface_binding(state, %{root_action_id: root_action_id} = identity)
+       when is_binary(root_action_id) and root_action_id != "" do
+    bindings = task_surface_bindings(state)
+    Map.put(state, :task_status_surfaces, Map.put(bindings, root_action_id, identity))
+  end
+
+  defp put_task_surface_binding(state, _identity), do: state
+
+  defp task_surface(task_id), do: {:status_task, task_id}
+
+  defp task_surface?({:status_task, task_id}) when is_binary(task_id) and task_id != "", do: true
+  defp task_surface?(_), do: false
+
+  defp valid_surface?(:status), do: true
+  defp valid_surface?({:status_task, task_id}) when is_binary(task_id) and task_id != "", do: true
+  defp valid_surface?(_), do: false
+
+  defp task_root_action?(action) when is_map(action) do
+    detail = Map.get(action, :detail) || %{}
+    kind = Map.get(action, :kind)
+    args = Map.get(detail, :args) || %{}
+    action_name = Map.get(args, "action") || Map.get(args, :action)
+
+    is_map(detail) and (detail[:name] == "task" or detail["name"] == "task") and
+      action_name not in ["poll", "join", :poll, :join] and
+      kind in ["subagent", :subagent]
+  end
+
+  defp task_root_action?(_action), do: false
+
+  defp action_parent_tool_use_id(action) when is_map(action) do
+    detail = Map.get(action, :detail) || %{}
+
+    if is_map(detail) do
+      detail[:parent_tool_use_id] || detail["parent_tool_use_id"]
+    end
+  end
+
+  defp action_parent_tool_use_id(_action), do: nil
+
+  defp projected_task_surface_binding(action, event_meta) when is_map(action) do
+    explicit_surface =
+      [
+        fetch(event_meta, :surface),
+        fetch(Map.get(action, :detail) || %{}, :surface)
+      ]
+      |> Enum.find(&valid_surface?/1)
+
+    root_action_id =
+      [
+        fetch(event_meta, :root_action_id),
+        fetch(Map.get(action, :detail) || %{}, :root_action_id),
+        action_parent_tool_use_id(action)
+      ]
+      |> Enum.find(&(is_binary(&1) and &1 != ""))
+
+    cond do
+      valid_surface?(explicit_surface) ->
+        {explicit_surface, root_action_id || surface_root_action_id(explicit_surface)}
+
+      is_binary(root_action_id) and root_action_id != "" ->
+        {task_surface(root_action_id), root_action_id}
+
+      true ->
+        nil
+    end
+  end
+
+  defp projected_task_surface_binding(_, _), do: nil
+
+  defp surface_root_action_id({:status_task, task_id}) when is_binary(task_id) and task_id != "",
+    do: task_id
+
+  defp surface_root_action_id(_), do: nil
+
+  defp surface_id_from_surface({:status_task, task_id})
+       when is_binary(task_id) and task_id != "",
+       do: task_id
+
+  defp surface_id_from_surface(_), do: nil
+
+  defp track_task_refs(state, action, identity) when is_map(identity) do
+    task_ids = action_task_ids(action)
+
+    if task_ids == [] do
+      state
+    else
+      existing_refs = Map.get(state, :task_status_refs, %{})
+
+      updated_refs =
+        Enum.reduce(task_ids, existing_refs, fn task_id, acc ->
+          ref = Map.get(acc, task_id, %{})
+
+          Map.put(acc, task_id, %{
+            surface_id: existing_identity_value(ref, :surface_id, identity.surface_id),
+            surface: existing_identity_value(ref, :surface, identity.surface),
+            root_action_id: existing_identity_value(ref, :root_action_id, identity.root_action_id)
+          })
+        end)
+
+      Map.put(state, :task_status_refs, updated_refs)
+    end
+  end
+
+  defp mapped_task_ref(task_refs, action) when is_map(task_refs) do
+    action
+    |> action_task_ids()
+    |> Enum.map(&Map.get(task_refs, &1))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> case do
+      [ref] -> ref
+      _ -> nil
+    end
+  end
+
+  defp mapped_task_ref(_, _), do: nil
+
+  defp ensure_task_root_surface(state, action_ev, identity)
+       when is_map(action_ev) and is_map(identity) do
+    metadata = task_surface_metadata(state, identity, action_ev)
+
+    with true <- valid_surface?(identity.surface),
+         true <- is_binary(identity.surface_id) and identity.surface_id != "",
+         true <- is_binary(identity.root_action_id) and identity.root_action_id != "",
+         {:ok, pid} <- AsyncTaskSurface.ensure_started(identity.surface_id, metadata: metadata) do
+      transition_task_surface(pid, desired_task_surface_status(action_ev), metadata, action_ev)
+    else
+      _ -> :ok
+    end
+
+    state
+  rescue
+    _ -> state
+  end
+
+  defp desired_task_surface_status(action_ev) when is_map(action_ev) do
+    action = Map.get(action_ev, :action) || %{}
+    phase = fetch(action_ev, :phase)
+
+    cond do
+      task_surface_terminal?(action_ev) -> :terminal_grace
+      task_root_action?(action) and phase in [:started, "started"] -> :bound
+      true -> :live
+    end
+  end
+
+  defp transition_task_surface(pid, target_status, metadata, action_ev)
+       when is_pid(pid) and target_status in [:bound, :live, :terminal_grace] and is_map(metadata) do
+    attrs = task_surface_transition_attrs(target_status, metadata, action_ev)
+
+    case AsyncTaskSurface.get(pid) do
+      {:ok, %{status: :pending_root}} ->
+        transition_pending_task_surface(pid, target_status, attrs)
+
+      {:ok, %{status: :bound}} ->
+        maybe_transition_task_surface_forward(pid, target_status, attrs)
+
+      {:ok, %{status: :live}} ->
+        maybe_transition_task_surface_forward(pid, target_status, attrs)
+
+      {:ok, %{status: :terminal_grace}} ->
+        :ok
+
+      _ ->
+        :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp transition_pending_task_surface(pid, :terminal_grace, attrs) do
+    case AsyncTaskSurface.transition(pid, :terminal_grace, attrs) do
+      {:ok, _snapshot} -> :ok
+      _ -> :ok
+    end
+  end
+
+  defp transition_pending_task_surface(pid, target_status, attrs) do
+    with {:ok, _snapshot} <- AsyncTaskSurface.transition(pid, :bound, %{metadata: attrs.metadata}) do
+      maybe_transition_task_surface_forward(pid, target_status, attrs)
+    else
+      _ -> :ok
+    end
+  end
+
+  defp maybe_transition_task_surface_forward(_pid, :bound, _attrs), do: :ok
+
+  defp maybe_transition_task_surface_forward(pid, :live, attrs) do
+    case AsyncTaskSurface.transition(pid, :live, %{metadata: attrs.metadata}) do
+      {:ok, _snapshot} -> :ok
+      _ -> :ok
+    end
+  end
+
+  defp maybe_transition_task_surface_forward(pid, :terminal_grace, attrs) do
+    case AsyncTaskSurface.transition(pid, :terminal_grace, attrs) do
+      {:ok, _snapshot} -> :ok
+      _ -> :ok
+    end
+  end
+
+  defp task_surface_identity(surface, root_action_id)
+       when is_binary(root_action_id) and root_action_id != "" do
+    %{
+      surface_id: surface_id_from_surface(surface) || root_action_id,
+      surface: surface,
+      root_action_id: root_action_id
+    }
+  end
+
+  defp task_surface_metadata(state, identity, action_ev)
+       when is_map(identity) and is_map(action_ev) do
+    action = Map.get(action_ev, :action) || %{}
+
+    task_ids =
+      (Map.get(identity, :task_ids, []) ++ action_task_ids(action))
+      |> Enum.filter(&(is_binary(&1) and &1 != ""))
+      |> Enum.uniq()
+
+    %{
+      surface_id: identity.surface_id,
+      surface: identity.surface,
+      root_action_id: identity.root_action_id,
+      parent_run_id: state.run_id,
+      session_key: state.session_key,
+      task_id: List.first(task_ids),
+      task_ids: task_ids
+    }
+  end
+
+  defp existing_identity_value(existing, key, fallback) when is_map(existing) do
+    case Map.get(existing, key) do
+      value when not is_nil(value) -> value
+      _ -> fallback
+    end
+  end
+
+  defp existing_identity_value(_existing, _key, fallback), do: fallback
+
+  defp projected_task_surface_identity(surface, root_action_id, action)
+       when is_map(action) and is_binary(root_action_id) and root_action_id != "" do
+    if task_surface?(surface) do
+      task_surface_identity(surface, root_action_id)
+      |> Map.put(:task_ids, action_task_ids(action))
+    end
+  end
+
+  defp projected_task_surface_identity(_surface, _root_action_id, _action), do: nil
+
+  defp choose_projected_task_surface_identity(
+         existing_identity,
+         persisted_identity,
+         projected_identity
+       ) do
+    cond do
+      authoritative_projected_task_surface_identity?(projected_identity) ->
+        projected_identity
+
+      is_map(existing_identity) ->
+        existing_identity
+
+      is_map(persisted_identity) ->
+        persisted_identity
+
+      true ->
+        projected_identity
+    end
+  end
+
+  defp authoritative_projected_task_surface_identity?(%{
+         surface: surface,
+         surface_id: surface_id,
+         root_action_id: root_action_id
+       })
+       when is_binary(surface_id) and surface_id != "" and is_binary(root_action_id) and
+              root_action_id != "" do
+    surface_id != root_action_id or surface != task_surface(root_action_id)
+  end
+
+  defp authoritative_projected_task_surface_identity?(_identity), do: false
+
+  defp lookup_persisted_root_ref(root_action_id)
+       when is_binary(root_action_id) and root_action_id != "" do
+    case AsyncTaskSurface.lookup_identity_by_root_action_id(root_action_id) do
+      {:ok, identity} ->
+        identity
+
+      :error ->
+        case AsyncTaskSurface.lookup_identity(root_action_id) do
+          {:ok, identity} -> identity
+          :error -> nil
+        end
+    end
+  end
+
+  defp lookup_persisted_root_ref(_root_action_id), do: nil
+
+  defp lookup_persisted_task_ref(action) when is_map(action) do
+    action
+    |> action_task_ids()
+    |> Enum.find_value(fn task_id ->
+      case AsyncTaskSurface.lookup_identity_by_task_id(task_id) do
+        {:ok, identity} -> Map.put(identity, :task_ids, [task_id])
+        :error -> nil
+      end
+    end)
+  end
+
+  defp lookup_persisted_task_ref(_action), do: nil
+
+  defp task_surface_terminal?(action_ev) when is_map(action_ev) do
+    action = Map.get(action_ev, :action) || %{}
+    detail = Map.get(action, :detail) || %{}
+    result_meta = Map.get(detail, :result_meta) || %{}
+
+    terminal_task_status?(
+      fetch(result_meta, :status) || fetch(detail, :status) || Map.get(action_ev, :status)
+    )
+  end
+
+  defp task_surface_terminal?(_action_ev), do: false
+
+  defp terminal_task_status?(status) when status in [:completed, :failed, :error, :cancelled],
+    do: true
+
+  defp terminal_task_status?(status)
+       when status in ["completed", "failed", "error", "cancelled", "canceled"],
+       do: true
+
+  defp terminal_task_status?(_status), do: false
+
+  defp task_surface_transition_attrs(:terminal_grace, metadata, action_ev)
+       when is_map(metadata) do
+    terminal_status =
+      action_ev
+      |> task_surface_terminal_status()
+      |> to_string()
+
+    attrs = %{metadata: metadata}
+
+    if terminal_status == "completed" do
+      Map.put(attrs, :result, %{status: terminal_status})
+    else
+      Map.put(attrs, :error, terminal_status)
+    end
+  end
+
+  defp task_surface_transition_attrs(_target_status, metadata, _action_ev)
+       when is_map(metadata) do
+    %{metadata: metadata}
+  end
+
+  defp task_surface_terminal_status(action_ev) when is_map(action_ev) do
+    action = Map.get(action_ev, :action) || %{}
+    detail = Map.get(action, :detail) || %{}
+    result_meta = Map.get(detail, :result_meta) || %{}
+
+    fetch(result_meta, :status) || fetch(detail, :status) || Map.get(action_ev, :status)
+  end
+
+  defp task_surface_terminal_status(_action_ev), do: nil
+
+  defp action_task_ids(action) when is_map(action) do
+    detail = Map.get(action, :detail) || %{}
+    args = Map.get(detail, :args) || %{}
+    result_meta = Map.get(detail, :result_meta) || %{}
+
+    []
+    |> maybe_prepend_task_id(Map.get(detail, :task_id) || Map.get(detail, "task_id"))
+    |> maybe_prepend_task_ids(Map.get(detail, :task_ids) || Map.get(detail, "task_ids"))
+    |> maybe_prepend_task_id(Map.get(result_meta, :task_id) || Map.get(result_meta, "task_id"))
+    |> maybe_prepend_task_ids(Map.get(result_meta, :task_ids) || Map.get(result_meta, "task_ids"))
+    |> maybe_prepend_task_id(Map.get(args, :task_id) || Map.get(args, "task_id"))
+    |> maybe_prepend_task_ids(Map.get(args, :task_ids) || Map.get(args, "task_ids"))
+    |> Enum.uniq()
+  end
+
+  defp action_task_ids(_), do: []
+
+  defp maybe_prepend_task_id(list, task_id)
+       when is_list(list) and is_binary(task_id) and task_id != "",
+       do: [task_id | list]
+
+  defp maybe_prepend_task_id(list, _), do: list
+
+  defp maybe_prepend_task_ids(list, task_ids) when is_list(list) and is_list(task_ids) do
+    task_ids
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
+    |> Kernel.++(list)
+  end
+
+  defp maybe_prepend_task_ids(list, _), do: list
+
+  defp attach_task_parent(action_ev, state) when is_map(action_ev) do
+    task_refs = Map.get(state, :task_status_refs, %{})
+    action = Map.get(action_ev, :action) || %{}
+
+    cond do
+      action_parent_tool_use_id(action) ->
+        action_ev
+
+      true ->
+        case mapped_task_ref(task_refs, action) do
+          %{root_action_id: root_action_id}
+          when is_binary(root_action_id) and root_action_id != "" ->
+            if root_action_id != Map.get(action, :id) do
+              detail = Map.get(action, :detail) || %{}
+
+              action =
+                Map.put(action, :detail, Map.put(detail, :parent_tool_use_id, root_action_id))
+
+              Map.put(action_ev, :action, action)
+            else
+              action_ev
+            end
+
+          _ ->
+            action_ev
+        end
+    end
+  end
+
+  defp attach_task_parent(action_ev, _), do: action_ev
+
+  defp normalize_projected_action(action_ev, event_meta, surface)
+       when is_map(action_ev) and is_map(event_meta) do
+    action = Map.get(action_ev, :action) || %{}
+    detail = Map.get(action, :detail) || %{}
+
+    root_action_id =
+      [
+        fetch(event_meta, :root_action_id),
+        fetch(detail, :root_action_id),
+        action_parent_tool_use_id(action),
+        surface_root_action_id(surface)
+      ]
+      |> Enum.find(&(is_binary(&1) and &1 != ""))
+
+    detail =
+      detail
+      |> maybe_put_surface(surface)
+      |> maybe_put_projected_parent(action, root_action_id)
+
+    Map.put(action_ev, :action, Map.put(action, :detail, detail))
+  end
+
+  defp normalize_projected_action(action_ev, _event_meta, _surface), do: action_ev
+
+  defp maybe_put_surface(detail, surface) when is_map(detail) do
+    case fetch(detail, :surface) do
+      nil ->
+        if valid_surface?(surface), do: Map.put(detail, :surface, surface), else: detail
+
+      _ ->
+        detail
+    end
+  end
+
+  defp maybe_put_projected_parent(detail, action, root_action_id)
+       when is_map(detail) and is_map(action) do
+    cond do
+      action_parent_tool_use_id(action) ->
+        detail
+
+      not (is_binary(root_action_id) and root_action_id != "") ->
+        detail
+
+      Map.get(action, :id) == root_action_id ->
+        detail
+
+      true ->
+        Map.put(detail, :parent_tool_use_id, root_action_id)
+    end
+  end
+
+  defp prune_stale_task_surfaces(state) do
+    task_surfaces = task_surface_bindings(state)
+
+    stale_root_action_ids =
+      task_surfaces
+      |> Enum.filter(fn {_root_action_id, identity} ->
+        surface = binding_surface(identity)
+        task_surface?(surface) and not task_surface_alive?(state, surface)
+      end)
+      |> Enum.map(fn {root_action_id, _identity} -> root_action_id end)
+
+    if stale_root_action_ids == [] do
+      state
+    else
+      Map.put(state, :task_status_surfaces, Map.drop(task_surfaces, stale_root_action_ids))
+    end
+  rescue
+    _ -> state
+  end
+
+  defp task_surface_alive?(state, surface) do
+    case lookup_tool_status_surface_pid(state, surface) do
+      {:ok, _pid} -> true
+      :error -> false
+    end
+  end
+
+  defp tool_status_surface_alive?(state, surface) do
+    case lookup_tool_status_surface_pid(state, surface) do
+      {:ok, _pid} -> true
+      :error -> false
+    end
+  end
+
+  defp lookup_tool_status_surface_pid(state, surface) do
+    with {:ok, channel_id} <- ChannelContext.channel_id(state.session_key),
+         [{pid, _}] <-
+           Registry.lookup(
+             LemonRouter.ToolStatusRegistry,
+             {state.session_key, channel_id, surface}
+           ),
+         true <- is_pid(pid) and Process.alive?(pid) do
+      {:ok, pid}
+    else
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp surface_binding_for_surface(state, surface) do
+    state
+    |> task_surface_bindings()
+    |> Map.values()
+    |> Enum.find(fn identity -> binding_surface(identity) == surface end)
+  end
+
+  defp binding_surface(%{surface: surface}), do: surface
+  defp binding_surface(surface), do: surface
+
+  defp track_task_surface_monitor(state, surface, pid) when is_pid(pid) do
+    monitors = Map.get(state, :task_status_surface_monitors, %{})
+    monitor_refs = Map.get(state, :task_status_surface_monitor_refs, %{})
+
+    case Map.get(monitors, surface) do
+      %{pid: ^pid, ref: ref} when is_reference(ref) ->
+        state
+
+      %{ref: ref} when is_reference(ref) ->
+        Process.demonitor(ref, [:flush])
+        monitor_refs = Map.delete(monitor_refs, ref)
+        ref = Process.monitor(pid)
+
+        state
+        |> Map.put(
+          :task_status_surface_monitors,
+          Map.put(monitors, surface, %{pid: pid, ref: ref})
+        )
+        |> Map.put(:task_status_surface_monitor_refs, Map.put(monitor_refs, ref, surface))
+
+      _ ->
+        ref = Process.monitor(pid)
+
+        state
+        |> Map.put(
+          :task_status_surface_monitors,
+          Map.put(monitors, surface, %{pid: pid, ref: ref})
+        )
+        |> Map.put(:task_status_surface_monitor_refs, Map.put(monitor_refs, ref, surface))
+    end
+  end
 
   defp request_cwd(%{execution_request: %LemonGateway.ExecutionRequest{cwd: cwd}})
        when is_binary(cwd) and cwd != "",

--- a/apps/lemon_router/lib/lemon_router/run_process/watchdog.ex
+++ b/apps/lemon_router/lib/lemon_router/run_process/watchdog.ex
@@ -93,7 +93,9 @@ defmodule LemonRouter.RunProcess.Watchdog do
 
   @spec maybe_request_watchdog_confirmation(map()) :: {:ok, map()} | :error
   def maybe_request_watchdog_confirmation(state) do
-    with {:ok, intent} <- watchdog_confirmation_intent(state),
+    prompt_seq = next_watchdog_prompt_seq(state)
+
+    with {:ok, intent} <- watchdog_confirmation_intent(state, prompt_seq),
          :ok <- dispatcher().dispatch(intent) do
       timeout_ms =
         state.run_watchdog_confirm_timeout_ms || @default_run_idle_watchdog_confirm_timeout_ms
@@ -105,7 +107,7 @@ defmodule LemonRouter.RunProcess.Watchdog do
           "session_key=#{inspect(state.session_key)} confirm_timeout_ms=#{timeout_ms}"
       )
 
-      {:ok, put_in_watchdog_confirmation(state, ref)}
+      {:ok, put_in_watchdog_confirmation(state, ref, prompt_seq)}
     else
       _ ->
         :error
@@ -123,14 +125,20 @@ defmodule LemonRouter.RunProcess.Watchdog do
         "session_key=#{inspect(state.session_key)} idle_timeout_ms=#{timeout_ms}"
     )
 
-    emit_synthetic_run_completion(state, {:run_idle_watchdog_timeout, timeout_ms}, timeout_ms)
-    clear_watchdog_confirmation(state)
+    state
+    |> emit_synthetic_run_completion(
+      {:run_idle_watchdog_timeout, timeout_ms},
+      timeout_ms,
+      :run_watchdog_timeout
+    )
+    |> clear_watchdog_confirmation()
   end
 
   @spec fail_run_for_user_cancel(map()) :: map()
   def fail_run_for_user_cancel(state) do
-    emit_synthetic_run_completion(state, :user_requested, nil)
-    clear_watchdog_confirmation(state)
+    state
+    |> emit_synthetic_run_completion(:user_requested, nil, :user_requested)
+    |> clear_watchdog_confirmation()
   end
 
   @spec clear_watchdog_confirmation(map()) :: map()
@@ -157,7 +165,8 @@ defmodule LemonRouter.RunProcess.Watchdog do
     :ok
   end
 
-  defp watchdog_confirmation_intent(state) do
+  defp watchdog_confirmation_intent(state, prompt_seq)
+       when is_integer(prompt_seq) and prompt_seq > 0 do
     parsed = ChannelContext.parse_session_key(state.session_key)
 
     with "telegram" <- parsed.channel_id,
@@ -180,12 +189,12 @@ defmodule LemonRouter.RunProcess.Watchdog do
 
       {:ok,
        %DeliveryIntent{
-         intent_id: "#{state.run_id}:watchdog:prompt:#{idle_timeout_ms}",
+         intent_id: "#{state.run_id}:watchdog:prompt:#{idle_timeout_ms}:#{prompt_seq}",
          run_id: state.run_id,
          session_key: state.session_key,
          route: route,
          kind: :watchdog_prompt,
-         body: %{text: text, seq: 0},
+         body: %{text: text, seq: prompt_seq},
          controls: %{allow_cancel?: true, watchdog_prompt?: true},
          meta: %{surface: :status, user_msg_id: nil}
        }}
@@ -196,42 +205,61 @@ defmodule LemonRouter.RunProcess.Watchdog do
     _ -> :error
   end
 
-  defp emit_synthetic_run_completion(state, error, duration_ms) do
-    try do
-      LemonGateway.Runtime.cancel_by_run_id(state.run_id, :run_watchdog_timeout)
-    rescue
-      _ -> :ok
+  defp emit_synthetic_run_completion(state, error, duration_ms, cancel_reason) do
+    cond do
+      state.completed ->
+        state
+
+      Map.get(state, :synthetic_completion_sent?, false) ->
+        state
+
+      true ->
+        try do
+          runtime().cancel_by_run_id(state.run_id, cancel_reason)
+        rescue
+          _ -> :ok
+        end
+
+        event =
+          LemonCore.Event.new(
+            :run_completed,
+            %{
+              completed: %{
+                ok: false,
+                error: error,
+                answer: ""
+              },
+              duration_ms: duration_ms
+            },
+            %{
+              run_id: state.run_id,
+              session_key: state.session_key,
+              synthetic: true
+            }
+          )
+
+        LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(state.run_id), event)
+        Map.put(state, :synthetic_completion_sent?, true)
     end
-
-    event =
-      LemonCore.Event.new(
-        :run_completed,
-        %{
-          completed: %{
-            ok: false,
-            error: error,
-            answer: ""
-          },
-          duration_ms: duration_ms
-        },
-        %{
-          run_id: state.run_id,
-          session_key: state.session_key,
-          synthetic: true
-        }
-      )
-
-    LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(state.run_id), event)
   end
 
-  defp put_in_watchdog_confirmation(state, ref) do
+  defp put_in_watchdog_confirmation(state, ref, prompt_seq) do
     state
     |> cancel_run_watchdog_confirmation()
     |> Map.put(:run_watchdog_confirmation_ref, ref)
     |> Map.put(:run_watchdog_awaiting_confirmation?, true)
+    |> Map.put(:run_watchdog_prompt_seq, prompt_seq)
   end
 
   defp dispatcher do
     Application.get_env(:lemon_router, :dispatcher, LemonChannels.Dispatcher)
+  end
+
+  defp runtime do
+    Application.get_env(:lemon_router, :watchdog_runtime, LemonGateway.Runtime)
+  end
+
+  defp next_watchdog_prompt_seq(state) do
+    (Map.get(state, :run_watchdog_prompt_seq, 0) || 0) + 1
   end
 end

--- a/apps/lemon_router/lib/lemon_router/stream_coalescer.ex
+++ b/apps/lemon_router/lib/lemon_router/stream_coalescer.ex
@@ -144,6 +144,32 @@ defmodule LemonRouter.StreamCoalescer do
   end
 
   @doc """
+  Finalize the current answer turn, move its message tracking to another surface,
+  and reset the answer coalescer so the next delta creates a fresh message.
+  """
+  @spec handoff_turn(
+          session_key :: binary(),
+          channel_id :: binary(),
+          run_id :: binary(),
+          target_surface :: term()
+        ) :: {:ok, binary()} | :noop
+  def handoff_turn(session_key, channel_id, run_id, target_surface)
+      when is_binary(session_key) and is_binary(channel_id) and is_binary(run_id) and
+             not is_nil(target_surface) do
+    case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, channel_id}) do
+      [{pid, _}] ->
+        try do
+          GenServer.call(pid, {:handoff_turn, run_id, target_surface}, 5_000)
+        catch
+          :exit, _ -> :noop
+        end
+
+      _ ->
+        :noop
+    end
+  end
+
+  @doc """
   Force flush the coalescer buffer.
   """
   @spec flush(session_key :: binary(), channel_id :: binary()) :: :ok
@@ -338,6 +364,33 @@ defmodule LemonRouter.StreamCoalescer do
     {:reply, :ok, state}
   end
 
+  def handle_call({:handoff_turn, run_id, target_surface}, _from, state) do
+    {reply, state} =
+      if state.run_id == run_id and is_binary(state.full_text) and state.full_text != "" do
+        text = state.full_text
+        state = do_finalize(state, text)
+        move_presentation_state_answer(state, target_surface)
+        cancel_timer(state.flush_timer)
+
+        state = %{
+          state
+          | buffer: "",
+            full_text: "",
+            last_sent_text: nil,
+            flush_timer: nil,
+            first_delta_ts: nil,
+            finalized: false,
+            pending_clear: false
+        }
+
+        {{:ok, text}, state}
+      else
+        {:noop, state}
+      end
+
+    {:reply, reply, state}
+  end
+
   @impl true
   def handle_info(:idle_timeout, state) do
     state = do_flush(state)
@@ -420,17 +473,39 @@ defmodule LemonRouter.StreamCoalescer do
         is_binary(final_text) and final_text != "" -> final_text
         is_binary(state.full_text) and state.full_text != "" -> state.full_text
         is_binary(state.buffer) and state.buffer != "" -> state.buffer
-        true -> "Done"
+        true -> nil
       end
 
     state =
-      case build_intent(state, :stream_finalize, text) do
-        {:ok, intent} ->
-          _ = dispatcher().dispatch(intent)
-          %{state | last_sent_text: text, finalized: true}
+      case text do
+        nil ->
+          Logger.warning(
+            "StreamCoalescer finalizing #{state.session_key} with empty text " <>
+              "(run_id=#{state.run_id}, last_seq=#{state.last_seq})"
+          )
 
-        :error ->
-          %{state | finalized: true}
+          case build_intent(
+                 state,
+                 :stream_finalize,
+                 "⚠️ Empty response from model — no output was generated."
+               ) do
+            {:ok, intent} ->
+              _ = dispatcher().dispatch(intent)
+              %{state | last_sent_text: nil, finalized: true}
+
+            :error ->
+              %{state | finalized: true}
+          end
+
+        _ ->
+          case build_intent(state, :stream_finalize, text) do
+            {:ok, intent} ->
+              _ = dispatcher().dispatch(intent)
+              %{state | last_sent_text: text, finalized: true}
+
+            :error ->
+              %{state | finalized: true}
+          end
       end
 
     cancel_timer(state.flush_timer)
@@ -440,7 +515,8 @@ defmodule LemonRouter.StreamCoalescer do
   end
 
   defp build_intent(state, kind, text) when is_binary(text) do
-    with {:ok, route} <- DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
+    with {:ok, route} <-
+           DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
       {:ok,
        %DeliveryIntent{
          intent_id: "#{state.run_id}:stream:#{state.last_seq}:#{Atom.to_string(kind)}",
@@ -460,8 +536,20 @@ defmodule LemonRouter.StreamCoalescer do
   end
 
   defp clear_presentation_state_answer(state) do
-    with {:ok, route} <- DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
+    with {:ok, route} <-
+           DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
       LemonChannels.PresentationState.clear(route, state.run_id, :answer)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp move_presentation_state_answer(state, target_surface) when not is_nil(target_surface) do
+    with {:ok, route} <-
+           DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
+      LemonChannels.PresentationState.move(route, state.run_id, :answer, target_surface)
     end
 
     :ok

--- a/apps/lemon_router/lib/lemon_router/tool_status_coalescer.ex
+++ b/apps/lemon_router/lib/lemon_router/tool_status_coalescer.ex
@@ -8,29 +8,37 @@ defmodule LemonRouter.ToolStatusCoalescer do
   Channel-specific presentation is handled by `LemonChannels.Dispatcher`.
   """
 
-  use GenServer
+  use GenServer, restart: :temporary
 
   require Logger
 
   alias LemonChannels.Dispatcher
   alias LemonCore.DeliveryIntent
+  alias LemonRouter.AsyncTaskSurface
   alias LemonRouter.ChannelContext
   alias LemonRouter.DeliveryRouteResolver
 
   @default_idle_ms 400
   @default_max_latency_ms 1200
+  @default_task_reap_ms 60_000
 
   @max_actions 40
 
   defstruct [
     :session_key,
     :channel_id,
+    :surface,
+    :surface_binding,
     :run_id,
     :actions,
     :order,
+    :prefix_text,
     :last_text,
+    :last_kind,
     :first_event_ts,
     :flush_timer,
+    :reap_timer,
+    :reap_token,
     :config,
     :meta,
     :seq,
@@ -42,12 +50,14 @@ defmodule LemonRouter.ToolStatusCoalescer do
   def start_link(opts) do
     session_key = Keyword.fetch!(opts, :session_key)
     channel_id = Keyword.fetch!(opts, :channel_id)
-    name = via_tuple(session_key, channel_id)
+    {surface, _surface_binding} = surface_opts(opts)
+    name = via_tuple(session_key, channel_id, surface)
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  defp via_tuple(session_key, channel_id) do
-    {:via, Registry, {LemonRouter.ToolStatusRegistry, {session_key, channel_id}}}
+  defp via_tuple(session_key, channel_id, surface) do
+    {:via, Registry,
+     {LemonRouter.ToolStatusRegistry, registry_key(session_key, channel_id, surface)}}
   end
 
   @doc """
@@ -55,18 +65,20 @@ defmodule LemonRouter.ToolStatusCoalescer do
 
   Options:
   - `:meta` - semantic delivery metadata (for example `:user_msg_id`)
+  - `:surface` - semantic presentation surface, defaults to `:status`
   """
   def ingest_action(session_key, channel_id, run_id, action_event, opts \\ []) do
     meta = Keyword.get(opts, :meta, %{})
+    {surface, surface_binding} = surface_opts(opts)
 
     case normalize_action_event(action_event) do
       {:skip, _reason} ->
         :ok
 
       {:ok, _id, _action_data} ->
-        case get_or_start_coalescer(session_key, channel_id, meta) do
+        case get_or_start_coalescer(session_key, channel_id, surface, surface_binding, meta) do
           {:ok, pid} ->
-            GenServer.cast(pid, {:action, run_id, action_event, meta})
+            GenServer.cast(pid, {:action, run_id, action_event, meta, surface_binding})
 
           {:error, reason} ->
             Logger.warning("Failed to start tool status coalescer: #{inspect(reason)}")
@@ -77,27 +89,103 @@ defmodule LemonRouter.ToolStatusCoalescer do
   end
 
   @doc """
+  Ingest a projected child action into a parent-owned task surface.
+
+  This is a narrow wrapper over normal action ingestion so callers can be
+  explicit that the event originated from a bridged child run rather than the
+  parent run's native engine event stream.
+  """
+  def ingest_projected_child_action(
+        session_key,
+        channel_id,
+        parent_run_id,
+        surface,
+        projected_event,
+        opts \\ []
+      ) do
+    ingest_action(
+      session_key,
+      channel_id,
+      parent_run_id,
+      projected_event,
+      Keyword.merge(opts, surface: surface)
+    )
+  end
+
+  @doc """
   Force flush the tool status message for a session/channel.
   """
-  def flush(session_key, channel_id) do
-    case Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, channel_id}) do
+  def flush(session_key, channel_id, opts \\ []) do
+    {surface, _surface_binding} = surface_opts(opts)
+
+    case Registry.lookup(
+           LemonRouter.ToolStatusRegistry,
+           registry_key(session_key, channel_id, surface)
+         ) do
       [{pid, _}] -> GenServer.cast(pid, :flush)
       _ -> :ok
     end
   end
 
+  defp equivalent_action_id(actions, data) when is_map(actions) and is_map(data) do
+    Enum.find_value(actions, fn {existing_id, existing_data} ->
+      if equivalent_action?({existing_id, existing_data}, {data[:id], data}),
+        do: existing_id,
+        else: nil
+    end)
+  end
+
+  defp equivalent_action_id(_, _), do: nil
+
+  defp equivalent_action?(
+         {existing_id, existing},
+         {incoming_id, incoming}
+       )
+       when is_binary(existing_id) and is_binary(incoming_id) and is_map(existing) and
+              is_map(incoming) do
+    existing_detail = existing[:detail] || %{}
+    incoming_detail = incoming[:detail] || %{}
+
+    existing_child_run_id = existing_detail[:child_run_id] || existing_detail["child_run_id"]
+    incoming_child_run_id = incoming_detail[:child_run_id] || incoming_detail["child_run_id"]
+
+    existing_parent =
+      existing_detail[:parent_tool_use_id] || existing_detail["parent_tool_use_id"]
+
+    incoming_parent =
+      incoming_detail[:parent_tool_use_id] || incoming_detail["parent_tool_use_id"]
+
+    projected_embedded_equivalent_ids?(existing_id, incoming_id) and
+      is_binary(existing_child_run_id) and is_binary(incoming_child_run_id) and
+      existing_child_run_id == incoming_child_run_id and existing_parent == incoming_parent and
+      normalize_embedded_kind(to_string(existing[:kind])) ==
+        normalize_embedded_kind(to_string(incoming[:kind])) and
+      normalize_title(existing[:title]) == normalize_title(incoming[:title])
+  end
+
+  defp equivalent_action?(_, _), do: false
+
+  defp normalize_title(title) when is_binary(title), do: String.trim(title)
+  defp normalize_title(title), do: title |> to_string() |> String.trim()
+
   @doc """
-  Finalize the tool status for a run by marking any still-running actions as completed.
+  Attach subsequent tool status updates to the latest assistant text chunk.
   """
-  def finalize_run(session_key, channel_id, run_id, ok?, opts \\ [])
+  def anchor_segment(session_key, channel_id, run_id, prefix_text, opts \\ [])
 
-  def finalize_run(session_key, channel_id, run_id, ok?, opts) when is_binary(run_id) do
+  def anchor_segment(session_key, channel_id, run_id, prefix_text, opts)
+      when is_binary(run_id) and is_binary(prefix_text) do
     meta = Keyword.get(opts, :meta, %{})
+    {surface, surface_binding} = surface_opts(opts)
 
-    case get_or_start_coalescer(session_key, channel_id, meta) do
+    case get_or_start_coalescer(session_key, channel_id, surface, surface_binding, meta) do
       {:ok, pid} ->
         try do
-          GenServer.call(pid, {:finalize_run, run_id, ok?, meta}, 2_000)
+          GenServer.call(
+            pid,
+            {:anchor_segment, run_id, prefix_text, meta, surface_binding},
+            2_000
+          )
         catch
           :exit, _ -> :ok
         end
@@ -109,15 +197,100 @@ defmodule LemonRouter.ToolStatusCoalescer do
     end
   end
 
+  def anchor_segment(_session_key, _channel_id, _run_id, _prefix_text, _opts), do: :ok
+
+  @doc """
+  Finalize the current tool-status segment without marking running actions complete.
+  """
+  def commit_segment(session_key, channel_id, run_id, opts \\ [])
+
+  def commit_segment(session_key, channel_id, run_id, opts) when is_binary(run_id) do
+    meta = Keyword.get(opts, :meta, %{})
+    {surface, _surface_binding} = surface_opts(opts)
+
+    case Registry.lookup(
+           LemonRouter.ToolStatusRegistry,
+           registry_key(session_key, channel_id, surface)
+         ) do
+      [{pid, _}] ->
+        try do
+          GenServer.call(
+            pid,
+            {:commit_segment, run_id, meta, Keyword.get(opts, :surface_binding)},
+            2_000
+          )
+        catch
+          :exit, _ -> :ok
+        end
+
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  def commit_segment(_session_key, _channel_id, _run_id, _opts), do: :ok
+
+  @doc """
+  Finalize the tool status for a run by marking any still-running actions as completed.
+  """
+  def finalize_run(session_key, channel_id, run_id, ok?, opts \\ [])
+
+  def finalize_run(session_key, channel_id, run_id, ok?, opts) when is_binary(run_id) do
+    meta = Keyword.get(opts, :meta, %{})
+    {surface, surface_binding} = surface_opts(opts)
+    start? = Keyword.get(opts, :start?, true)
+
+    case get_or_start_coalescer(session_key, channel_id, surface, surface_binding, meta, start?) do
+      {:ok, pid} ->
+        try do
+          GenServer.call(pid, {:finalize_run, run_id, ok?, meta, surface_binding}, 2_000)
+        catch
+          :exit, _ -> :ok
+        end
+
+        :ok
+
+      :skip ->
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
   def finalize_run(_session_key, _channel_id, _run_id, _ok?, _opts), do: :ok
 
-  defp get_or_start_coalescer(session_key, channel_id, meta) do
-    case Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, channel_id}) do
+  defp get_or_start_coalescer(session_key, channel_id, surface, surface_binding, meta) do
+    get_or_start_coalescer(session_key, channel_id, surface, surface_binding, meta, true)
+  end
+
+  defp get_or_start_coalescer(session_key, channel_id, surface, _surface_binding, _meta, false) do
+    case Registry.lookup(
+           LemonRouter.ToolStatusRegistry,
+           registry_key(session_key, channel_id, surface)
+         ) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> :skip
+    end
+  end
+
+  defp get_or_start_coalescer(session_key, channel_id, surface, surface_binding, meta, true) do
+    key = registry_key(session_key, channel_id, surface)
+
+    case Registry.lookup(LemonRouter.ToolStatusRegistry, key) do
       [{pid, _}] ->
         {:ok, pid}
 
       [] ->
-        spec = {__MODULE__, session_key: session_key, channel_id: channel_id, meta: meta}
+        spec =
+          {__MODULE__,
+           session_key: session_key,
+           channel_id: channel_id,
+           surface: surface,
+           surface_binding: surface_binding,
+           meta: meta}
 
         case DynamicSupervisor.start_child(LemonRouter.ToolStatusSupervisor, spec) do
           {:ok, pid} -> {:ok, pid}
@@ -131,21 +304,29 @@ defmodule LemonRouter.ToolStatusCoalescer do
   def init(opts) do
     session_key = Keyword.fetch!(opts, :session_key)
     channel_id = Keyword.fetch!(opts, :channel_id)
+    {surface, surface_binding} = surface_opts(opts)
 
     config = %{
       idle_ms: Keyword.get(opts, :idle_ms, @default_idle_ms),
-      max_latency_ms: Keyword.get(opts, :max_latency_ms, @default_max_latency_ms)
+      max_latency_ms: Keyword.get(opts, :max_latency_ms, @default_max_latency_ms),
+      task_reap_ms: Keyword.get(opts, :task_reap_ms, @default_task_reap_ms)
     }
 
     state = %__MODULE__{
       session_key: session_key,
       channel_id: channel_id,
+      surface: surface,
+      surface_binding: surface_binding,
       run_id: nil,
       actions: %{},
       order: [],
+      prefix_text: nil,
       last_text: nil,
+      last_kind: nil,
       first_event_ts: nil,
       flush_timer: nil,
+      reap_timer: nil,
+      reap_token: nil,
       config: config,
       meta: Keyword.get(opts, :meta, %{}),
       seq: 0,
@@ -158,8 +339,9 @@ defmodule LemonRouter.ToolStatusCoalescer do
   end
 
   @impl true
-  def handle_cast({:action, run_id, action_event, meta}, state) do
+  def handle_cast({:action, run_id, action_event, meta, surface_binding}, state) do
     now = System.system_time(:millisecond)
+    state = state |> cancel_task_reap() |> maybe_put_surface_binding(surface_binding)
 
     state =
       if state.run_id != run_id do
@@ -170,9 +352,13 @@ defmodule LemonRouter.ToolStatusCoalescer do
           | run_id: run_id,
             actions: %{},
             order: [],
+            prefix_text: nil,
             last_text: nil,
+            last_kind: nil,
             first_event_ts: nil,
             flush_timer: nil,
+            reap_timer: nil,
+            reap_token: nil,
             seq: 0,
             finalized: false,
             meta: compact_meta(meta),
@@ -191,24 +377,29 @@ defmodule LemonRouter.ToolStatusCoalescer do
           {:skip, _reason} ->
             state
 
-          {:ok, id, action_data} ->
-            {actions, order} = upsert_action(state.actions, state.order, id, action_data)
+          {:ok, _id, action_data} ->
+            action_data
+            |> expand_embedded_actions()
+            |> Enum.reduce({state.actions, state.order}, fn data, {actions, order} ->
+              upsert_action(actions, order, data.id, data)
+            end)
+            |> then(fn {actions, order} ->
+              engine =
+                state.engine ||
+                  (is_binary(action_data[:caller_engine]) && action_data[:caller_engine]) ||
+                  nil
 
-            engine =
-              state.engine ||
-                (is_binary(action_data[:caller_engine]) && action_data[:caller_engine]) ||
-                nil
+              state = %{
+                state
+                | actions: actions,
+                  order: order,
+                  first_event_ts: state.first_event_ts || now,
+                  run_started_at: state.run_started_at || now,
+                  engine: engine
+              }
 
-            state = %{
-              state
-              | actions: actions,
-                order: order,
-                first_event_ts: state.first_event_ts || now,
-                run_started_at: state.run_started_at || now,
-                engine: engine
-            }
-
-            maybe_flush(state, now)
+              maybe_flush(state, now)
+            end)
         end
 
       {:noreply, state}
@@ -221,24 +412,13 @@ defmodule LemonRouter.ToolStatusCoalescer do
   end
 
   @impl true
-  def handle_call({:finalize_run, run_id, ok?, meta}, _from, state) do
+  def handle_call({:anchor_segment, run_id, prefix_text, meta, surface_binding}, _from, state) do
+    state = state |> cancel_task_reap() |> maybe_put_surface_binding(surface_binding)
+
     state =
       cond do
         state.run_id == nil ->
-          %{
-            state
-            | run_id: run_id,
-              meta: compact_meta(meta),
-              actions: %{},
-              order: [],
-              last_text: nil,
-              first_event_ts: nil,
-              flush_timer: nil,
-              seq: 0,
-              finalized: false,
-              run_started_at: nil,
-              engine: nil
-          }
+          %{state | run_id: run_id, meta: compact_meta(meta)}
 
         state.run_id != run_id ->
           cancel_timer(state.flush_timer)
@@ -248,10 +428,13 @@ defmodule LemonRouter.ToolStatusCoalescer do
             | run_id: run_id,
               actions: %{},
               order: [],
+              prefix_text: nil,
               last_text: nil,
+              last_kind: nil,
               first_event_ts: nil,
               flush_timer: nil,
-              seq: 0,
+              reap_timer: nil,
+              reap_token: nil,
               finalized: false,
               meta: compact_meta(meta),
               run_started_at: nil,
@@ -264,11 +447,71 @@ defmodule LemonRouter.ToolStatusCoalescer do
 
     state =
       state
-      |> Map.put(:finalized, true)
-      |> finalize_running_actions(ok?)
-      |> do_flush()
+      |> finalize_segment()
+      |> reset_segment()
+      |> Map.put(:prefix_text, prefix_text)
 
     {:reply, :ok, state}
+  end
+
+  def handle_call({:commit_segment, run_id, meta, surface_binding}, _from, state) do
+    state = state |> cancel_task_reap() |> maybe_put_surface_binding(surface_binding)
+
+    state =
+      if state.run_id == run_id do
+        state
+        |> Map.put(:meta, Map.merge(state.meta || %{}, compact_meta(meta)))
+        |> finalize_segment()
+        |> reset_segment()
+      else
+        state
+      end
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:finalize_run, run_id, ok?, meta, surface_binding}, _from, state) do
+    if is_binary(state.run_id) and state.run_id != run_id do
+      {:reply, :ok, state}
+    else
+      state = state |> cancel_task_reap() |> maybe_put_surface_binding(surface_binding)
+
+      state =
+        cond do
+          state.run_id == nil ->
+            %{
+              state
+              | run_id: run_id,
+                meta: compact_meta(meta),
+                actions: %{},
+                order: [],
+                prefix_text: nil,
+                last_text: nil,
+                last_kind: nil,
+                first_event_ts: nil,
+                flush_timer: nil,
+                reap_timer: nil,
+                reap_token: nil,
+                seq: 0,
+                finalized: false,
+                run_started_at: nil,
+                engine: nil
+            }
+
+          true ->
+            %{state | meta: Map.merge(state.meta || %{}, compact_meta(meta))}
+        end
+
+      state =
+        state
+        |> Map.put(:finalized, true)
+        |> finalize_running_actions(ok?)
+        |> do_flush()
+        |> maybe_schedule_task_reap()
+
+      {:reply, :ok, state}
+    end
   end
 
   @impl true
@@ -277,11 +520,37 @@ defmodule LemonRouter.ToolStatusCoalescer do
     {:noreply, state}
   end
 
+  def handle_info({:reap_if_idle, token}, %{reap_token: token} = state) do
+    state = %{state | reap_timer: nil, reap_token: nil}
+
+    if task_surface_reapable?(state) do
+      maybe_reap_terminal_surface_binding(state)
+      {:stop, :normal, state}
+    else
+      {:noreply, state}
+    end
+  end
+
   def handle_info(_msg, state), do: {:noreply, state}
 
   # ---- Internal ----
 
   defp compact_meta(meta), do: ChannelContext.compact_meta(meta)
+
+  defp surface_opts(opts) do
+    surface_binding = Keyword.get(opts, :surface_binding)
+    surface = binding_surface(surface_binding) || Keyword.get(opts, :surface, :status)
+    {surface, surface_binding}
+  end
+
+  defp binding_surface(%{surface: surface}), do: surface
+  defp binding_surface(_), do: nil
+
+  defp maybe_put_surface_binding(%__MODULE__{} = state, %{surface: _} = surface_binding) do
+    %{state | surface_binding: surface_binding}
+  end
+
+  defp maybe_put_surface_binding(%__MODULE__{} = state, _surface_binding), do: state
 
   defp dispatcher do
     Application.get_env(:lemon_router, :dispatcher, Dispatcher)
@@ -314,22 +583,28 @@ defmodule LemonRouter.ToolStatusCoalescer do
       state.channel_id
       |> LemonRouter.ToolStatusRenderer.render(state.actions, state.order, opts)
       |> maybe_prefix_running(state)
+      |> maybe_prefix_text(state)
+
+    kind = if state.finalized == true, do: :tool_status_finalize, else: :tool_status_snapshot
 
     state =
       cond do
         state.order == [] ->
           state
 
-        text == state.last_text ->
+        text == state.last_text and kind == state.last_kind ->
           state
 
         true ->
           state = %{state | seq: state.seq + 1}
-          state = emit_output(state, text)
-          %{state | last_text: text}
+          state = emit_output(state, kind, text)
+          %{state | last_text: text, last_kind: kind}
       end
 
-    %{state | first_event_ts: nil, flush_timer: nil}
+    state
+    |> Map.put(:first_event_ts, nil)
+    |> Map.put(:flush_timer, nil)
+    |> maybe_schedule_task_reap()
   end
 
   defp finalize_running_actions(state, ok?) do
@@ -350,9 +625,83 @@ defmodule LemonRouter.ToolStatusCoalescer do
     %{state | actions: actions}
   end
 
-  defp emit_output(state, text) do
-    kind = if state.finalized == true, do: :tool_status_finalize, else: :tool_status_snapshot
+  defp finalize_segment(%__MODULE__{order: []} = state), do: state
 
+  defp finalize_segment(%__MODULE__{} = state) do
+    state
+    |> Map.put(:finalized, true)
+    |> do_flush()
+  end
+
+  defp reset_segment(%__MODULE__{} = state) do
+    state = cancel_task_reap(state)
+    cancel_timer(state.flush_timer)
+
+    %{
+      state
+      | actions: %{},
+        order: [],
+        prefix_text: nil,
+        last_text: nil,
+        last_kind: nil,
+        first_event_ts: nil,
+        flush_timer: nil,
+        reap_timer: nil,
+        reap_token: nil,
+        finalized: false,
+        engine: nil
+    }
+  end
+
+  defp maybe_schedule_task_reap(%__MODULE__{} = state) do
+    task_reap_ms = state.config[:task_reap_ms]
+
+    cond do
+      not task_surface?(state.surface) ->
+        state
+
+      not is_integer(task_reap_ms) or task_reap_ms <= 0 ->
+        state
+
+      not task_surface_reapable?(state) ->
+        state
+
+      true ->
+        state = cancel_task_reap(state)
+        token = make_ref()
+        timer = Process.send_after(self(), {:reap_if_idle, token}, task_reap_ms)
+        %{state | reap_timer: timer, reap_token: token}
+    end
+  end
+
+  defp cancel_task_reap(%__MODULE__{reap_timer: nil} = state), do: %{state | reap_token: nil}
+
+  defp cancel_task_reap(%__MODULE__{reap_timer: timer} = state) do
+    cancel_timer(timer)
+    %{state | reap_timer: nil, reap_token: nil}
+  end
+
+  defp task_surface_reapable?(%__MODULE__{} = state) do
+    task_surface?(state.surface) and state.order != [] and not any_running_action?(state)
+  end
+
+  defp task_surface?({:status_task, task_id}) when is_binary(task_id) and task_id != "", do: true
+  defp task_surface?(_), do: false
+
+  defp maybe_reap_terminal_surface_binding(%__MODULE__{surface_binding: nil}), do: :ok
+
+  defp maybe_reap_terminal_surface_binding(%__MODULE__{surface_binding: surface_binding}) do
+    with %{surface_id: surface_id} <- surface_binding,
+         true <- is_binary(surface_id) and surface_id != "",
+         {:ok, %{status: :terminal_grace}} <- AsyncTaskSurface.get(surface_id),
+         {:ok, _snapshot} <- AsyncTaskSurface.transition(surface_id, :reaped) do
+      :ok
+    else
+      _ -> :ok
+    end
+  end
+
+  defp emit_output(state, kind, text) do
     case build_intent(state, kind, text) do
       {:ok, intent} ->
         _ = dispatcher().dispatch(intent)
@@ -366,17 +715,19 @@ defmodule LemonRouter.ToolStatusCoalescer do
   end
 
   defp build_intent(state, kind, text) do
-    with {:ok, route} <- DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
+    with {:ok, route} <-
+           DeliveryRouteResolver.resolve(state.session_key, state.channel_id, state.meta || %{}) do
       {:ok,
        %DeliveryIntent{
-         intent_id: "#{state.run_id}:status:#{state.seq}:#{Atom.to_string(kind)}",
+         intent_id:
+           "#{state.run_id}:status:#{surface_token(state.surface)}:#{state.seq}:#{Atom.to_string(kind)}",
          run_id: state.run_id,
          session_key: state.session_key,
          route: route,
          kind: kind,
          body: %{text: text, seq: state.seq},
          controls: %{allow_cancel?: state.finalized != true},
-         meta: Map.put(state.meta || %{}, :surface, :status)
+         meta: Map.put(state.meta || %{}, :surface, state.surface)
        }}
     else
       _ -> :error
@@ -397,6 +748,58 @@ defmodule LemonRouter.ToolStatusCoalescer do
 
   defp maybe_prefix_running(text, _state), do: text
 
+  defp maybe_prefix_text(text, %__MODULE__{prefix_text: prefix} = state)
+       when is_binary(text) and is_binary(prefix) do
+    trimmed = String.trim(prefix)
+
+    if trimmed == "" do
+      text
+    else
+      combine_prefix_and_status(trimmed, text, chunk_limit(state.channel_id))
+    end
+  end
+
+  defp maybe_prefix_text(text, _state), do: text
+
+  # Keep the current tool-status snapshot visible even when the handed-off
+  # assistant prefix is long. Telegram truncation preserves the start of a
+  # message, so without budgeting the prefix separately we can hide the tool
+  # lines entirely.
+  defp combine_prefix_and_status(prefix, text, max_len)
+       when is_binary(prefix) and is_binary(text) and is_integer(max_len) and max_len > 0 do
+    separator = "\n\n"
+    combined = prefix <> separator <> text
+
+    cond do
+      String.length(combined) <= max_len ->
+        combined
+
+      String.length(text) + String.length(separator) >= max_len ->
+        text
+
+      true ->
+        available_for_prefix = max_len - String.length(text) - String.length(separator) - 1
+
+        if available_for_prefix <= 0 do
+          text
+        else
+          prefix_tail = String.slice(prefix, -available_for_prefix, available_for_prefix)
+          "…" <> prefix_tail <> separator <> text
+        end
+    end
+  end
+
+  defp chunk_limit(channel_id) when is_binary(channel_id) and channel_id != "" do
+    case LemonChannels.Registry.get_capabilities(channel_id) do
+      %{chunk_limit: limit} when is_integer(limit) and limit > 0 -> limit
+      _ -> 4096
+    end
+  rescue
+    _ -> 4096
+  end
+
+  defp chunk_limit(_), do: 4096
+
   defp any_running_action?(%__MODULE__{} = state) do
     actions = state.actions || %{}
     order = state.order || []
@@ -410,6 +813,15 @@ defmodule LemonRouter.ToolStatusCoalescer do
     end)
   rescue
     _ -> false
+  end
+
+  defp registry_key(session_key, channel_id, :status), do: {session_key, channel_id}
+  defp registry_key(session_key, channel_id, surface), do: {session_key, channel_id, surface}
+
+  defp surface_token(surface) do
+    surface
+    |> :erlang.term_to_binary()
+    |> Base.url_encode64(padding: false)
   end
 
   defp normalize_action_event(ev) when is_map(ev) do
@@ -464,8 +876,250 @@ defmodule LemonRouter.ToolStatusCoalescer do
 
   defp normalize_action_event(_), do: {:skip, :unknown}
 
+  defp expand_embedded_actions(action_data) when is_map(action_data) do
+    case {skip_parent_action?(action_data), embedded_child_action(action_data)} do
+      {true, nil} -> []
+      {true, child} -> [child]
+      {false, nil} -> [action_data]
+      {false, child} -> [action_data, child]
+    end
+  end
+
+  defp expand_embedded_actions(action_data), do: [action_data]
+
+  defp skip_parent_action?(action_data) when is_map(action_data) do
+    detail = action_data[:detail] || %{}
+    args = Map.get(detail, :args) || Map.get(detail, "args") || %{}
+    name = Map.get(detail, :name) || Map.get(detail, "name")
+    action_name = Map.get(args, :action) || Map.get(args, "action")
+
+    action_data[:kind] in ["subagent", :subagent] and name == "task" and
+      action_name in ["poll", "join"]
+  end
+
+  defp skip_parent_action?(_), do: false
+
+  defp embedded_child_action(action_data) when is_map(action_data) do
+    detail = action_data[:detail] || %{}
+
+    parent_id =
+      Map.get(detail, :parent_tool_use_id) || Map.get(detail, "parent_tool_use_id") ||
+        action_data[:id]
+
+    with true <- is_binary(parent_id) and parent_id != "",
+         %{title: title, kind: kind, phase: phase} <- current_action(detail),
+         true <- allowed_embedded_kind?(kind),
+         child_id when is_binary(child_id) <- embedded_child_id(parent_id, kind, title) do
+      %{
+        id: child_id,
+        kind: normalize_embedded_kind(kind),
+        caller_engine: embedded_engine(detail) || action_data[:caller_engine],
+        title: title,
+        phase: normalize_embedded_phase(phase),
+        ok: embedded_ok(phase),
+        message: nil,
+        level: nil,
+        detail:
+          (embedded_action_detail(detail) || %{})
+          |> Map.put_new(:parent_tool_use_id, parent_id)
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp embedded_child_action(_), do: nil
+
+  defp current_action(detail) when is_map(detail) do
+    current_action_from_partial_result(detail) || current_action_from_result_meta(detail)
+  end
+
+  defp current_action(_), do: nil
+
+  defp current_action_from_partial_result(detail) when is_map(detail) do
+    partial_result = Map.get(detail, :partial_result) || Map.get(detail, "partial_result")
+
+    with true <- is_map(partial_result),
+         details when is_map(details) <-
+           Map.get(partial_result, :details) || Map.get(partial_result, "details"),
+         current when is_map(current) <-
+           Map.get(details, :current_action) || Map.get(details, "current_action"),
+         title when is_binary(title) and title != "" <-
+           Map.get(current, :title) || Map.get(current, "title"),
+         kind when is_binary(kind) and kind != "" <-
+           Map.get(current, :kind) || Map.get(current, "kind"),
+         phase when is_binary(phase) and phase != "" <-
+           Map.get(current, :phase) || Map.get(current, "phase") do
+      %{title: title, kind: kind, phase: phase}
+    else
+      _ -> nil
+    end
+  end
+
+  defp current_action_from_partial_result(_), do: nil
+
+  defp current_action_from_result_meta(detail) when is_map(detail) do
+    result_meta = Map.get(detail, :result_meta) || Map.get(detail, "result_meta")
+
+    with true <- is_map(result_meta),
+         current when is_map(current) <-
+           Map.get(result_meta, :current_action) || Map.get(result_meta, "current_action"),
+         title when is_binary(title) and title != "" <-
+           Map.get(current, :title) || Map.get(current, "title"),
+         kind when is_binary(kind) and kind != "" <-
+           Map.get(current, :kind) || Map.get(current, "kind"),
+         phase when is_binary(phase) and phase != "" <-
+           Map.get(current, :phase) || Map.get(current, "phase") do
+      %{title: title, kind: kind, phase: phase}
+    else
+      _ -> nil
+    end
+  end
+
+  defp current_action_from_result_meta(_), do: nil
+
+  defp embedded_action_detail(detail) when is_map(detail) do
+    embedded_action_detail_from_partial_result(detail) ||
+      embedded_action_detail_from_result_meta(detail)
+  end
+
+  defp embedded_action_detail(_), do: %{}
+
+  defp embedded_action_detail_from_partial_result(detail) when is_map(detail) do
+    partial_result = Map.get(detail, :partial_result) || Map.get(detail, "partial_result")
+
+    with true <- is_map(partial_result),
+         details when is_map(details) <-
+           Map.get(partial_result, :details) || Map.get(partial_result, "details"),
+         action_detail when is_map(action_detail) <-
+           Map.get(details, :action_detail) || Map.get(details, "action_detail") do
+      action_detail
+    else
+      _ -> nil
+    end
+  end
+
+  defp embedded_action_detail_from_partial_result(_), do: nil
+
+  defp embedded_action_detail_from_result_meta(detail) when is_map(detail) do
+    result_meta = Map.get(detail, :result_meta) || Map.get(detail, "result_meta")
+
+    with true <- is_map(result_meta),
+         action_detail when is_map(action_detail) <-
+           Map.get(result_meta, :action_detail) || Map.get(result_meta, "action_detail") do
+      action_detail
+    else
+      _ -> nil
+    end
+  end
+
+  defp embedded_action_detail_from_result_meta(_), do: nil
+
+  defp embedded_engine(detail) when is_map(detail) do
+    embedded_engine_from_partial_result(detail) || embedded_engine_from_result_meta(detail)
+  end
+
+  defp embedded_engine(_), do: nil
+
+  defp embedded_engine_from_partial_result(detail) when is_map(detail) do
+    partial_result = Map.get(detail, :partial_result) || Map.get(detail, "partial_result")
+
+    with true <- is_map(partial_result),
+         details when is_map(details) <-
+           Map.get(partial_result, :details) || Map.get(partial_result, "details"),
+         engine when is_binary(engine) and engine != "" <-
+           Map.get(details, :engine) || Map.get(details, "engine") do
+      engine
+    else
+      _ -> nil
+    end
+  end
+
+  defp embedded_engine_from_partial_result(_), do: nil
+
+  defp embedded_engine_from_result_meta(detail) when is_map(detail) do
+    result_meta = Map.get(detail, :result_meta) || Map.get(detail, "result_meta")
+
+    with true <- is_map(result_meta),
+         engine when is_binary(engine) and engine != "" <-
+           Map.get(result_meta, :engine) || Map.get(result_meta, "engine") do
+      engine
+    else
+      _ -> nil
+    end
+  end
+
+  defp embedded_engine_from_result_meta(_), do: nil
+
+  defp embedded_child_id(parent_id, kind, title)
+       when is_binary(parent_id) and is_binary(kind) and is_binary(title) do
+    digest =
+      "#{kind}:#{title}"
+      |> :erlang.md5()
+      |> Base.encode16(case: :lower)
+
+    "#{parent_id}:#{digest}"
+  end
+
+  defp normalize_embedded_kind(kind) when is_binary(kind) do
+    case String.downcase(kind) do
+      "tool" -> "tool"
+      "command" -> "command"
+      "file_change" -> "file_change"
+      "web_search" -> "web_search"
+      "subagent" -> "subagent"
+      other -> other
+    end
+  end
+
+  defp normalize_embedded_kind(kind), do: kind
+
+  defp allowed_embedded_kind?(kind) when is_binary(kind) do
+    normalize_embedded_kind(kind) in ["tool", "command", "file_change", "web_search", "subagent"]
+  end
+
+  defp allowed_embedded_kind?(_), do: false
+
+  defp normalize_embedded_phase(phase) when is_binary(phase) do
+    case String.downcase(phase) do
+      "started" -> :started
+      "updated" -> :updated
+      "completed" -> :completed
+      _ -> :updated
+    end
+  end
+
+  defp normalize_embedded_phase(_), do: :updated
+
+  defp embedded_ok(phase) when is_binary(phase) do
+    case String.downcase(phase) do
+      "completed" -> true
+      _ -> nil
+    end
+  end
+
+  defp embedded_ok(_), do: nil
+
+  defp projected_embedded_equivalent_ids?(left, right) do
+    {projected_child_action_id?(left), embedded_child_action_id?(left),
+     projected_child_action_id?(right), embedded_child_action_id?(right)} in [
+      {true, false, false, true},
+      {false, true, true, false}
+    ]
+  end
+
+  defp projected_child_action_id?(<<"taskproj:", _::binary>>), do: true
+  defp projected_child_action_id?(_), do: false
+
+  defp embedded_child_action_id?(id) when is_binary(id) do
+    not projected_child_action_id?(id) and String.match?(id, ~r/:[0-9a-f]{32}$/)
+  end
+
+  defp embedded_child_action_id?(_), do: false
+
   defp upsert_action(actions, order, id, data) do
-    actions = Map.put(actions, id, data)
+    id = equivalent_action_id(actions, data) || id
+    actions = Map.put(actions, id, Map.put(data, :id, id))
     order = if id in order, do: order, else: order ++ [id]
 
     if length(order) > @max_actions do
@@ -486,5 +1140,4 @@ defmodule LemonRouter.ToolStatusCoalescer do
 
   defp cancel_timer(nil), do: :ok
   defp cancel_timer(timer), do: Process.cancel_timer(timer)
-
 end

--- a/apps/lemon_router/test/lemon_router/async_task_surface_test.exs
+++ b/apps/lemon_router/test/lemon_router/async_task_surface_test.exs
@@ -1,0 +1,365 @@
+defmodule LemonRouter.AsyncTaskSurfaceTest do
+  use ExUnit.Case, async: false
+
+  alias LemonRouter.AsyncTaskSurface
+
+  test "surface process can be started and located by surface_id" do
+    surface_id = unique_surface_id()
+
+    {:ok, pid} =
+      AsyncTaskSurface.ensure_started(surface_id,
+        metadata: %{parent_run_id: "parent-run-1", surface: {:status_task, "root-1"}}
+      )
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    assert pid == AsyncTaskSurface.whereis(surface_id)
+    assert [{^pid, _}] = Registry.lookup(LemonRouter.AsyncTaskSurfaceRegistry, surface_id)
+
+    assert {:ok, snapshot} = AsyncTaskSurface.get(surface_id)
+    assert snapshot.surface_id == surface_id
+    assert snapshot.status == :pending_root
+    assert snapshot.metadata.parent_run_id == "parent-run-1"
+    assert snapshot.metadata.surface == {:status_task, "root-1"}
+  end
+
+  test "redesign-aligned lifecycle requires binding before live" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    assert {:error, {:invalid_transition, :pending_root, :live}} =
+             AsyncTaskSurface.transition(surface_id, :live)
+
+    assert {:ok, bound} =
+             AsyncTaskSurface.transition(surface_id, :bound, %{
+               metadata: %{root_action_id: "tool-call-1"}
+             })
+
+    assert bound.status == :bound
+    assert bound.terminal_at_ms == nil
+    assert bound.metadata.root_action_id == "tool-call-1"
+
+    assert {:ok, live} = AsyncTaskSurface.transition(surface_id, :live)
+    assert live.status == :live
+    assert live.terminal_at_ms == nil
+
+    assert {:ok, terminal} =
+             AsyncTaskSurface.transition(surface_id, :terminal_grace, %{result: %{ok: true}})
+
+    assert terminal.status == :terminal_grace
+    assert terminal.result == %{ok: true}
+    assert is_integer(terminal.terminal_at_ms)
+    assert terminal.error == nil
+
+    assert {:ok, reaped} = AsyncTaskSurface.transition(surface_id, :reaped)
+    assert reaped.status == :reaped
+    assert reaped.result == %{ok: true}
+    assert reaped.terminal_at_ms == terminal.terminal_at_ms
+  end
+
+  test ":reaped immediately hides the stale pid and allows a fresh surface to be created" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+    ref = Process.monitor(pid)
+
+    assert {:ok, _bound} = AsyncTaskSurface.transition(surface_id, :bound)
+    assert {:ok, _live} = AsyncTaskSurface.transition(surface_id, :live)
+
+    assert {:ok, terminal} =
+             AsyncTaskSurface.transition(surface_id, :terminal_grace, %{result: :done})
+
+    assert {:ok, reaped} = AsyncTaskSurface.transition(surface_id, :reaped)
+
+    assert reaped.status == :reaped
+    assert reaped.result == :done
+    assert reaped.terminal_at_ms == terminal.terminal_at_ms
+
+    assert AsyncTaskSurface.whereis(surface_id) == nil
+
+    assert {:ok, fresh_pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(fresh_pid) do
+        GenServer.stop(fresh_pid, :normal)
+      end
+    end)
+
+    assert fresh_pid != pid
+    assert AsyncTaskSurface.whereis(surface_id) == fresh_pid
+    assert {:ok, fresh} = AsyncTaskSurface.get(surface_id)
+    assert fresh.status == :pending_root
+    assert fresh.metadata == %{}
+    assert fresh.result == nil
+    assert fresh.error == nil
+    assert fresh.terminal_at_ms == nil
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+  end
+
+  test "concurrent ensure_started waits for a fresh pid while the old reaped child is still exiting" do
+    surface_id = unique_surface_id()
+    reap_ref = make_ref()
+
+    {:ok, pid} =
+      AsyncTaskSurface.ensure_started(surface_id, reap_test_hook: {self(), reap_ref})
+
+    on_exit(fn ->
+      send(pid, {:continue_async_task_surface_reap, reap_ref})
+    end)
+
+    assert {:ok, _bound} = AsyncTaskSurface.transition(surface_id, :bound)
+    assert {:ok, _live} = AsyncTaskSurface.transition(surface_id, :live)
+    assert {:ok, _terminal} = AsyncTaskSurface.transition(surface_id, :terminal_grace)
+
+    reaped_task =
+      Task.async(fn ->
+        AsyncTaskSurface.transition(surface_id, :reaped)
+      end)
+
+    assert_receive {:async_task_surface_reap_blocked, ^surface_id, ^pid, ^reap_ref}, 1_000
+    assert [{^pid, _}] = Registry.lookup(LemonRouter.AsyncTaskSurfaceRegistry, surface_id)
+    assert AsyncTaskSurface.whereis(surface_id) == nil
+    assert Process.alive?(pid)
+
+    ensure_task =
+      Task.async(fn ->
+        AsyncTaskSurface.ensure_started(surface_id)
+      end)
+
+    assert Task.yield(ensure_task, 100) == nil
+
+    send(pid, {:continue_async_task_surface_reap, reap_ref})
+
+    assert {:ok, %{status: :reaped}} = Task.await(reaped_task, 1_000)
+    assert {:ok, fresh_pid} = Task.await(ensure_task, 1_000)
+
+    on_exit(fn ->
+      if Process.alive?(fresh_pid) do
+        GenServer.stop(fresh_pid, :normal)
+      end
+    end)
+
+    assert fresh_pid != pid
+    assert AsyncTaskSurface.whereis(surface_id) == fresh_pid
+    assert {:ok, %{status: :pending_root}} = AsyncTaskSurface.get(surface_id)
+    refute Process.alive?(pid)
+  end
+
+  test "registry and supervisor wiring reuse the same child for the same surface_id" do
+    surface_id = unique_surface_id()
+    assert Process.whereis(LemonRouter.AsyncTaskSurfaceRegistry)
+    assert Process.whereis(LemonRouter.AsyncTaskSurfaceSupervisor)
+
+    before_counts = DynamicSupervisor.count_children(LemonRouter.AsyncTaskSurfaceSupervisor)
+
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+    {:ok, same_pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    after_counts = DynamicSupervisor.count_children(LemonRouter.AsyncTaskSurfaceSupervisor)
+
+    assert pid == same_pid
+    assert after_counts.active == before_counts.active + 1
+    assert after_counts.workers == before_counts.workers + 1
+  end
+
+  test "ensure_started reuses a live surface even while it is temporarily suspended" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        _ = safe_resume(pid)
+
+        if Process.alive?(pid) do
+          GenServer.stop(pid, :normal)
+        end
+      end
+    end)
+
+    assert {:ok, _bound} =
+             AsyncTaskSurface.transition(surface_id, :bound, %{
+               metadata: %{root_action_id: "tool-call-1"}
+             })
+
+    assert {:ok, _live} = AsyncTaskSurface.transition(surface_id, :live)
+    assert :ok = :sys.suspend(pid)
+
+    try do
+      assert AsyncTaskSurface.whereis(surface_id) == pid
+      assert {:ok, ^pid} = AsyncTaskSurface.ensure_started(surface_id)
+    after
+      assert :ok = :sys.resume(pid)
+    end
+  end
+
+  test "duplicate bound transitions preserve the first identity metadata" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    assert {:ok, bound} =
+             AsyncTaskSurface.transition(surface_id, :bound, %{
+               metadata: %{parent_run_id: "parent-run-1", root_action_id: "tool-call-1"}
+             })
+
+    assert {:ok, duplicate} =
+             AsyncTaskSurface.transition(surface_id, :bound, %{
+               metadata: %{parent_run_id: "parent-run-2", root_action_id: "tool-call-2"}
+             })
+
+    assert duplicate == bound
+    assert duplicate.metadata == %{parent_run_id: "parent-run-1", root_action_id: "tool-call-1"}
+  end
+
+  test "duplicate terminal transitions preserve the first payload" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    assert {:ok, _bound} = AsyncTaskSurface.transition(surface_id, :bound)
+    assert {:ok, _live} = AsyncTaskSurface.transition(surface_id, :live)
+
+    assert {:ok, terminal} =
+             AsyncTaskSurface.transition(surface_id, :terminal_grace, %{error: :timeout})
+
+    assert {:ok, duplicate} =
+             AsyncTaskSurface.transition(surface_id, :terminal_grace, %{result: %{ok: true}})
+
+    assert terminal.status == :terminal_grace
+    assert terminal.error == :timeout
+    assert terminal.result == nil
+    assert is_integer(terminal.terminal_at_ms)
+
+    assert duplicate == terminal
+  end
+
+  test "duplicate live transitions enrich task metadata without rewriting surface identity" do
+    surface_id = unique_surface_id()
+    surface = {:status_task, "task-surface-live-enrichment"}
+
+    {:ok, pid} =
+      AsyncTaskSurface.ensure_started(surface_id,
+        metadata: %{
+          surface_id: surface_id,
+          surface: surface,
+          root_action_id: "task-root-live-enrichment",
+          parent_run_id: "parent-run-1",
+          session_key: "session-1"
+        }
+      )
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    assert {:ok, _bound} = AsyncTaskSurface.transition(surface_id, :bound)
+    assert {:ok, live} = AsyncTaskSurface.transition(surface_id, :live)
+    assert live.metadata[:task_id] == nil
+    assert :error = AsyncTaskSurface.lookup_identity_by_task_id("task-live-enrichment-1")
+
+    assert {:ok, enriched_live} =
+             AsyncTaskSurface.transition(surface_id, :live, %{
+               metadata: %{
+                 surface_id: "wrong-surface-id",
+                 surface: {:status_task, "wrong-surface"},
+                 root_action_id: "wrong-root-action-id",
+                 parent_run_id: "parent-run-2",
+                 session_key: "session-2",
+                 task_id: "task-live-enrichment-1",
+                 task_ids: ["task-live-enrichment-1"]
+               }
+             })
+
+    assert enriched_live.status == :live
+    assert enriched_live.metadata.surface_id == surface_id
+    assert enriched_live.metadata.surface == surface
+    assert enriched_live.metadata.root_action_id == "task-root-live-enrichment"
+    assert enriched_live.metadata.parent_run_id == "parent-run-1"
+    assert enriched_live.metadata.session_key == "session-1"
+    assert enriched_live.metadata.task_id == "task-live-enrichment-1"
+    assert enriched_live.metadata.task_ids == ["task-live-enrichment-1"]
+
+    assert {:ok,
+            %{
+              surface_id: ^surface_id,
+              surface: ^surface,
+              root_action_id: "task-root-live-enrichment"
+            }} = AsyncTaskSurface.lookup_identity_by_task_id("task-live-enrichment-1")
+  end
+
+  test "stale pid inputs return not_found instead of crashing" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+    GenServer.stop(pid, :normal)
+
+    assert {:error, :not_found} = AsyncTaskSurface.get(pid)
+    assert {:error, :not_found} = AsyncTaskSurface.transition(pid, :bound)
+  end
+
+  test "invalid startup metadata returns an actionable error and does not register a surface" do
+    surface_id = unique_surface_id()
+
+    assert {:error, {:invalid_metadata, :expected_map_or_key_value_list}} =
+             AsyncTaskSurface.ensure_started(surface_id, metadata: "bad")
+
+    assert AsyncTaskSurface.whereis(surface_id) == nil
+    assert Registry.lookup(LemonRouter.AsyncTaskSurfaceRegistry, surface_id) == []
+  end
+
+  test "invalid transition metadata returns an actionable error without crashing the server" do
+    surface_id = unique_surface_id()
+    {:ok, pid} = AsyncTaskSurface.ensure_started(surface_id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    assert {:error, {:invalid_metadata, :expected_map_or_key_value_list}} =
+             AsyncTaskSurface.transition(surface_id, :bound, %{metadata: "bad"})
+
+    assert Process.alive?(pid)
+    assert {:ok, snapshot} = AsyncTaskSurface.get(surface_id)
+    assert snapshot.status == :pending_root
+    assert snapshot.metadata == %{}
+  end
+
+  defp unique_surface_id do
+    "async-task-surface-#{System.unique_integer([:positive, :monotonic])}"
+  end
+
+  defp safe_resume(pid) do
+    :sys.resume(pid)
+  catch
+    :exit, _reason -> :ok
+  end
+end

--- a/apps/lemon_router/test/lemon_router/run_process_test.exs
+++ b/apps/lemon_router/test/lemon_router/run_process_test.exs
@@ -13,6 +13,7 @@ defmodule LemonRouter.RunProcessTest do
   alias LemonCore.{ChatStateStore, RunRequest, SessionKey}
   alias LemonCore.ResumeToken
   alias Elixir.LemonRouter.RunProcess
+  alias LemonRouter.AsyncTaskSurface
   alias LemonRouter.PendingCompactionStore
 
   defmodule RunProcessTestOutboxAPI do
@@ -122,6 +123,19 @@ defmodule LemonRouter.RunProcessTest do
     end
   end
 
+  defmodule WatchdogRuntimeStub do
+    @moduledoc false
+
+    def cancel_by_run_id(run_id, reason) do
+      case :persistent_term.get({__MODULE__, :notify_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:watchdog_runtime_cancel, run_id, reason})
+        _ -> :ok
+      end
+
+      :ok
+    end
+  end
+
   setup do
     # Ensure PubSub is running for LemonCore.Bus.
     if is_nil(Process.whereis(LemonCore.PubSub)) do
@@ -159,6 +173,17 @@ defmodule LemonRouter.RunProcessTest do
       DynamicSupervisor.start_link(
         strategy: :one_for_one,
         name: Elixir.LemonRouter.ToolStatusSupervisor
+      )
+    end)
+
+    start_if_needed(LemonRouter.AsyncTaskSurfaceRegistry, fn ->
+      Registry.start_link(keys: :unique, name: LemonRouter.AsyncTaskSurfaceRegistry)
+    end)
+
+    start_if_needed(LemonRouter.AsyncTaskSurfaceSupervisor, fn ->
+      DynamicSupervisor.start_link(
+        strategy: :one_for_one,
+        name: LemonRouter.AsyncTaskSurfaceSupervisor
       )
     end)
 
@@ -304,10 +329,173 @@ defmodule LemonRouter.RunProcessTest do
     end
   end
 
+  defp payload_text(%{text: text}) when is_binary(text), do: text
+  defp payload_text(text) when is_binary(text), do: text
+
   describe "abort/2" do
     test "abort by non-existent run_id returns :ok" do
       # Abort on non-existent run should be safe
       assert :ok = RunProcess.abort("non-existent-run", :test_abort)
+    end
+
+    test "aborted run without a gateway pid synthesizes completion and exits" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+      job = make_test_job(run_id)
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      assert :ok = RunProcess.abort(pid, :test_abort)
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{ok: false, error: :test_abort}},
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     1_500
+
+      assert eventually(fn -> not Process.alive?(pid) end)
+    end
+
+    test "abort fallback stays single-shot when other completion fallbacks are also queued" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+      job = make_test_job(run_id)
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(
+            :run_started,
+            %{run_id: run_id},
+            %{run_id: run_id, session_key: session_key}
+          )
+        )
+
+      assert :ok = RunProcess.abort(pid, :test_abort)
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{ok: false, error: :test_abort}},
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     1_500
+
+      refute_receive %LemonCore.Event{type: :run_completed}, 2_000
+      assert eventually(fn -> not Process.alive?(pid) end)
+    end
+  end
+
+  describe "run_started without gateway binding" do
+    test "late run_completed beats synthetic missing-gateway failure" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+      job = make_test_job(run_id)
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(
+            :run_started,
+            %{run_id: run_id},
+            %{run_id: run_id, session_key: session_key}
+          )
+        )
+
+      Process.sleep(300)
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(
+            :run_completed,
+            %{
+              completed: %{ok: true, answer: "done"},
+              duration_ms: 123
+            },
+            %{run_id: run_id, session_key: session_key}
+          )
+        )
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{ok: true, answer: "done"}},
+                       meta: %{run_id: ^run_id, session_key: ^session_key}
+                     },
+                     1_500
+
+      refute_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{error: :gateway_run_missing_after_start}}
+                     },
+                     1_700
+
+      assert eventually(fn -> not Process.alive?(pid) end)
+    end
+
+    test "started run without a gateway pid synthesizes completion and exits" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+      job = make_test_job(run_id)
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(
+            :run_started,
+            %{run_id: run_id},
+            %{run_id: run_id, session_key: session_key}
+          )
+        )
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{
+                         completed: %{ok: false, error: :gateway_run_missing_after_start}
+                       },
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     2_500
+
+      assert eventually(fn -> not Process.alive?(pid) end)
     end
   end
 
@@ -367,14 +555,1128 @@ defmodule LemonRouter.RunProcessTest do
       assert :ok = RunProcess.abort(pid, :test_abort)
 
       assert eventually(fn ->
-               state = :sys.get_state(pid)
-               state.aborted == true
+               if Process.alive?(pid) do
+                 state = :sys.get_state(pid)
+                 state.aborted == true
+               else
+                 true
+               end
              end)
 
       {:ok, _scheduler_pid} = start_supervised({TestScheduler, [notify_pid: self()]})
 
       refute_receive {:test_scheduler_submit, %LemonGateway.ExecutionRequest{run_id: ^run_id}},
                      400
+
+      if Process.alive?(pid), do: GenServer.stop(pid)
+    end
+
+    test "projected child task actions attach to the existing task surface" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_root_projected"}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_projected",
+              kind: "subagent",
+              title: "task(codex): review fix",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_started)
+
+      projected_child =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_1:read_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{
+                parent_tool_use_id: "task_root_projected",
+                child_run_id: "child_run_1",
+                task_id: "task-store-1"
+              }
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), projected_child)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   state = :sys.get_state(status_pid)
+
+                   Enum.any?(Map.values(state.actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == "task_root_projected" and
+                       action[:title] == "Read: AGENTS.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: kind,
+                        content: content,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert kind in [:text, :edit]
+
+      task_text =
+        case content do
+          %{text: text} -> text
+          text when is_binary(text) -> text
+        end
+
+      assert String.contains?(task_text, "task(codex): review fix")
+      assert String.contains?(task_text, "Read: AGENTS.md")
+
+      refute eventually(fn ->
+               Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", :status}) !=
+                 []
+             end)
+
+      GenServer.stop(pid)
+    end
+
+    test "projected child actions honor explicit surface metadata without prior parent reconstruction" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_root_meta"}
+
+      projected_child =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_meta:read_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{
+                child_run_id: "child_run_meta",
+                task_id: "task-store-meta"
+              }
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{
+            run_id: run_id,
+            session_key: session_key,
+            surface: task_surface,
+            root_action_id: "task_root_meta"
+          }
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), projected_child)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   state = :sys.get_state(status_pid)
+
+                   case Map.get(state.actions, "taskproj:child_run_meta:read_1") do
+                     %{detail: %{parent_tool_use_id: "task_root_meta", surface: ^task_surface}} ->
+                       true
+
+                     _ ->
+                       false
+                   end
+
+                 _ ->
+                   false
+               end
+             end)
+
+      refute eventually(fn ->
+               Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", :status}) !=
+                 []
+             end)
+
+      GenServer.stop(pid)
+    end
+
+    test "explicit projected-child metadata seeds reusable bindings for later poll follow-up events" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_root_meta_followup"}
+
+      projected_child =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_meta_followup:read_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{
+                child_run_id: "child_run_meta_followup",
+                task_id: "task-store-meta-followup"
+              }
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{
+            run_id: run_id,
+            session_key: session_key,
+            surface: task_surface,
+            root_action_id: "task_root_meta_followup"
+          }
+        )
+
+      poll_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_poll_meta_followup_1",
+              kind: "subagent",
+              title: "task: poll review",
+              detail: %{
+                name: "task",
+                args: %{"action" => "poll", "task_id" => "task-store-meta-followup"},
+                result_meta: %{
+                  task_id: "task-store-meta-followup",
+                  status: "running",
+                  engine: "codex",
+                  current_action: %{title: "Write: report.md", kind: "tool", phase: "completed"}
+                }
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), projected_child)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), poll_completed)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   state = :sys.get_state(status_pid)
+
+                   Enum.any?(Map.values(state.actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == "task_root_meta_followup" and
+                       action[:title] == "Write: report.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert eventually(fn ->
+               state = :sys.get_state(pid)
+
+               state.task_status_surfaces["task_root_meta_followup"] == %{
+                 surface_id: "task_root_meta_followup",
+                 surface: task_surface,
+                 root_action_id: "task_root_meta_followup"
+               } and
+                 state.task_status_refs["task-store-meta-followup"] == %{
+                   surface_id: "task_root_meta_followup",
+                   surface: task_surface,
+                   root_action_id: "task_root_meta_followup"
+                 }
+             end)
+
+      refute eventually(fn ->
+               Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", :status}) !=
+                 []
+             end)
+
+      GenServer.stop(pid)
+    end
+
+    test "persisted projected-child rebinding honors explicit surface metadata when surface_id differs from root_action_id" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      root_run_id = "run_#{System.unique_integer([:positive])}"
+      root_job = make_test_job(root_run_id, %{progress_msg_id: 111, user_msg_id: 222})
+
+      assert {:ok, root_pid} =
+               RunProcess.start_link(%{
+                 run_id: root_run_id,
+                 session_key: session_key,
+                 job: root_job,
+                 submit_to_gateway?: false
+               })
+
+      surface_id = "task_surface_meta_cross_run"
+      task_surface = {:status_task, surface_id}
+      root_action_id = "task_root_meta_cross_run"
+
+      projected_child =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_meta_cross_run:read_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{child_run_id: "child_run_meta_cross_run"}
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{
+            run_id: root_run_id,
+            session_key: session_key,
+            surface: task_surface,
+            root_action_id: root_action_id
+          }
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), projected_child)
+
+      assert eventually(fn ->
+               case AsyncTaskSurface.get(surface_id) do
+                 {:ok, snapshot} ->
+                   snapshot.status == :live and
+                     snapshot.metadata.surface == task_surface and
+                     snapshot.metadata.root_action_id == root_action_id
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert root_surface_pid = AsyncTaskSurface.whereis(surface_id)
+      GenServer.stop(root_pid)
+
+      followup_run_id = "run_#{System.unique_integer([:positive])}"
+      followup_job = make_test_job(followup_run_id, %{progress_msg_id: 333, user_msg_id: 444})
+
+      assert {:ok, followup_pid} =
+               RunProcess.start_link(%{
+                 run_id: followup_run_id,
+                 session_key: session_key,
+                 job: followup_job,
+                 submit_to_gateway?: false
+               })
+
+      persisted_followup =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_meta_cross_run:write_1",
+              kind: "tool",
+              title: "Write: report.md",
+              detail: %{child_run_id: "child_run_meta_cross_run"}
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{
+            run_id: followup_run_id,
+            session_key: session_key,
+            root_action_id: root_action_id
+          }
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(followup_run_id), persisted_followup)
+
+      assert AsyncTaskSurface.whereis(surface_id) == root_surface_pid
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   Enum.any?(Map.values(:sys.get_state(status_pid).actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == root_action_id and
+                       action[:title] == "Write: report.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      refute eventually(fn ->
+               Registry.lookup(
+                 LemonRouter.ToolStatusRegistry,
+                 {session_key, "telegram", {:status_task, root_action_id}}
+               ) != []
+             end)
+
+      assert eventually(fn ->
+               state = :sys.get_state(followup_pid)
+
+               state.task_status_surfaces[root_action_id] == %{
+                 surface_id: surface_id,
+                 surface: task_surface,
+                 root_action_id: root_action_id
+               }
+             end)
+
+      GenServer.stop(followup_pid)
+    end
+
+    test "root-action-first projected child metadata overrides the default task surface across runs" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      root_run_id = "run_#{System.unique_integer([:positive])}"
+      root_job = make_test_job(root_run_id, %{progress_msg_id: 111, user_msg_id: 222})
+
+      assert {:ok, root_pid} =
+               RunProcess.start_link(%{
+                 run_id: root_run_id,
+                 session_key: session_key,
+                 job: root_job,
+                 submit_to_gateway?: false
+               })
+
+      root_action_id = "task_root_override_late"
+      surface_id = "task_surface_override_late"
+      task_surface = {:status_task, surface_id}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: root_action_id,
+              kind: "subagent",
+              title: "task(codex): inspect repo",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: root_run_id, session_key: session_key}
+        )
+
+      projected_child =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_override_late:read_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{
+                child_run_id: "child_run_override_late",
+                task_id: "task-store-override-late"
+              }
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{
+            run_id: root_run_id,
+            session_key: session_key,
+            surface: task_surface,
+            root_action_id: root_action_id
+          }
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), task_started)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), projected_child)
+
+      assert eventually(fn ->
+               state = :sys.get_state(root_pid)
+               identity = state.task_status_surfaces[root_action_id]
+
+               is_map(identity) and identity.surface_id == surface_id and
+                 identity.surface == task_surface and identity.root_action_id == root_action_id
+             end)
+
+      assert eventually(fn ->
+               AsyncTaskSurface.lookup_identity_by_root_action_id(root_action_id) ==
+                 {:ok,
+                  %{
+                    surface_id: surface_id,
+                    surface: task_surface,
+                    root_action_id: root_action_id
+                  }}
+             end)
+
+      GenServer.stop(root_pid)
+
+      followup_run_id = "run_#{System.unique_integer([:positive])}"
+      followup_job = make_test_job(followup_run_id, %{progress_msg_id: 333, user_msg_id: 444})
+
+      assert {:ok, followup_pid} =
+               RunProcess.start_link(%{
+                 run_id: followup_run_id,
+                 session_key: session_key,
+                 job: followup_job,
+                 submit_to_gateway?: false
+               })
+
+      persisted_followup =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_override_late:write_1",
+              kind: "tool",
+              title: "Write: summary.md",
+              detail: %{child_run_id: "child_run_override_late"}
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{
+            run_id: followup_run_id,
+            session_key: session_key,
+            root_action_id: root_action_id
+          }
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(followup_run_id), persisted_followup)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   Enum.any?(Map.values(:sys.get_state(status_pid).actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == root_action_id and
+                       action[:title] == "Write: summary.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert eventually(fn ->
+               state = :sys.get_state(followup_pid)
+
+               state.task_status_surfaces[root_action_id] == %{
+                 surface_id: surface_id,
+                 surface: task_surface,
+                 root_action_id: root_action_id
+               }
+             end)
+
+      GenServer.stop(followup_pid)
+    end
+
+    test "projected child actions bind to their task surface out of order, broadcast to the session, and track files" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      prefix = "Inspecting the projected task"
+      task_surface = {:status_task, "task_root_out_of_order"}
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(:delta, %{seq: 1, text: prefix}, %{
+            run_id: run_id,
+            session_key: session_key
+          })
+        )
+
+      assert eventually(fn ->
+               case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, "telegram"}) do
+                 [{coalescer_pid, _}] -> :sys.get_state(coalescer_pid).last_seq == 1
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.StreamCoalescer.flush(session_key, "telegram")
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: :text,
+                        content: ^prefix,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      projected_started =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_1:read_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{
+                parent_tool_use_id: "task_root_out_of_order",
+                child_run_id: "child_run_1",
+                task_id: "task-store-1"
+              }
+            },
+            phase: :started,
+            ok: nil,
+            message: nil,
+            level: nil
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), projected_started)
+
+      assert_receive %LemonCore.Event{
+                       type: :task_projected_child_action,
+                       payload: %{
+                         action: %{detail: %{parent_tool_use_id: "task_root_out_of_order"}}
+                       },
+                       meta: %{run_id: ^run_id, session_key: ^session_key}
+                     },
+                     1_500
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   "taskproj:child_run_1:read_1" in :sys.get_state(status_pid).order
+
+                 _ ->
+                   false
+               end
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: task_kind,
+                        content: task_content,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert task_kind in [:text, :edit]
+      task_text = payload_text(task_content)
+
+      assert String.contains?(task_text, prefix)
+      assert String.contains?(task_text, "Read: AGENTS.md")
+
+      projected_file_change =
+        LemonCore.Event.new(
+          :task_projected_child_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "taskproj:child_run_1:file_1",
+              kind: "file_change",
+              title: "Write review summary",
+              detail: %{
+                parent_tool_use_id: "task_root_out_of_order",
+                child_run_id: "child_run_1",
+                task_id: "task-store-1",
+                changes: [
+                  %{path: "artifacts/chart.png", kind: "added"},
+                  %{path: "notes.txt", kind: "added"}
+                ],
+                result_meta: %{
+                  auto_send_files: [
+                    %{path: "workspace/report.txt", filename: "report.txt", caption: "Review"}
+                  ]
+                }
+              }
+            },
+            phase: :completed,
+            ok: true,
+            message: nil,
+            level: nil
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), projected_file_change)
+
+      assert eventually(fn ->
+               state = :sys.get_state(pid)
+
+               state.generated_image_paths == ["artifacts/chart.png"] and
+                 state.requested_send_files == [
+                   %{path: "workspace/report.txt", filename: "report.txt", caption: "Review"}
+                 ]
+             end)
+
+      refute eventually(fn ->
+               Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", :status}) !=
+                 []
+             end)
+
+      GenServer.stop(pid)
+    end
+
+    test "stream handoff preserves the task surface binding on the task-scoped coalescer" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      prefix = "Inspecting the task handoff"
+      task_surface = {:status_task, "task_root_handoff_binding"}
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(:delta, %{seq: 1, text: prefix}, %{
+            run_id: run_id,
+            session_key: session_key
+          })
+        )
+
+      assert eventually(fn ->
+               case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, "telegram"}) do
+                 [{coalescer_pid, _}] -> :sys.get_state(coalescer_pid).last_seq == 1
+                 _ -> false
+               end
+             end)
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_handoff_binding",
+              kind: "subagent",
+              title: "task(codex): inspect repo",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_started)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   :sys.get_state(status_pid).surface_binding == %{
+                     surface_id: "task_root_handoff_binding",
+                     surface: task_surface,
+                     root_action_id: "task_root_handoff_binding"
+                   }
+
+                 _ ->
+                   false
+               end
+             end)
 
       GenServer.stop(pid)
     end
@@ -532,6 +1834,268 @@ defmodule LemonRouter.RunProcessTest do
                      1_500
 
       assert eventually(fn -> not Process.alive?(pid) end)
+    end
+
+    test "two idle watchdog cycles on the same telegram run produce two visible prompts" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "default",
+          peer_kind: :group,
+          peer_id: "12345",
+          thread_id: "778"
+        })
+
+      job = make_test_job(run_id)
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false,
+                 run_watchdog_timeout_ms: 40,
+                 run_watchdog_confirm_timeout_ms: 250
+               })
+
+      started_event =
+        LemonCore.Event.new(
+          :run_started,
+          %{run_id: run_id, session_key: session_key, engine: "echo"},
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), started_event)
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: first_kind,
+                        content: first_content,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert first_kind in [:text, :edit]
+      assert payload_text(first_content) =~ "Keep waiting?"
+
+      RunProcess.keep_alive(run_id, :continue)
+
+      assert eventually(
+               fn ->
+                 st = :sys.get_state(pid)
+                 st.run_watchdog_awaiting_confirmation? == false
+               end,
+               1_000
+             )
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: second_kind,
+                        content: second_content,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert second_kind in [:text, :edit]
+      assert payload_text(second_content) =~ "Keep waiting?"
+
+      st = :sys.get_state(pid)
+      assert st.run_watchdog_prompt_seq == 2
+
+      RunProcess.keep_alive(run_id, :cancel)
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{ok: false, error: :user_requested}},
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     1_500
+
+      assert eventually(fn -> not Process.alive?(pid) end)
+    end
+
+    test "watchdog user cancel preserves :user_requested runtime cancel reason" do
+      previous_runtime = Application.get_env(:lemon_router, :watchdog_runtime)
+      Application.put_env(:lemon_router, :watchdog_runtime, __MODULE__.WatchdogRuntimeStub)
+      :persistent_term.put({__MODULE__.WatchdogRuntimeStub, :notify_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({__MODULE__.WatchdogRuntimeStub, :notify_pid})
+
+        if is_nil(previous_runtime) do
+          Application.delete_env(:lemon_router, :watchdog_runtime)
+        else
+          Application.put_env(:lemon_router, :watchdog_runtime, previous_runtime)
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "default",
+          peer_kind: :group,
+          peer_id: "12345",
+          thread_id: "779"
+        })
+
+      job = make_test_job(run_id)
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.session_topic(session_key))
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false,
+                 run_watchdog_timeout_ms: 40,
+                 run_watchdog_confirm_timeout_ms: 120
+               })
+
+      started_event =
+        LemonCore.Event.new(
+          :run_started,
+          %{run_id: run_id, session_key: session_key, engine: "echo"},
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), started_event)
+
+      assert eventually(
+               fn ->
+                 st = :sys.get_state(pid)
+                 st.run_watchdog_awaiting_confirmation? == true
+               end,
+               1_000
+             )
+
+      RunProcess.keep_alive(run_id, :cancel)
+
+      assert_receive {:watchdog_runtime_cancel, ^run_id, :user_requested}, 1_500
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{ok: false, error: :user_requested}},
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     1_500
+
+      assert eventually(fn -> not Process.alive?(pid) end)
+    end
+
+    test "watchdog cancel path keeps synthetic completion state across a later timeout signal" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.run_topic(run_id))
+
+      state = %{
+        run_id: run_id,
+        session_key: session_key,
+        completed: false,
+        aborted: false,
+        run_watchdog_timeout_ms: 40,
+        run_watchdog_confirmation_ref: nil,
+        run_watchdog_awaiting_confirmation?: true,
+        synthetic_completion_sent?: false
+      }
+
+      assert {:noreply, next_state} =
+               RunProcess.handle_cast({:watchdog_keep_alive, :cancel}, state)
+
+      assert next_state.synthetic_completion_sent?
+      refute next_state.run_watchdog_awaiting_confirmation?
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{completed: %{ok: false, error: :user_requested}},
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     1_500
+
+      assert {:noreply, final_state} =
+               RunProcess.handle_info(:run_watchdog_confirmation_timeout, next_state)
+
+      assert final_state.synthetic_completion_sent?
+      refute_receive %LemonCore.Event{type: :run_completed}, 100
+    end
+
+    test "watchdog timeout path keeps synthetic completion state across a later fallback" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+
+      LemonCore.Bus.subscribe(LemonCore.Bus.run_topic(run_id))
+
+      state = %{
+        run_id: run_id,
+        session_key: session_key,
+        completed: false,
+        aborted: false,
+        run_watchdog_timeout_ms: 40,
+        run_watchdog_confirmation_ref: nil,
+        run_watchdog_awaiting_confirmation?: false,
+        synthetic_completion_sent?: false
+      }
+
+      assert {:noreply, next_state} =
+               RunProcess.handle_info(:run_watchdog_confirmation_timeout, state)
+
+      assert next_state.synthetic_completion_sent?
+
+      assert_receive %LemonCore.Event{
+                       type: :run_completed,
+                       payload: %{
+                         completed: %{ok: false, error: {:run_idle_watchdog_timeout, 40}}
+                       },
+                       meta: %{run_id: ^run_id, session_key: ^session_key, synthetic: true}
+                     },
+                     1_500
+
+      assert {:noreply, final_state} =
+               RunProcess.handle_info({:gateway_run_down, :watchdog_followup}, next_state)
+
+      assert final_state.synthetic_completion_sent?
+      refute_receive %LemonCore.Event{type: :run_completed}, 100
     end
   end
 
@@ -742,6 +2306,1267 @@ defmodule LemonRouter.RunProcessTest do
 
       assert eventually(fn -> not Process.alive?(pid) end)
       assert eventually(fn -> ChatStateStore.get(session_key) == nil end)
+    end
+  end
+
+  describe "task tool status routing" do
+    test "task child actions stay attached to the parent task surface after later assistant text" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ =
+          :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      prefix = "Found the key files. Let me read the markdown renderer and the formatter:"
+      task_surface = {:status_task, "task_1"}
+
+      delta_event_1 =
+        LemonCore.Event.new(
+          :delta,
+          %{seq: 1, text: prefix},
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), delta_event_1)
+
+      assert eventually(fn ->
+               case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, "telegram"}) do
+                 [{coalescer_pid, _}] -> :sys.get_state(coalescer_pid).last_seq == 1
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.StreamCoalescer.flush(session_key, "telegram")
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: :text,
+                        content: ^prefix,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      task_start_event =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_1",
+              kind: "subagent",
+              title: "task(claude): inspect repo",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_start_event)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] -> "task_1" in :sys.get_state(status_pid).order
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: task_kind,
+                        content: task_content,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert task_kind in [:text, :edit]
+      task_text = payload_text(task_content)
+
+      assert String.contains?(task_text, prefix)
+      assert String.contains?(task_text, "task(claude): inspect repo")
+
+      separate = "Separate answer chunk"
+
+      delta_event_2 =
+        LemonCore.Event.new(
+          :delta,
+          %{seq: 2, text: separate},
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), delta_event_2)
+
+      assert eventually(fn ->
+               case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, "telegram"}) do
+                 [{coalescer_pid, _}] -> :sys.get_state(coalescer_pid).last_seq == 2
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.StreamCoalescer.flush(session_key, "telegram")
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: :text,
+                        content: ^separate,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      task_child_event =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "claude",
+            action: %{
+              id: "task_child_1",
+              kind: "command",
+              title: "pwd",
+              detail: %{parent_tool_use_id: "task_1"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_child_event)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] -> "task_child_1" in :sys.get_state(status_pid).order
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: :edit,
+                        content: %{text: task_child_text},
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert String.contains?(task_child_text, prefix)
+      assert String.contains?(task_child_text, "task(claude): inspect repo")
+      assert String.contains?(task_child_text, "pwd")
+      refute String.contains?(task_child_text, separate)
+
+      GenServer.stop(pid)
+    end
+
+    test "parent completion does not recreate a reaped task surface" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job = make_test_job(run_id, %{progress_msg_id: 111, user_msg_id: 222})
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_reaped_before_parent_done"}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_reaped_before_parent_done",
+              kind: "subagent",
+              title: "task(codex): inspect repo",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      task_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_reaped_before_parent_done",
+              kind: "subagent",
+              title: "task(codex): inspect repo",
+              detail: %{name: "task"}
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_started)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_completed)
+
+      assert eventually(fn ->
+               Registry.lookup(
+                 LemonRouter.ToolStatusRegistry,
+                 {session_key, "telegram", task_surface}
+               ) != []
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      [{task_pid, _}] =
+        Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", task_surface})
+
+      task_state = :sys.get_state(task_pid)
+      assert is_reference(task_state.reap_token)
+
+      task_ref = Process.monitor(task_pid)
+      send(task_pid, {:reap_if_idle, task_state.reap_token})
+      assert_receive {:DOWN, ^task_ref, :process, ^task_pid, :normal}, 500
+
+      assert eventually(fn ->
+               state = :sys.get_state(pid)
+               state.task_status_surfaces == %{}
+             end)
+
+      completed_event =
+        LemonCore.Event.new(
+          :run_completed,
+          %{completed: %{ok: true, answer: "done"}},
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), completed_event)
+
+      assert eventually(fn -> not Process.alive?(pid) end)
+
+      assert [] ==
+               Registry.lookup(
+                 LemonRouter.ToolStatusRegistry,
+                 {session_key, "telegram", task_surface}
+               )
+    end
+
+    test "async task poll actions bind by detail.task_id" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_root_detail"}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_detail",
+              kind: "subagent",
+              title: "task(codex): review fix",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      task_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_detail",
+              kind: "subagent",
+              title: "task(codex): review fix",
+              detail: %{
+                name: "task",
+                result: "Task queued: review fix (task-store-detail-1)",
+                result_meta: %{status: "queued", run_id: "child_run_detail_1"},
+                task_id: "task-store-detail-1"
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      poll_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_poll_detail_1",
+              kind: "subagent",
+              title: "task: poll review",
+              detail: %{
+                name: "task",
+                args: %{"action" => "poll"},
+                task_id: "task-store-detail-1",
+                result_meta: %{
+                  status: "running",
+                  engine: "codex",
+                  current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "completed"}
+                }
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_started)
+
+      assert eventually(fn ->
+               case AsyncTaskSurface.get("task_root_detail") do
+                 {:ok, snapshot} ->
+                   snapshot.status == :bound and
+                     snapshot.metadata.surface_id == "task_root_detail" and
+                     snapshot.metadata.root_action_id == "task_root_detail" and
+                     snapshot.metadata.surface == task_surface and
+                     snapshot.metadata.parent_run_id == run_id
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert root_surface_pid = AsyncTaskSurface.whereis("task_root_detail")
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_completed)
+
+      assert eventually(fn ->
+               case AsyncTaskSurface.get("task_root_detail") do
+                 {:ok, snapshot} -> snapshot.status == :live
+                 _ -> false
+               end
+             end)
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), poll_completed)
+
+      assert AsyncTaskSurface.whereis("task_root_detail") == root_surface_pid
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   Enum.any?(Map.values(:sys.get_state(status_pid).actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == "task_root_detail" and
+                       action[:title] == "Read: AGENTS.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert eventually(fn ->
+               state = :sys.get_state(pid)
+
+               state.task_status_surfaces["task_root_detail"] == %{
+                 surface_id: "task_root_detail",
+                 surface: task_surface,
+                 root_action_id: "task_root_detail"
+               } and
+                 state.task_status_refs["task-store-detail-1"] == %{
+                   surface_id: "task_root_detail",
+                   surface: task_surface,
+                   root_action_id: "task_root_detail"
+                 }
+             end)
+
+      GenServer.stop(pid)
+    end
+
+    test "async task poll actions reuse router-owned task-root identity across runs" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      root_run_id = "run_#{System.unique_integer([:positive])}"
+      root_job = make_test_job(root_run_id, %{progress_msg_id: 111, user_msg_id: 222})
+
+      assert {:ok, root_pid} =
+               RunProcess.start_link(%{
+                 run_id: root_run_id,
+                 session_key: session_key,
+                 job: root_job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_root_cross_run"}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_cross_run",
+              kind: "subagent",
+              title: "task(codex): cross run review",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: root_run_id, session_key: session_key}
+        )
+
+      task_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_cross_run",
+              kind: "subagent",
+              title: "task(codex): cross run review",
+              detail: %{
+                name: "task",
+                result: "Task queued: cross run review (task-store-cross-run-1)",
+                result_meta: %{task_id: "task-store-cross-run-1", status: "queued"},
+                task_id: "task-store-cross-run-1"
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: root_run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), task_started)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), task_completed)
+
+      assert eventually(fn ->
+               case AsyncTaskSurface.get("task_root_cross_run") do
+                 {:ok, snapshot} ->
+                   snapshot.status == :live and
+                     snapshot.metadata.task_ids == ["task-store-cross-run-1"]
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert root_surface_pid = AsyncTaskSurface.whereis("task_root_cross_run")
+      GenServer.stop(root_pid)
+
+      poll_run_id = "run_#{System.unique_integer([:positive])}"
+      poll_job = make_test_job(poll_run_id, %{progress_msg_id: 333, user_msg_id: 444})
+
+      assert {:ok, poll_pid} =
+               RunProcess.start_link(%{
+                 run_id: poll_run_id,
+                 session_key: session_key,
+                 job: poll_job,
+                 submit_to_gateway?: false
+               })
+
+      poll_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_poll_cross_run_1",
+              kind: "subagent",
+              title: "task: poll cross run review",
+              detail: %{
+                name: "task",
+                args: %{"action" => "poll", "task_id" => "task-store-cross-run-1"},
+                result_meta: %{
+                  task_id: "task-store-cross-run-1",
+                  engine: "codex",
+                  current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "completed"}
+                }
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: poll_run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(poll_run_id), poll_completed)
+
+      assert AsyncTaskSurface.whereis("task_root_cross_run") == root_surface_pid
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   Enum.any?(Map.values(:sys.get_state(status_pid).actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == "task_root_cross_run" and
+                       action[:title] == "Read: AGENTS.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      assert eventually(fn ->
+               state = :sys.get_state(poll_pid)
+
+               state.task_status_refs["task-store-cross-run-1"] == %{
+                 surface_id: "task_root_cross_run",
+                 surface: task_surface,
+                 root_action_id: "task_root_cross_run"
+               }
+             end)
+
+      GenServer.stop(poll_pid)
+    end
+
+    test "late parent-linked task_id enrichment persists across run exit and follow-up polls" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      root_run_id = "run_#{System.unique_integer([:positive])}"
+      root_job = make_test_job(root_run_id, %{progress_msg_id: 111, user_msg_id: 222})
+
+      assert {:ok, root_pid} =
+               RunProcess.start_link(%{
+                 run_id: root_run_id,
+                 session_key: session_key,
+                 job: root_job,
+                 submit_to_gateway?: false
+               })
+
+      root_action_id = "task_root_parent_task_id"
+      task_id = "task-store-parent-task-id"
+      task_surface = {:status_task, root_action_id}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: root_action_id,
+              kind: "subagent",
+              title: "task(codex): inspect repo",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: root_run_id, session_key: session_key}
+        )
+
+      child_action =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "codex",
+            action: %{
+              id: "task_child_parent_task_id_1",
+              kind: "tool",
+              title: "Read: AGENTS.md",
+              detail: %{
+                parent_tool_use_id: root_action_id,
+                task_id: task_id
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: root_run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), task_started)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(root_run_id), child_action)
+
+      assert eventually(fn ->
+               case AsyncTaskSurface.get(root_action_id) do
+                 {:ok, snapshot} ->
+                   snapshot.metadata.task_id == task_id and
+                     snapshot.metadata.task_ids == [task_id]
+
+                 _ ->
+                   false
+               end
+             end)
+
+      GenServer.stop(root_pid)
+
+      assert AsyncTaskSurface.lookup_identity_by_task_id(task_id) ==
+               {:ok,
+                %{
+                  surface_id: root_action_id,
+                  surface: task_surface,
+                  root_action_id: root_action_id
+                }}
+
+      poll_run_id = "run_#{System.unique_integer([:positive])}"
+      poll_job = make_test_job(poll_run_id, %{progress_msg_id: 333, user_msg_id: 444})
+
+      assert {:ok, poll_pid} =
+               RunProcess.start_link(%{
+                 run_id: poll_run_id,
+                 session_key: session_key,
+                 job: poll_job,
+                 submit_to_gateway?: false
+               })
+
+      poll_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_poll_parent_task_id_1",
+              kind: "subagent",
+              title: "task: poll inspect repo",
+              detail: %{
+                name: "task",
+                args: %{"action" => "poll", "task_id" => task_id},
+                result_meta: %{
+                  task_id: task_id,
+                  engine: "codex",
+                  current_action: %{title: "Write: summary.md", kind: "tool", phase: "completed"}
+                }
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: poll_run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(poll_run_id), poll_completed)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   Enum.any?(Map.values(:sys.get_state(status_pid).actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == root_action_id and
+                       action[:title] == "Write: summary.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      GenServer.stop(poll_pid)
+    end
+
+    test "terminal task poll events drive router-owned async task surfaces to terminal and reap" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ = :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job = make_test_job(run_id, %{progress_msg_id: 111, user_msg_id: 222})
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      task_surface = {:status_task, "task_root_terminal"}
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_terminal",
+              kind: "subagent",
+              title: "task(codex): terminal review",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      task_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_root_terminal",
+              kind: "subagent",
+              title: "task(codex): terminal review",
+              detail: %{
+                name: "task",
+                result_meta: %{task_id: "task-store-terminal", status: "queued"},
+                task_id: "task-store-terminal"
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      poll_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_poll_terminal_1",
+              kind: "subagent",
+              title: "task: poll terminal review",
+              detail: %{
+                name: "task",
+                args: %{"action" => "poll", "task_id" => "task-store-terminal"},
+                result_meta: %{
+                  task_id: "task-store-terminal",
+                  status: "completed",
+                  engine: "codex",
+                  current_action: %{title: "Write: summary.md", kind: "tool", phase: "completed"}
+                }
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_started)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_completed)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), poll_completed)
+
+      assert eventually(fn ->
+               case AsyncTaskSurface.get("task_root_terminal") do
+                 {:ok, snapshot} -> snapshot.status == :terminal_grace
+                 _ -> false
+               end
+             end)
+
+      assert eventually(fn ->
+               Registry.lookup(
+                 LemonRouter.ToolStatusRegistry,
+                 {session_key, "telegram", task_surface}
+               ) != []
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      [{status_pid, _}] =
+        Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", task_surface})
+
+      status_state = :sys.get_state(status_pid)
+
+      assert status_state.surface_binding == %{
+               surface_id: "task_root_terminal",
+               surface: task_surface,
+               root_action_id: "task_root_terminal"
+             }
+
+      assert is_reference(status_state.reap_token)
+
+      status_ref = Process.monitor(status_pid)
+      send(status_pid, {:reap_if_idle, status_state.reap_token})
+
+      assert_receive {:DOWN, ^status_ref, :process, ^status_pid, :normal}, 500
+      assert AsyncTaskSurface.whereis("task_root_terminal") == nil
+      assert {:error, :not_found} = AsyncTaskSurface.get("task_root_terminal")
+
+      GenServer.stop(pid)
+    end
+
+    test "async task poll actions stay attached to the original task surface by task_id" do
+      start_if_needed(LemonChannels.Registry, fn -> LemonChannels.Registry.start_link([]) end)
+      start_if_needed(LemonChannels.Outbox, fn -> LemonChannels.Outbox.start_link([]) end)
+
+      start_if_needed(LemonChannels.Outbox.RateLimiter, fn ->
+        LemonChannels.Outbox.RateLimiter.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.Outbox.Dedupe, fn ->
+        LemonChannels.Outbox.Dedupe.start_link([])
+      end)
+
+      start_if_needed(LemonChannels.PresentationState, fn ->
+        LemonChannels.PresentationState.start_link([])
+      end)
+
+      :persistent_term.put({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid}, self())
+
+      existing = LemonChannels.Registry.get_plugin("telegram")
+      _ = LemonChannels.Registry.unregister("telegram")
+      :ok = LemonChannels.Registry.register(__MODULE__.RunProcessTestTelegramPlugin)
+
+      on_exit(fn ->
+        _ =
+          :persistent_term.erase({__MODULE__.RunProcessTestTelegramPlugin, :notify_pid})
+
+        if is_pid(Process.whereis(LemonChannels.Registry)) do
+          _ = LemonChannels.Registry.unregister("telegram")
+
+          if is_atom(existing) and not is_nil(existing) do
+            _ = LemonChannels.Registry.register(existing)
+          end
+        end
+      end)
+
+      run_id = "run_#{System.unique_integer([:positive])}"
+
+      session_key =
+        SessionKey.channel_peer(%{
+          agent_id: "test-agent",
+          channel_id: "telegram",
+          account_id: "botx",
+          peer_kind: :dm,
+          peer_id: "12345"
+        })
+
+      job =
+        make_test_job(run_id, %{
+          progress_msg_id: 111,
+          user_msg_id: 222
+        })
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 job: job,
+                 submit_to_gateway?: false
+               })
+
+      prefix = "Running external reviews"
+      root_action_id = "task_root_followup_task_id"
+      task_id = "task-store-followup-task-id-1"
+      task_surface = {:status_task, root_action_id}
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(:delta, %{seq: 1, text: prefix}, %{
+            run_id: run_id,
+            session_key: session_key
+          })
+        )
+
+      assert eventually(fn ->
+               case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, "telegram"}) do
+                 [{coalescer_pid, _}] -> :sys.get_state(coalescer_pid).last_seq == 1
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.StreamCoalescer.flush(session_key, "telegram")
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: :text,
+                        content: ^prefix,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      task_started =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: root_action_id,
+              kind: "subagent",
+              title: "task(codex): review fix",
+              detail: %{name: "task"}
+            },
+            phase: :started
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      task_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: root_action_id,
+              kind: "subagent",
+              title: "task(codex): review fix",
+              detail: %{
+                name: "task",
+                result: "Task queued: review fix (#{task_id})",
+                result_meta: %{task_id: task_id, status: "queued", run_id: "child_run_1"}
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_started)
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), task_completed)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] -> root_action_id in :sys.get_state(status_pid).order
+                 _ -> false
+               end
+             end)
+
+      followup_text = "Waiting on the review"
+
+      :ok =
+        LemonCore.Bus.broadcast(
+          LemonCore.Bus.run_topic(run_id),
+          LemonCore.Event.new(:delta, %{seq: 2, text: followup_text}, %{
+            run_id: run_id,
+            session_key: session_key
+          })
+        )
+
+      assert eventually(fn ->
+               case Registry.lookup(LemonRouter.CoalescerRegistry, {session_key, "telegram"}) do
+                 [{coalescer_pid, _}] -> :sys.get_state(coalescer_pid).last_seq == 2
+                 _ -> false
+               end
+             end)
+
+      LemonRouter.StreamCoalescer.flush(session_key, "telegram")
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: :text,
+                        content: ^followup_text,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      poll_completed =
+        LemonCore.Event.new(
+          :engine_action,
+          %{
+            engine: "lemon",
+            action: %{
+              id: "task_poll_1",
+              kind: "subagent",
+              title: "task: ",
+              detail: %{
+                name: "task",
+                args: %{"action" => "poll", "task_id" => task_id},
+                result: "Read: AGENTS.md",
+                result_meta: %{
+                  task_id: task_id,
+                  engine: "codex",
+                  current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "completed"}
+                }
+              }
+            },
+            phase: :completed,
+            ok: true
+          },
+          %{run_id: run_id, session_key: session_key}
+        )
+
+      :ok = LemonCore.Bus.broadcast(LemonCore.Bus.run_topic(run_id), poll_completed)
+
+      assert eventually(fn ->
+               case Registry.lookup(
+                      LemonRouter.ToolStatusRegistry,
+                      {session_key, "telegram", task_surface}
+                    ) do
+                 [{status_pid, _}] ->
+                   state = :sys.get_state(status_pid)
+
+                   Enum.any?(Map.values(state.actions), fn action ->
+                     action[:detail][:parent_tool_use_id] == root_action_id and
+                       action[:title] == "Read: AGENTS.md"
+                   end)
+
+                 _ ->
+                   false
+               end
+             end)
+
+      refute eventually(fn ->
+               Registry.lookup(LemonRouter.ToolStatusRegistry, {session_key, "telegram", :status}) !=
+                 []
+             end)
+
+      LemonRouter.ToolStatusCoalescer.flush(session_key, "telegram", surface: task_surface)
+
+      assert_receive {:delivered,
+                      %LemonChannels.OutboundPayload{
+                        kind: task_kind,
+                        content: task_content,
+                        meta: %{run_id: ^run_id}
+                      }},
+                     1_500
+
+      assert task_kind in [:text, :edit]
+      task_text = payload_text(task_content)
+
+      assert String.contains?(task_text, prefix)
+      assert String.contains?(task_text, "task(codex): review fix")
+      assert String.contains?(task_text, "Read: AGENTS.md")
+      refute String.contains?(task_text, followup_text)
+      refute String.contains?(task_text, "\ntask: ")
+
+      GenServer.stop(pid)
     end
   end
 

--- a/apps/lemon_router/test/lemon_router/tool_status_coalescer_test.exs
+++ b/apps/lemon_router/test/lemon_router/tool_status_coalescer_test.exs
@@ -4,6 +4,8 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
 
   alias LemonCore.DeliveryIntent
   alias LemonCore.DeliveryRoute
+  alias LemonRouter.AsyncTaskSurface
+  alias Elixir.LemonRouter.StreamCoalescer
   alias Elixir.LemonRouter.ToolStatusCoalescer
 
   defmodule ToolStatusCoalescerTestTelegramPlugin do
@@ -28,6 +30,28 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
     end
   end
 
+  defmodule ToolStatusCoalescerTestShortPlugin do
+    @moduledoc false
+
+    def id, do: "short"
+
+    def meta do
+      %{
+        name: "Test Short",
+        capabilities: %{
+          edit_support: true,
+          chunk_limit: 120
+        }
+      }
+    end
+
+    def deliver(payload) do
+      pid = :persistent_term.get({__MODULE__, :test_pid}, nil)
+      if is_pid(pid), do: send(pid, {:delivered, payload})
+      {:ok, %{"ok" => true, "result" => %{"message_id" => 1002}}}
+    end
+  end
+
   defmodule ToolStatusIntentDispatcherStub do
     @moduledoc false
 
@@ -42,6 +66,18 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
   end
 
   setup do
+    if is_nil(Process.whereis(Elixir.LemonRouter.CoalescerRegistry)) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: Elixir.LemonRouter.CoalescerRegistry)
+    end
+
+    if is_nil(Process.whereis(Elixir.LemonRouter.CoalescerSupervisor)) do
+      {:ok, _} =
+        DynamicSupervisor.start_link(
+          strategy: :one_for_one,
+          name: Elixir.LemonRouter.CoalescerSupervisor
+        )
+    end
+
     if is_nil(Process.whereis(Elixir.LemonRouter.ToolStatusRegistry)) do
       {:ok, _} = Registry.start_link(keys: :unique, name: Elixir.LemonRouter.ToolStatusRegistry)
     end
@@ -51,6 +87,18 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
         DynamicSupervisor.start_link(
           strategy: :one_for_one,
           name: Elixir.LemonRouter.ToolStatusSupervisor
+        )
+    end
+
+    if is_nil(Process.whereis(LemonRouter.AsyncTaskSurfaceRegistry)) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: LemonRouter.AsyncTaskSurfaceRegistry)
+    end
+
+    if is_nil(Process.whereis(LemonRouter.AsyncTaskSurfaceSupervisor)) do
+      {:ok, _} =
+        DynamicSupervisor.start_link(
+          strategy: :one_for_one,
+          name: LemonRouter.AsyncTaskSurfaceSupervisor
         )
     end
 
@@ -204,6 +252,437 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
            end)
   end
 
+  test "expands embedded task current_action into a child action" do
+    session_key = "agent:embedded:telegram:bot:dm:654"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+
+    ev = %{
+      engine: "lemon",
+      action: %{
+        id: "task_1",
+        kind: "subagent",
+        title: "task: Read AGENTS.md in lemon repo",
+        detail: %{
+          name: "task",
+          partial_result: %AgentCore.Types.AgentToolResult{
+            content: [%Ai.Types.TextContent{type: :text, text: "pwd"}],
+            details: %{
+              status: "running",
+              description: "Read AGENTS.md in lemon repo",
+              engine: "claude",
+              current_action: %{title: "pwd", kind: "command", phase: "started"}
+            },
+            trust: :trusted
+          }
+        }
+      },
+      phase: :updated,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, ev)
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    [{pid, _}] = Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id})
+    state = :sys.get_state(pid)
+
+    child_action =
+      state.actions
+      |> Map.values()
+      |> Enum.find(fn action ->
+        action[:detail][:parent_tool_use_id] == "task_1"
+      end)
+
+    assert child_action.title == "pwd"
+    assert child_action.kind == "command"
+    assert child_action.phase == :started
+    assert child_action.caller_engine == "claude"
+    assert String.contains?(state.last_text, "▸ task: Read AGENTS.md in lemon repo")
+    assert String.contains?(state.last_text, "\n▸ pwd")
+  end
+
+  test "expands embedded codex task current_action into a child action" do
+    session_key = "agent:embedded:telegram:bot:dm:655"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+
+    ev = %{
+      engine: "lemon",
+      action: %{
+        id: "task_codex_1",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{
+          name: "task",
+          partial_result: %AgentCore.Types.AgentToolResult{
+            content: [%Ai.Types.TextContent{type: :text, text: "Read: AGENTS.md"}],
+            details: %{
+              status: "running",
+              description: "inspect repo",
+              engine: "codex",
+              current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "completed"}
+            },
+            trust: :trusted
+          }
+        }
+      },
+      phase: :updated,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, ev)
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    [{pid, _}] = Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id})
+    state = :sys.get_state(pid)
+
+    child_action =
+      state.actions
+      |> Map.values()
+      |> Enum.find(fn action ->
+        action[:detail][:parent_tool_use_id] == "task_codex_1"
+      end)
+
+    assert child_action.title == "Read: AGENTS.md"
+    assert child_action.kind == "tool"
+    assert child_action.phase == :completed
+    assert child_action.ok == true
+    assert child_action.caller_engine == "codex"
+    assert String.contains?(state.last_text, "▸ task(codex): inspect repo")
+    assert String.contains?(state.last_text, "\n✓ Read: AGENTS.md")
+  end
+
+  test "skips internal task poll action and renders its current_action as a child" do
+    session_key = "agent:embedded:telegram:bot:dm:656"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_codex_root",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    poll_completed = %{
+      engine: "lemon",
+      action: %{
+        id: "task_poll_1",
+        kind: "subagent",
+        title: "task: ",
+        detail: %{
+          name: "task",
+          args: %{"action" => "poll", "task_id" => "task-store-1"},
+          parent_tool_use_id: "task_codex_root",
+          result_meta: %{
+            task_id: "task-store-1",
+            engine: "codex",
+            current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "completed"}
+          }
+        }
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started)
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, poll_completed)
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    [{pid, _}] = Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id})
+    state = :sys.get_state(pid)
+
+    refute Enum.any?(state.order, &(&1 == "task_poll_1"))
+
+    child_action =
+      state.actions
+      |> Map.values()
+      |> Enum.find(fn action ->
+        action[:detail][:parent_tool_use_id] == "task_codex_root"
+      end)
+
+    assert child_action.title == "Read: AGENTS.md"
+    assert child_action.kind == "tool"
+    assert child_action.phase == :completed
+    assert child_action.caller_engine == "codex"
+    assert String.contains?(state.last_text, "▸ task(codex): inspect repo")
+    assert String.contains?(state.last_text, "\n✓ Read: AGENTS.md")
+    refute String.contains?(state.last_text, "\n✓ task: ")
+  end
+
+  test "poll current_action dedupes against an already projected child action" do
+    session_key = "agent:embedded:telegram:bot:dm:657"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    surface = {:status_task, "task_codex_root_live"}
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_codex_root_live",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    projected = %{
+      engine: "codex",
+      action: %{
+        id: "taskproj:child_run_1:read_1",
+        kind: "tool",
+        title: "Read: AGENTS.md",
+        detail: %{parent_tool_use_id: "task_codex_root_live", child_run_id: "child_run_1"}
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    poll_completed = %{
+      engine: "lemon",
+      action: %{
+        id: "task_poll_live_1",
+        kind: "subagent",
+        title: "task: ",
+        detail: %{
+          name: "task",
+          args: %{"action" => "poll", "task_id" => "task-store-1"},
+          parent_tool_use_id: "task_codex_root_live",
+          result_meta: %{
+            task_id: "task-store-1",
+            run_id: "child_run_1",
+            engine: "codex",
+            current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "completed"},
+            action_detail: %{child_run_id: "child_run_1"}
+          }
+        }
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface: surface
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_projected_child_action(
+               session_key,
+               channel_id,
+               run_id,
+               surface,
+               projected
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, poll_completed,
+               surface: surface
+             )
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id, surface: surface)
+
+    [{pid, _}] =
+      Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id, surface})
+
+    state = :sys.get_state(pid)
+
+    matching_children =
+      state.actions
+      |> Map.values()
+      |> Enum.filter(fn action ->
+        action[:detail][:parent_tool_use_id] == "task_codex_root_live" and
+          action[:title] == "Read: AGENTS.md"
+      end)
+
+    assert length(matching_children) == 1
+    refute Enum.any?(state.order, &(&1 == "task_poll_live_1"))
+  end
+
+  test "repeated embedded-only current_action updates reuse the same child row" do
+    session_key = "agent:embedded:telegram:bot:dm:657b"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_codex_root_repeat_embedded",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    poll_started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_poll_repeat_1",
+        kind: "subagent",
+        title: "task: ",
+        detail: %{
+          name: "task",
+          args: %{"action" => "poll", "task_id" => "task-store-repeat"},
+          parent_tool_use_id: "task_codex_root_repeat_embedded",
+          result_meta: %{
+            task_id: "task-store-repeat",
+            engine: "codex",
+            current_action: %{title: "Read: AGENTS.md", kind: "tool", phase: "started"}
+          }
+        }
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    poll_completed =
+      put_in(poll_started.action.detail.result_meta.current_action.phase, "completed")
+
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started)
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, poll_started)
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, poll_completed)
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    [{pid, _}] = Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id})
+    state = :sys.get_state(pid)
+
+    matching_children =
+      state.actions
+      |> Map.values()
+      |> Enum.filter(fn action ->
+        action[:detail][:parent_tool_use_id] == "task_codex_root_repeat_embedded" and
+          action[:title] == "Read: AGENTS.md"
+      end)
+
+    assert length(matching_children) == 1
+    assert hd(matching_children).phase == :completed
+    refute Enum.any?(state.order, &(&1 == "task_poll_repeat_1"))
+  end
+
+  test "distinct projected child actions with the same title remain distinct" do
+    session_key = "agent:embedded:telegram:bot:dm:658"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    surface = {:status_task, "task_codex_root_repeat"}
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_codex_root_repeat",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    projected_1 = %{
+      engine: "codex",
+      action: %{
+        id: "taskproj:child_run_repeat:read_1",
+        kind: "tool",
+        title: "Read: AGENTS.md",
+        detail: %{parent_tool_use_id: "task_codex_root_repeat", child_run_id: "child_run_repeat"}
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    projected_2 = %{
+      engine: "codex",
+      action: %{
+        id: "taskproj:child_run_repeat:read_2",
+        kind: "tool",
+        title: "Read: AGENTS.md",
+        detail: %{parent_tool_use_id: "task_codex_root_repeat", child_run_id: "child_run_repeat"}
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface: surface
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_projected_child_action(
+               session_key,
+               channel_id,
+               run_id,
+               surface,
+               projected_1
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_projected_child_action(
+               session_key,
+               channel_id,
+               run_id,
+               surface,
+               projected_2
+             )
+
+    [{pid, _}] =
+      Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id, surface})
+
+    state = :sys.get_state(pid)
+
+    matching_children =
+      state.actions
+      |> Map.values()
+      |> Enum.filter(fn action ->
+        action[:detail][:parent_tool_use_id] == "task_codex_root_repeat" and
+          action[:title] == "Read: AGENTS.md"
+      end)
+
+    assert Enum.sort(Enum.map(matching_children, & &1.id)) == [
+             "taskproj:child_run_repeat:read_1",
+             "taskproj:child_run_repeat:read_2"
+           ]
+  end
+
   test "telegram tool status creates a new message when only progress_msg_id is present (no status_msg_id)" do
     session_key = "agent:tool-status:telegram:bot:group:12345:thread:777"
     channel_id = "telegram"
@@ -262,6 +741,588 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
                    1_000
 
     assert String.contains?(text, "working")
+  end
+
+  test "anchored tool status edits the handed-off answer message and finalizes in place" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:778"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    route = telegram_route("bot", :group, "12345", "778")
+    prefix = "Found the key files. Let me read the markdown renderer and the formatter:"
+
+    StreamCoalescer.ingest_delta(session_key, channel_id, run_id, 1, prefix,
+      meta: %{user_msg_id: 9}
+    )
+
+    StreamCoalescer.flush(session_key, channel_id)
+
+    assert eventually(fn ->
+             LemonChannels.PresentationState.get(route, run_id, :answer).platform_message_id ==
+               1001
+           end)
+
+    assert {:ok, ^prefix} = StreamCoalescer.handoff_turn(session_key, channel_id, run_id, :status)
+
+    assert :ok =
+             ToolStatusCoalescer.anchor_segment(session_key, channel_id, run_id, prefix,
+               meta: %{user_msg_id: 9}
+             )
+
+    started = %{
+      engine: "lemon",
+      action: %{id: "a1", kind: "tool", title: "Read: markdown.ex", detail: %{}},
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started)
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    assert_receive {:delivered,
+                    %LemonChannels.OutboundPayload{
+                      channel_id: "telegram",
+                      kind: :edit,
+                      content: %{message_id: "1001", text: text},
+                      meta: %{run_id: ^run_id}
+                    }},
+                   1_000
+
+    assert String.contains?(text, prefix <> "\n\n")
+    assert String.contains?(text, "Read: markdown.ex")
+
+    assert :ok = ToolStatusCoalescer.commit_segment(session_key, channel_id, run_id)
+
+    assert_receive {:delivered,
+                    %LemonChannels.OutboundPayload{
+                      channel_id: "telegram",
+                      kind: :edit,
+                      content: %{message_id: "1001", text: final_text},
+                      meta: %{reply_markup: %{"inline_keyboard" => []}, run_id: ^run_id}
+                    }},
+                   1_000
+
+    assert String.contains?(final_text, prefix <> "\n\n")
+    assert String.contains?(final_text, "Read: markdown.ex")
+  end
+
+  test "anchored tool status keeps tool lines visible when the handed-off prefix is very long" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:7781"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    route = telegram_route("bot", :group, "12345", "7781")
+    prefix = String.duplicate("thinking block ", 350)
+
+    StreamCoalescer.ingest_delta(session_key, channel_id, run_id, 1, prefix,
+      meta: %{user_msg_id: 9}
+    )
+
+    StreamCoalescer.flush(session_key, channel_id)
+
+    assert eventually(fn ->
+             LemonChannels.PresentationState.get(route, run_id, :answer).platform_message_id ==
+               1001
+           end)
+
+    assert {:ok, ^prefix} = StreamCoalescer.handoff_turn(session_key, channel_id, run_id, :status)
+
+    assert :ok =
+             ToolStatusCoalescer.anchor_segment(session_key, channel_id, run_id, prefix,
+               meta: %{user_msg_id: 9}
+             )
+
+    started = %{
+      engine: "lemon",
+      action: %{id: "a1", kind: "tool", title: "Read: markdown.ex", detail: %{}},
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok = ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started)
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    assert_receive {:delivered,
+                    %LemonChannels.OutboundPayload{
+                      channel_id: "telegram",
+                      kind: :edit,
+                      content: %{message_id: "1001", text: text},
+                      meta: %{run_id: ^run_id}
+                    }},
+                   1_000
+
+    assert String.contains?(text, "Read: markdown.ex")
+    assert String.length(text) <= LemonChannels.Telegram.Truncate.max_length()
+    refute String.starts_with?(text, prefix <> "\n\n")
+  end
+
+  test "anchored tool status uses the channel chunk limit instead of telegram-specific budgeting" do
+    _ = LemonChannels.Registry.unregister("short")
+    :persistent_term.put({__MODULE__.ToolStatusCoalescerTestShortPlugin, :test_pid}, self())
+    :ok = LemonChannels.Registry.register(__MODULE__.ToolStatusCoalescerTestShortPlugin)
+
+    on_exit(fn ->
+      :persistent_term.erase({__MODULE__.ToolStatusCoalescerTestShortPlugin, :test_pid})
+
+      if is_pid(Process.whereis(LemonChannels.Registry)) do
+        _ = LemonChannels.Registry.unregister("short")
+      end
+    end)
+
+    session_key = "agent:tool-status:short:bot:group:12345:thread:7782"
+    channel_id = "short"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    prefix = String.duplicate("thinking block ", 20)
+
+    assert :ok =
+             ToolStatusCoalescer.anchor_segment(session_key, channel_id, run_id, prefix,
+               meta: %{user_msg_id: 9, peer: %{kind: :group, id: "12345", thread_id: "7782"}}
+             )
+
+    started = %{
+      engine: "lemon",
+      action: %{id: "a1", kind: "tool", title: "Read: markdown.ex", detail: %{}},
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               meta: %{user_msg_id: 9, peer: %{kind: :group, id: "12345", thread_id: "7782"}}
+             )
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id)
+
+    assert_receive {:delivered,
+                    %LemonChannels.OutboundPayload{
+                      channel_id: "short",
+                      content: text,
+                      meta: %{run_id: ^run_id}
+                    }},
+                   1_000
+
+    assert String.contains?(text, "Read: markdown.ex")
+    assert String.length(text) <= 120
+    refute String.starts_with?(text, prefix <> "\n\n")
+  end
+
+  test "task-specific surface keeps its message separate from generic status" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:779"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    route = telegram_route("bot", :group, "12345", "779")
+    surface = {:status_task, "task_1"}
+    prefix = "Inspecting the repo layout"
+
+    StreamCoalescer.ingest_delta(session_key, channel_id, run_id, 1, prefix,
+      meta: %{user_msg_id: 9}
+    )
+
+    StreamCoalescer.flush(session_key, channel_id)
+
+    assert eventually(fn ->
+             LemonChannels.PresentationState.get(route, run_id, :answer).platform_message_id ==
+               1001
+           end)
+
+    assert {:ok, ^prefix} = StreamCoalescer.handoff_turn(session_key, channel_id, run_id, surface)
+
+    assert :ok =
+             ToolStatusCoalescer.anchor_segment(session_key, channel_id, run_id, prefix,
+               meta: %{user_msg_id: 9},
+               surface: surface
+             )
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_1",
+        kind: "subagent",
+        title: "task(claude): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface: surface
+             )
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id, surface: surface)
+
+    assert eventually(fn ->
+             LemonChannels.PresentationState.get(route, run_id, surface).platform_message_id ==
+               1001
+           end)
+
+    assert is_nil(LemonChannels.PresentationState.get(route, run_id, :status).platform_message_id)
+  end
+
+  test "ingest_projected_child_action renders nested child lines under existing task surface" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:780"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    surface = {:status_task, "task_root"}
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_root",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    projected = %{
+      engine: "codex",
+      action: %{
+        id: "taskproj:child_1:read_1",
+        kind: "tool",
+        title: "Read: AGENTS.md",
+        detail: %{
+          parent_tool_use_id: "task_root",
+          child_run_id: "child_1",
+          task_id: "task-store-1"
+        }
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface: surface
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_projected_child_action(
+               session_key,
+               channel_id,
+               run_id,
+               surface,
+               projected
+             )
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id, surface: surface)
+
+    [{pid, _}] =
+      Registry.lookup(Elixir.LemonRouter.ToolStatusRegistry, {session_key, channel_id, surface})
+
+    state = :sys.get_state(pid)
+
+    assert String.contains?(state.last_text, "task(codex): inspect repo")
+    assert String.contains?(state.last_text, "Read: AGENTS.md")
+  end
+
+  test "task-scoped coalescers reap themselves after finalize_run" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:7801"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    surface = {:status_task, "task_reap_1"}
+
+    assert {:ok, pid} =
+             DynamicSupervisor.start_child(
+               Elixir.LemonRouter.ToolStatusSupervisor,
+               {ToolStatusCoalescer,
+                session_key: session_key,
+                channel_id: channel_id,
+                surface: surface,
+                task_reap_ms: 25}
+             )
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_reap_1",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface: surface
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.finalize_run(session_key, channel_id, run_id, true,
+               surface: surface
+             )
+
+    state = :sys.get_state(pid)
+    assert is_reference(state.reap_timer)
+    assert is_reference(state.reap_token)
+
+    ref = Process.monitor(pid)
+    send(pid, {:reap_if_idle, state.reap_token})
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+  end
+
+  test "task-scoped coalescers reap themselves after idle completed actions" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:7802"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+    surface = {:status_task, "task_reap_idle_1"}
+
+    assert {:ok, pid} =
+             DynamicSupervisor.start_child(
+               Elixir.LemonRouter.ToolStatusSupervisor,
+               {ToolStatusCoalescer,
+                session_key: session_key,
+                channel_id: channel_id,
+                surface: surface,
+                task_reap_ms: 25}
+             )
+
+    completed = %{
+      engine: "lemon",
+      action: %{
+        id: "task_reap_idle_1",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, completed,
+               surface: surface
+             )
+
+    assert :ok = ToolStatusCoalescer.flush(session_key, channel_id, surface: surface)
+
+    state = :sys.get_state(pid)
+    assert is_reference(state.reap_timer)
+    assert is_reference(state.reap_token)
+
+    ref = Process.monitor(pid)
+    send(pid, {:reap_if_idle, state.reap_token})
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+  end
+
+  test "task-scoped coalescers accept router-owned surface bindings directly" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:7803"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+
+    surface_binding = %{
+      surface_id: "task_binding_1",
+      surface: {:status_task, "task_binding_1"},
+      root_action_id: "task_binding_1"
+    }
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_binding_1",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface_binding: surface_binding
+             )
+
+    [{pid, _}] =
+      Registry.lookup(
+        Elixir.LemonRouter.ToolStatusRegistry,
+        {session_key, channel_id, {:status_task, "task_binding_1"}}
+      )
+
+    state = :sys.get_state(pid)
+    assert state.surface == {:status_task, "task_binding_1"}
+    assert state.surface_binding == surface_binding
+
+    assert :ok =
+             ToolStatusCoalescer.finalize_run(session_key, channel_id, run_id, true,
+               surface_binding: surface_binding
+             )
+
+    state = :sys.get_state(pid)
+    assert is_reference(state.reap_timer)
+    assert is_reference(state.reap_token)
+
+    ref = Process.monitor(pid)
+    send(pid, {:reap_if_idle, state.reap_token})
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+  end
+
+  test "late finalize for an older run does not wipe a reused task-scoped coalescer" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:7803b"
+    channel_id = "telegram"
+    original_run_id = "run_#{System.unique_integer([:positive])}"
+    newer_run_id = "run_#{System.unique_integer([:positive])}"
+
+    surface_binding = %{
+      surface_id: "task_binding_reused_1",
+      surface: {:status_task, "task_binding_reused_1"},
+      root_action_id: "task_binding_reused_1"
+    }
+
+    original_completed = %{
+      engine: "lemon",
+      action: %{
+        id: "task_binding_reused_1",
+        kind: "subagent",
+        title: "task(codex): first run",
+        detail: %{name: "task"}
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    newer_started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_poll_reused_1",
+        kind: "tool",
+        title: "Read: summary.md",
+        detail: %{parent_tool_use_id: "task_binding_reused_1"}
+      },
+      phase: :started,
+      ok: nil,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(
+               session_key,
+               channel_id,
+               original_run_id,
+               original_completed,
+               surface_binding: surface_binding
+             )
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(
+               session_key,
+               channel_id,
+               newer_run_id,
+               newer_started,
+               surface_binding: surface_binding
+             )
+
+    [{pid, _}] =
+      Registry.lookup(
+        Elixir.LemonRouter.ToolStatusRegistry,
+        {session_key, channel_id, {:status_task, "task_binding_reused_1"}}
+      )
+
+    assert :ok =
+             ToolStatusCoalescer.finalize_run(session_key, channel_id, original_run_id, true,
+               surface_binding: surface_binding
+             )
+
+    state = :sys.get_state(pid)
+
+    assert state.run_id == newer_run_id
+    assert state.finalized == false
+    assert state.order == ["task_poll_reused_1"]
+    assert state.actions["task_poll_reused_1"].phase == :started
+    assert state.reap_timer == nil
+    assert state.reap_token == nil
+  end
+
+  test "task-scoped coalescer reap transitions a terminal router-owned async task surface" do
+    session_key = "agent:tool-status:telegram:bot:group:12345:thread:7804"
+    channel_id = "telegram"
+    run_id = "run_#{System.unique_integer([:positive])}"
+
+    surface_binding = %{
+      surface_id: "task_binding_terminal_1",
+      surface: {:status_task, "task_binding_terminal_1"},
+      root_action_id: "task_binding_terminal_1"
+    }
+
+    assert {:ok, surface_pid} =
+             AsyncTaskSurface.ensure_started(surface_binding.surface_id,
+               metadata: Map.merge(surface_binding, %{parent_run_id: run_id})
+             )
+
+    assert {:ok, %{status: :bound}} =
+             AsyncTaskSurface.transition(surface_pid, :bound, %{
+               metadata: Map.merge(surface_binding, %{parent_run_id: run_id})
+             })
+
+    assert {:ok, %{status: :live}} = AsyncTaskSurface.transition(surface_pid, :live)
+
+    assert {:ok, %{status: :terminal_grace}} =
+             AsyncTaskSurface.transition(surface_pid, :terminal_grace)
+
+    started = %{
+      engine: "lemon",
+      action: %{
+        id: "task_binding_terminal_1",
+        kind: "subagent",
+        title: "task(codex): inspect repo",
+        detail: %{name: "task"}
+      },
+      phase: :completed,
+      ok: true,
+      message: nil,
+      level: nil
+    }
+
+    assert :ok =
+             ToolStatusCoalescer.ingest_action(session_key, channel_id, run_id, started,
+               surface_binding: surface_binding
+             )
+
+    [{pid, _}] =
+      Registry.lookup(
+        Elixir.LemonRouter.ToolStatusRegistry,
+        {session_key, channel_id, {:status_task, "task_binding_terminal_1"}}
+      )
+
+    assert :ok =
+             ToolStatusCoalescer.flush(session_key, channel_id, surface_binding: surface_binding)
+
+    state = :sys.get_state(pid)
+    assert is_reference(state.reap_token)
+
+    ref = Process.monitor(pid)
+    send(pid, {:reap_if_idle, state.reap_token})
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+    assert AsyncTaskSurface.whereis(surface_binding.surface_id) == nil
+    assert {:error, :not_found} = AsyncTaskSurface.get(surface_binding.surface_id)
   end
 
   test "finalize_run does not create status output when there are no tool actions" do
@@ -418,7 +1479,8 @@ defmodule LemonRouter.ToolStatusCoalescerTest do
                     }},
                    1_000
 
-    assert intent_id == "#{run_id}:status:1:tool_status_snapshot"
+    assert String.starts_with?(intent_id, "#{run_id}:status:")
+    assert String.ends_with?(intent_id, ":1:tool_status_snapshot")
     assert String.contains?(text, "Read: foo.txt")
   end
 

--- a/docs/plans/async-task-surface-implementation-loop.md
+++ b/docs/plans/async-task-surface-implementation-loop.md
@@ -1,0 +1,91 @@
+# AsyncTaskSurface Implementation Loop
+
+## Source of Truth
+If resuming in a new session, start here:
+- `docs/plans/async-task-surface-implementation-loop.md` (this file)
+- `memory/topics/async-task-status-review.md`
+- `docs/plans/async-task-tool-surfacing-migration-progress.md`
+
+## Goal
+Replace the increasingly fragile bridge/binding/coalescer patch stack with a cleaner router-owned `AsyncTaskSurface` lifecycle so async child task activity stays attached to the original parent task surface/message with simpler ownership and cleanup semantics.
+
+## Why we are doing this
+Incremental patching improved the happy path but Codex architecture review concluded the ownership boundary is still wrong:
+- parent `RunProcess` owns state that should live for the child-task lifetime
+- surface mapping is duplicated across coding agent bindings and router in-memory maps
+- coalescer behavior is compensating for an underspecified upstream contract
+- repeated review/fix rounds keep moving lifecycle bugs instead of removing the root cause
+
+## Architecture choice
+Chosen direction: **implement the `AsyncTaskSurface` redesign** described in `memory/topics/async-task-status-review.md`.
+
+### Core design
+Introduce `LemonRouter.AsyncTaskSurface` as a router-owned GenServer with one process per async task surface.
+
+State machine:
+- `pending_root`
+- `bound`
+- `live`
+- `terminal_grace`
+- `reaped`
+
+Key ownership rules:
+- task surface is owned by router, not by parent run maps plus coding-agent bindings
+- child run subscription belongs to the task-surface process
+- poll/join are fallback/snapshot paths, not a second primary source of truth
+- cleanup/reap is local to async task surface lifecycle
+
+## 8-step implementation plan
+1. Add `LemonRouter.AsyncTaskSurface` + supervisor + registry.
+2. Seed surface ownership from task-root start in router.
+3. Bind `task_id` + `child_run_id` from existing result metadata path.
+4. Move child run subscription into `AsyncTaskSurface`; keep `LiveBridge` only as a temporary shim if needed.
+5. Route poll/join by `task_id` through async-task-surface registry.
+6. Add explicit `:task_surface_bound` / `:task_surface_terminal` events from task tool lifecycle if necessary.
+7. Remove obsolete pieces once replacement is proven: `TaskProgressBindingStore`, `TaskProgressBindingServer`, `LiveBridge`, and embedded-child repair/dedupe logic that becomes unnecessary.
+8. Validate end-to-end, including the important case where child progress continues correctly even if the parent `RunProcess` exits.
+
+## Current status
+- We completed the original incremental migration/hardening path through multiple Codex rounds.
+- We have hardened baseline work in isolated worktrees:
+  - coding worktree latest known hardening commit: `8b7443d7`
+  - router worktree latest known hardening commits include `a3653db75963e87df65d6eead7fed400601511b5` and `64b5b50c`
+- We are now shifting to the **AsyncTaskSurface implementation loop** as the next major step.
+- **Step 1 complete in worktree:** `.worktrees/async-task-surface-step1`
+  - Added `LemonRouter.AsyncTaskSurface`
+  - Added `LemonRouter.AsyncTaskSurfaceSupervisor`
+  - Wired `LemonRouter.AsyncTaskSurfaceRegistry` + supervisor into `LemonRouter.Application`
+  - Preserved the old projected-child / bridge path unchanged
+  - Final Step 1 lifecycle scaffold uses redesign-aligned states: `:pending_root`, `:bound`, `:live`, `:terminal_grace`, `:reaped`
+  - Hardened for immediate + concurrent reap/recreate, suspended/busy live reuse, stale pid safety, and actionable invalid-metadata errors
+  - Targeted green suites at approval point:
+    - `mix test apps/lemon_router/test/lemon_router/async_task_surface_test.exs`
+    - `mix test apps/lemon_router/test/lemon_router/run_process_test.exs`
+    - `mix test apps/lemon_router/test/lemon_router/tool_status_coalescer_test.exs`
+
+## Implementation/review loop protocol
+For each round:
+1. Pick the next smallest viable `AsyncTaskSurface` slice.
+2. Launch Codex implement task in isolated worktree(s).
+3. Run targeted tests.
+4. Launch Codex review task.
+5. If issues remain, launch the next fix round.
+6. Update this file and `memory/topics/async-task-status-review.md` with what changed and what remains.
+
+## Immediate next work
+Step 1 is complete.
+
+Proceed to Step 2:
+- parent `RunProcess` / `OutputTracker` seeds task-root ownership into `AsyncTaskSurface`
+- bind/create/reuse surfaces from task-root start and poll paths
+- persist router-owned `surface_id` + `root_action_id` as authoritative identity
+- keep existing projected-child rendering path intact for now
+- defer LiveBridge removal / child-run subscription migration to later steps
+
+## Exit criteria
+We can call this done only when:
+- `AsyncTaskSurface` is the primary owner of async task surfaces
+- child run subscription no longer relies on fragile cross-layer bridge/binding semantics
+- poll/join behave as fallback only
+- obsolete bridge/binding repair logic is removed or clearly deprecated
+- real Telegram canary confirms correct nested live updates

--- a/docs/plans/async-task-tool-surfacing-migration-progress.md
+++ b/docs/plans/async-task-tool-surfacing-migration-progress.md
@@ -1,0 +1,86 @@
+# Async Task Tool Surfacing Migration Progress
+
+> **Status note:** This file records the completed incremental migration/hardening path. The next implementation loop should start from the `AsyncTaskSurface` redesign source of truth in `docs/plans/async-task-surface-implementation-loop.md` and `memory/topics/async-task-status-review.md`.
+
+## AsyncTaskSurface redesign loop checkpoints
+
+### Step 1 scaffold — APPROVED
+- **Worktree:** `.worktrees/async-task-surface-step1`
+- Added router-owned scaffold pieces:
+  - `apps/lemon_router/lib/lemon_router/async_task_surface.ex`
+  - `apps/lemon_router/lib/lemon_router/async_task_surface_supervisor.ex`
+  - `LemonRouter.AsyncTaskSurfaceRegistry` + `LemonRouter.AsyncTaskSurfaceSupervisor` in `LemonRouter.Application`
+- Public scaffold now uses redesign-aligned lifecycle states:
+  - `:pending_root`
+  - `:bound`
+  - `:live`
+  - `:terminal_grace`
+  - `:reaped`
+- Hardening completed during review loop:
+  - immediate reap stops/unregisters and supports fresh recreate
+  - concurrent reap/recreate no longer returns stale pid
+  - live-but-suspended surfaces are reused instead of timed out
+  - duplicate same-state transitions preserve prior identity/payload
+  - invalid metadata returns actionable errors instead of crashing/misreporting `:not_found`
+- Approval review verdict: **APPROVED**
+- Targeted green suites at final approval:
+  - `mix test apps/lemon_router/test/lemon_router/async_task_surface_test.exs`
+  - `mix test apps/lemon_router/test/lemon_router/run_process_test.exs`
+  - `mix test apps/lemon_router/test/lemon_router/tool_status_coalescer_test.exs`
+
+### Recommended next slice
+- Step 2 only: wire `AsyncTaskSurface` into task-root ownership in router (`RunProcess` / `OutputTracker`) while keeping the existing projected-child path intact.
+
+## Goal
+Complete the async task tool surfacing migration so live child task activity stays attached to the original parent task surface/message, with robust lifecycle cleanup and safe dedupe behavior.
+
+## 8-step migration plan
+
+1. **Binding store** — transient task progress binding store and server.
+2. **Launch metadata capture** — persist `root_action_id` / `surface` / parent metadata at async launch.
+3. **Live bridge** — subscribe to child run bus events and project child actions.
+4. **Projected ingress API** — explicit coalescer ingress for projected child actions.
+5. **Router integration** — route projected child actions into task surfaces and add regression coverage.
+6. **Poll/join dedupe** — reconcile poll/join results with already-live projected child actions.
+7. **Coding-side lifecycle hardening** — bridge teardown, fail-open binding creation, starter failure handling, malformed child detail robustness.
+8. **Router-side lifecycle hardening + final validation** — watchdog prompt idempotency, task-surface reap/cleanup, projected routing cleanup, final canary/review.
+
+## Status
+
+- [x] Step 1 — Binding store
+- [x] Step 2 — Launch metadata capture
+- [x] Step 3 — Live bridge
+- [x] Step 4 — Projected ingress API
+- [x] Step 5 — Router integration + regression coverage
+- [x] Step 6 — Poll/join dedupe
+- [x] Step 7 — Coding-side lifecycle hardening
+- [x] Step 8 — Router-side lifecycle hardening + final validation
+
+## Current known backlog
+
+### Coding-side
+- Ensure bridge teardown matches the **real** async terminal lifecycle path, not only synthetic `:run_completed`.
+- Prevent `LiveBridge` crashes on non-map `action.detail` payloads.
+- Ensure starter callback raises are handled cleanly without partial-state leaks.
+- Add regression coverage for the above.
+
+### Router-side
+- Fix repeated watchdog prompt idempotency across multiple idle cycles.
+- Prevent reaped task-scoped coalescers from being recreated/leaking at parent run completion.
+- Preserve `:user_requested` cancel reason through watchdog cancel path.
+- Revisit remaining embedded-child dedupe edge cases if still needed.
+
+## Latest checkpoints
+- Initial migration tasks (1–6) implemented and covered by targeted tests.
+- Additional coding-side hardening commit landed in coding worktree (`8b7443d7`).
+- Additional router-side hardening commit landed in router worktree (`a3653db75963e87df65d6eead7fed400601511b5`).
+- Final targeted router pass reported:
+  - task-surface stale binding cleanup
+  - `detail.task_id` / `detail.task_ids` poll rebinding support
+  - regression coverage for reaped-surface parent completion and poll-only `detail.task_id`
+  - `mix test apps/lemon_router/test/lemon_router/run_process_test.exs apps/lemon_router/test/lemon_router/tool_status_coalescer_test.exs` → `66 tests, 0 failures`
+- Migration steps 1–8 are now marked complete in the tracker; next action is final cross-tree review/canary confirmation before merging.
+
+## Notes
+- Use Codex tasks in isolated worktrees for further implementation/review rounds.
+- Do not call this done until both worktrees get a clean final Codex review and the real Telegram canary is run.


### PR DESCRIPTION
## Summary
- add router-owned `AsyncTaskSurface` scaffold, supervisor, and registry wiring
- wire task-root ownership/reuse into router output tracking and tool-status coalescing
- preserve legacy projected-child / LiveBridge path while migrating task-root identity ownership
- add tracking docs for the async task surface redesign loop
- include watchdog synthetic-completion state-threading fix discovered in pre-PR review

## Scope
This is the clean branch rebased onto current `main`.
It replaces the earlier polluted PR branch that was based on an old side branch.

## Included
### Step 1
- approved `AsyncTaskSurface` scaffold
- redesign-aligned lifecycle states
- reap/recreate hardening
- stale-pid and busy-surface safety
- actionable invalid-metadata errors

### Step 2 (current branch state)
- task-root ownership seeding/reuse through `RunProcess.OutputTracker`
- persisted identity/rebinding work for `surface_id`, `root_action_id`, and `task_id`
- task-surface terminal/reap wiring through router/coalescer paths
- projected-child compatibility fixes and ordering/race regressions currently implemented on branch

## Test Plan
- `mix test apps/lemon_router/test/lemon_router/run_process_test.exs`
- `mix test apps/lemon_router/test/lemon_router/tool_status_coalescer_test.exs`
- `mix test apps/lemon_router/test/lemon_router/async_task_surface_test.exs`

## Notes
- Focused router suites are green locally on this clean branch.
- Draft until the remaining Step 2 review loop is explicitly closed.
