### PR TITLE
Add memory and skill harness contract evals

### DIFF
--- a/apps/coding_agent/README.md
+++ b/apps/coding_agent/README.md
@@ -212,7 +212,9 @@ For coordination workflows that must produce one final same-turn answer, queued 
 |--------|-------------|
 | `CodingAgent.Checkpoint` | Snapshot/restore for long-running sessions with aggregate stats |
 | `CodingAgent.Tools.FeatureRequirements` | Persists `FEATURE_REQUIREMENTS.json` with dependency-aware progress tracking |
-| `CodingAgent.Evals.Harness` | Evaluation harness for automated agent testing |
+| `CodingAgent.Evals.Harness` | Evaluation harness for automated agent testing; includes deterministic tool contracts, read/edit workflow checks, memory scope/topic checks, and relevant-skill prompt progressive-disclosure checks |
+
+The eval harness is intentionally lightweight and deterministic. It should catch harness-contract drift before behavioral/LLM evals run: default tool registry coverage, stable builtin tool ordering, basic file workflow viability, `search_memory` current-scope resolution, `memory_topic` scaffold behavior, and relevant-skill prompt guidance that points agents to `read_skill` without inlining full skill bodies.
 
 ### Security
 

--- a/apps/coding_agent/lib/coding_agent/evals/harness.ex
+++ b/apps/coding_agent/lib/coding_agent/evals/harness.ex
@@ -9,7 +9,8 @@ defmodule CodingAgent.Evals.Harness do
   """
 
   alias AgentCore.Types.AgentToolResult
-  alias CodingAgent.ToolRegistry
+  alias CodingAgent.{PromptBuilder, ToolRegistry}
+  alias CodingAgent.Tools.{MemoryTopic, SearchMemory}
 
   @required_builtin_tools ~w(read read_skill memory_topic search_memory write edit patch bash grep find ls webfetch websearch todo task extensions_status)
 
@@ -32,7 +33,10 @@ defmodule CodingAgent.Evals.Harness do
     results = [
       deterministic_contract_eval(cwd),
       statistical_stability_eval(cwd, iterations),
-      read_edit_workflow_eval(cwd)
+      read_edit_workflow_eval(cwd),
+      memory_scope_contract_eval(cwd),
+      memory_topic_contract_eval(cwd),
+      auto_skill_prompt_contract_eval(cwd)
     ]
 
     passed = Enum.count(results, &(&1.status == :pass))
@@ -126,6 +130,198 @@ defmodule CodingAgent.Evals.Harness do
           details: %{reason: format_reason(reason)}
         }
     end
+  end
+
+  @spec memory_scope_contract_eval(String.t()) :: eval_result()
+  def memory_scope_contract_eval(_cwd) do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "lemon_memory_scope_eval_#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    project_dir = Path.join(tmp_dir, "project")
+    home_dir = Path.join(tmp_dir, "home")
+
+    search_fn = fn query, opts ->
+      scope_key = Keyword.fetch!(opts, :scope_key)
+      limit = Keyword.fetch!(opts, :limit)
+
+      [
+        %{
+          doc_id: "#{Path.basename(scope_key)}-doc",
+          query: query,
+          limit: limit,
+          scope_key: scope_key
+        }
+      ]
+    end
+
+    format_results_fn = fn docs ->
+      docs
+      |> Enum.map(&Map.fetch!(&1, :doc_id))
+      |> Enum.join(",")
+    end
+
+    tool =
+      SearchMemory.tool(project_dir,
+        workspace_dir: home_dir,
+        search_fn: search_fn,
+        format_results_fn: format_results_fn
+      )
+
+    result = tool.execute.("eval-search-memory", %{"query" => "deployment notes"}, nil, nil)
+    text = flatten_text(result)
+
+    cond do
+      result.details[:scope] != :current ->
+        contract_fail("memory_scope_contract", "expected default scope :current", result.details)
+
+      result.details[:resolved_scopes] != [:project, :home] ->
+        contract_fail("memory_scope_contract", "expected project and home scopes", result.details)
+
+      not String.contains?(text, "project-doc") or not String.contains?(text, "home-doc") ->
+        contract_fail("memory_scope_contract", "expected project and home search hits", %{
+          text: text
+        })
+
+      true ->
+        %{
+          name: "memory_scope_contract",
+          status: :pass,
+          details: %{
+            scope: result.details[:scope],
+            resolved_scopes: result.details[:resolved_scopes]
+          }
+        }
+    end
+  rescue
+    e -> contract_fail("memory_scope_contract", Exception.message(e), %{})
+  end
+
+  @spec memory_topic_contract_eval(String.t()) :: eval_result()
+  def memory_topic_contract_eval(_cwd) do
+    with {:ok, tmp_dir} <- create_tmp_dir() do
+      workspace_dir = Path.join(tmp_dir, "workspace")
+      template_path = Path.join(workspace_dir, "memory/topics/TEMPLATE.md")
+      topic_path = Path.join(workspace_dir, "memory/topics/harness-contract.md")
+
+      File.mkdir_p!(Path.dirname(template_path))
+      File.write!(template_path, "# Topic: <topic-slug>\n\ncontract-template")
+
+      result =
+        MemoryTopic.execute(
+          "eval-memory-topic",
+          %{"topic" => "Harness Contract"},
+          nil,
+          nil,
+          workspace_dir
+        )
+
+      cond do
+        not match?(%AgentToolResult{}, result) ->
+          contract_fail("memory_topic_contract", "unexpected result", %{result: inspect(result)})
+
+        result.details[:created] != true ->
+          contract_fail("memory_topic_contract", "topic was not created", result.details)
+
+        result.details[:path] != topic_path ->
+          contract_fail("memory_topic_contract", "topic path drifted", result.details)
+
+        not File.exists?(topic_path) ->
+          contract_fail("memory_topic_contract", "topic file missing", %{path: topic_path})
+
+        not String.contains?(File.read!(topic_path), "# Topic: harness-contract") ->
+          contract_fail("memory_topic_contract", "template slug replacement failed", %{
+            path: topic_path
+          })
+
+        true ->
+          File.rm_rf(tmp_dir)
+
+          %{
+            name: "memory_topic_contract",
+            status: :pass,
+            details: %{slug: result.details[:slug], path: result.details[:path]}
+          }
+      end
+    else
+      {:error, reason} -> contract_fail("memory_topic_contract", format_reason(reason), %{})
+    end
+  rescue
+    e -> contract_fail("memory_topic_contract", Exception.message(e), %{})
+  end
+
+  @spec auto_skill_prompt_contract_eval(String.t()) :: eval_result()
+  def auto_skill_prompt_contract_eval(_cwd) do
+    with {:ok, tmp_dir} <- create_tmp_dir() do
+      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "hermes-memory"])
+      skill_path = Path.join(skill_dir, "SKILL.md")
+      sentinel = "FULL BODY SENTINEL MUST NOT BE IN PROMPT"
+
+      File.mkdir_p!(skill_dir)
+
+      File.write!(skill_path, """
+      ---
+      name: hermes-memory
+      description: Hermes memory recall and durable profile discipline
+      keywords:
+        - hermes
+        - memory
+        - recall
+      ---
+
+      # Hermes Memory
+
+      #{sentinel}
+      """)
+
+      prompt =
+        PromptBuilder.build(tmp_dir, %{
+          base_prompt: "Base.",
+          context: "improve hermes memory recall and profile discipline",
+          include_skills: true,
+          include_commands: false,
+          include_mentions: false
+        })
+
+      cond do
+        not String.contains?(prompt, "<relevant-skills>") ->
+          contract_fail("auto_skill_prompt_contract", "missing relevant skills block", %{
+            prompt: prompt
+          })
+
+        not String.contains?(prompt, "<key>hermes-memory</key>") ->
+          contract_fail("auto_skill_prompt_contract", "missing relevant skill key", %{
+            prompt: prompt
+          })
+
+        not String.contains?(prompt, "Use `read_skill`") ->
+          contract_fail("auto_skill_prompt_contract", "missing read_skill loading reminder", %{
+            prompt: prompt
+          })
+
+        String.contains?(prompt, sentinel) ->
+          contract_fail("auto_skill_prompt_contract", "full skill body leaked into prompt", %{})
+
+        true ->
+          File.rm_rf(tmp_dir)
+
+          %{
+            name: "auto_skill_prompt_contract",
+            status: :pass,
+            details: %{skill: "hermes-memory", progressive_disclosure: true}
+          }
+      end
+    else
+      {:error, reason} -> contract_fail("auto_skill_prompt_contract", format_reason(reason), %{})
+    end
+  rescue
+    e -> contract_fail("auto_skill_prompt_contract", Exception.message(e), %{})
+  end
+
+  defp contract_fail(name, reason, details) do
+    %{name: name, status: :fail, details: Map.merge(%{reason: reason}, details)}
   end
 
   defp normalized_tool_names(cwd) do

--- a/apps/coding_agent/lib/coding_agent/evals/harness.ex
+++ b/apps/coding_agent/lib/coding_agent/evals/harness.ex
@@ -202,48 +202,50 @@ defmodule CodingAgent.Evals.Harness do
   @spec memory_topic_contract_eval(String.t()) :: eval_result()
   def memory_topic_contract_eval(_cwd) do
     with {:ok, tmp_dir} <- create_tmp_dir() do
-      workspace_dir = Path.join(tmp_dir, "workspace")
-      template_path = Path.join(workspace_dir, "memory/topics/TEMPLATE.md")
-      topic_path = Path.join(workspace_dir, "memory/topics/harness-contract.md")
+      try do
+        workspace_dir = Path.join(tmp_dir, "workspace")
+        template_path = Path.join(workspace_dir, "memory/topics/TEMPLATE.md")
+        topic_path = Path.join(workspace_dir, "memory/topics/harness-contract.md")
 
-      File.mkdir_p!(Path.dirname(template_path))
-      File.write!(template_path, "# Topic: <topic-slug>\n\ncontract-template")
+        File.mkdir_p!(Path.dirname(template_path))
+        File.write!(template_path, "# Topic: <topic-slug>\n\ncontract-template")
 
-      result =
-        MemoryTopic.execute(
-          "eval-memory-topic",
-          %{"topic" => "Harness Contract"},
-          nil,
-          nil,
-          workspace_dir
-        )
+        result =
+          MemoryTopic.execute(
+            "eval-memory-topic",
+            %{"topic" => "Harness Contract"},
+            nil,
+            nil,
+            workspace_dir
+          )
 
-      cond do
-        not match?(%AgentToolResult{}, result) ->
-          contract_fail("memory_topic_contract", "unexpected result", %{result: inspect(result)})
+        cond do
+          not match?(%AgentToolResult{}, result) ->
+            contract_fail("memory_topic_contract", "unexpected result", %{result: inspect(result)})
 
-        result.details[:created] != true ->
-          contract_fail("memory_topic_contract", "topic was not created", result.details)
+          result.details[:created] != true ->
+            contract_fail("memory_topic_contract", "topic was not created", result.details)
 
-        result.details[:path] != topic_path ->
-          contract_fail("memory_topic_contract", "topic path drifted", result.details)
+          result.details[:path] != topic_path ->
+            contract_fail("memory_topic_contract", "topic path drifted", result.details)
 
-        not File.exists?(topic_path) ->
-          contract_fail("memory_topic_contract", "topic file missing", %{path: topic_path})
+          not File.exists?(topic_path) ->
+            contract_fail("memory_topic_contract", "topic file missing", %{path: topic_path})
 
-        not String.contains?(File.read!(topic_path), "# Topic: harness-contract") ->
-          contract_fail("memory_topic_contract", "template slug replacement failed", %{
-            path: topic_path
-          })
+          not String.contains?(File.read!(topic_path), "# Topic: harness-contract") ->
+            contract_fail("memory_topic_contract", "template slug replacement failed", %{
+              path: topic_path
+            })
 
-        true ->
-          File.rm_rf(tmp_dir)
-
-          %{
-            name: "memory_topic_contract",
-            status: :pass,
-            details: %{slug: result.details[:slug], path: result.details[:path]}
-          }
+          true ->
+            %{
+              name: "memory_topic_contract",
+              status: :pass,
+              details: %{slug: result.details[:slug], path: result.details[:path]}
+            }
+        end
+      after
+        File.rm_rf(tmp_dir)
       end
     else
       {:error, reason} -> contract_fail("memory_topic_contract", format_reason(reason), %{})
@@ -255,63 +257,65 @@ defmodule CodingAgent.Evals.Harness do
   @spec auto_skill_prompt_contract_eval(String.t()) :: eval_result()
   def auto_skill_prompt_contract_eval(_cwd) do
     with {:ok, tmp_dir} <- create_tmp_dir() do
-      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "hermes-memory"])
-      skill_path = Path.join(skill_dir, "SKILL.md")
-      sentinel = "FULL BODY SENTINEL MUST NOT BE IN PROMPT"
+      try do
+        skill_dir = Path.join([tmp_dir, ".lemon", "skill", "hermes-memory"])
+        skill_path = Path.join(skill_dir, "SKILL.md")
+        sentinel = "FULL BODY SENTINEL MUST NOT BE IN PROMPT"
 
-      File.mkdir_p!(skill_dir)
+        File.mkdir_p!(skill_dir)
 
-      File.write!(skill_path, """
-      ---
-      name: hermes-memory
-      description: Hermes memory recall and durable profile discipline
-      keywords:
-        - hermes
-        - memory
-        - recall
-      ---
+        File.write!(skill_path, """
+        ---
+        name: hermes-memory
+        description: Hermes memory recall and durable profile discipline
+        keywords:
+          - hermes
+          - memory
+          - recall
+        ---
 
-      # Hermes Memory
+        # Hermes Memory
 
-      #{sentinel}
-      """)
+        #{sentinel}
+        """)
 
-      prompt =
-        PromptBuilder.build(tmp_dir, %{
-          base_prompt: "Base.",
-          context: "improve hermes memory recall and profile discipline",
-          include_skills: true,
-          include_commands: false,
-          include_mentions: false
-        })
-
-      cond do
-        not String.contains?(prompt, "<relevant-skills>") ->
-          contract_fail("auto_skill_prompt_contract", "missing relevant skills block", %{
-            prompt: prompt
+        prompt =
+          PromptBuilder.build(tmp_dir, %{
+            base_prompt: "Base.",
+            context: "improve hermes memory recall and profile discipline",
+            include_skills: true,
+            include_commands: false,
+            include_mentions: false
           })
 
-        not String.contains?(prompt, "<key>hermes-memory</key>") ->
-          contract_fail("auto_skill_prompt_contract", "missing relevant skill key", %{
-            prompt: prompt
-          })
+        cond do
+          not String.contains?(prompt, "<relevant-skills>") ->
+            contract_fail("auto_skill_prompt_contract", "missing relevant skills block", %{
+              prompt: prompt
+            })
 
-        not String.contains?(prompt, "Use `read_skill`") ->
-          contract_fail("auto_skill_prompt_contract", "missing read_skill loading reminder", %{
-            prompt: prompt
-          })
+          not String.contains?(prompt, "<key>hermes-memory</key>") ->
+            contract_fail("auto_skill_prompt_contract", "missing relevant skill key", %{
+              prompt: prompt
+            })
 
-        String.contains?(prompt, sentinel) ->
-          contract_fail("auto_skill_prompt_contract", "full skill body leaked into prompt", %{})
+          not String.contains?(prompt, "Use `read_skill`") ->
+            contract_fail("auto_skill_prompt_contract", "missing read_skill loading reminder", %{
+              prompt: prompt
+            })
 
-        true ->
-          File.rm_rf(tmp_dir)
+          String.contains?(prompt, sentinel) ->
+            contract_fail("auto_skill_prompt_contract", "full skill body leaked into prompt", %{})
 
-          %{
-            name: "auto_skill_prompt_contract",
-            status: :pass,
-            details: %{skill: "hermes-memory", progressive_disclosure: true}
-          }
+          true ->
+            %{
+              name: "auto_skill_prompt_contract",
+              status: :pass,
+              details: %{skill: "hermes-memory", progressive_disclosure: true}
+            }
+        end
+      after
+        File.rm_rf(tmp_dir)
       end
     else
       {:error, reason} -> contract_fail("auto_skill_prompt_contract", format_reason(reason), %{})

--- a/apps/coding_agent/test/coding_agent/evals/harness_contract_test.exs
+++ b/apps/coding_agent/test/coding_agent/evals/harness_contract_test.exs
@@ -1,0 +1,18 @@
+defmodule CodingAgent.Evals.HarnessContractTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAgent.Evals.Harness
+
+  @moduletag :tmp_dir
+
+  describe "run/1" do
+    test "includes Hermes-style memory and skill contract checks", %{tmp_dir: tmp_dir} do
+      report = Harness.run(cwd: tmp_dir, iterations: 2)
+      names = Enum.map(report.results, & &1.name)
+
+      assert "memory_scope_contract" in names
+      assert "memory_topic_contract" in names
+      assert "auto_skill_prompt_contract" in names
+    end
+  end
+end

--- a/apps/coding_agent/test/coding_agent/evals/harness_test.exs
+++ b/apps/coding_agent/test/coding_agent/evals/harness_test.exs
@@ -11,7 +11,10 @@ defmodule CodingAgent.Evals.HarnessTest do
     assert Enum.map(report.results, & &1.name) == [
              "deterministic_contract",
              "statistical_stability",
-             "read_edit_workflow"
+             "read_edit_workflow",
+             "memory_scope_contract",
+             "memory_topic_contract",
+             "auto_skill_prompt_contract"
            ]
   end
 end

--- a/apps/coding_agent/test/coding_agent_test.exs
+++ b/apps/coding_agent/test/coding_agent_test.exs
@@ -2,9 +2,9 @@ defmodule CodingAgentTest do
   use ExUnit.Case, async: true
 
   describe "coding_tools/2" do
-    test "returns list of 19 tools" do
+    test "returns list of 22 tools" do
       tools = CodingAgent.coding_tools("/tmp")
-      assert length(tools) == 19
+      assert length(tools) == 22
       assert Enum.all?(tools, &match?(%AgentCore.Types.AgentTool{}, &1))
     end
 
@@ -19,6 +19,9 @@ defmodule CodingAgentTest do
       assert "grep" in names
       assert "find" in names
       assert "ls" in names
+      assert "read_skill" in names
+      assert "memory_topic" in names
+      assert "search_memory" in names
       assert "webfetch" in names
       assert "websearch" in names
       assert "todo" in names
@@ -35,9 +38,11 @@ defmodule CodingAgentTest do
   describe "read_only_tools/2" do
     test "returns list with exploration tools" do
       tools = CodingAgent.read_only_tools("/tmp")
-      assert length(tools) == 4
+      assert length(tools) == 6
       names = Enum.map(tools, & &1.name)
       assert "read" in names
+      assert "read_skill" in names
+      assert "search_memory" in names
       assert "grep" in names
       assert "find" in names
       assert "ls" in names

--- a/apps/coding_agent/test/mix/tasks/lemon.eval_test.exs
+++ b/apps/coding_agent/test/mix/tasks/lemon.eval_test.exs
@@ -268,5 +268,20 @@ defmodule Mix.Tasks.Lemon.EvalTest do
       check_names = Enum.map(decoded["results"], & &1["name"])
       assert "read_edit_workflow" in check_names
     end
+
+    @tag :integration
+    test "memory and skill contract checks are included" do
+      output =
+        capture_io(fn ->
+          Eval.run(["--iterations", "2", "--json"])
+        end)
+
+      {:ok, decoded} = Jason.decode(output)
+
+      check_names = Enum.map(decoded["results"], & &1["name"])
+      assert "memory_scope_contract" in check_names
+      assert "memory_topic_contract" in check_names
+      assert "auto_skill_prompt_contract" in check_names
+    end
   end
 end

--- a/docs/catalog.exs
+++ b/docs/catalog.exs
@@ -80,7 +80,7 @@
   %{
     path: "docs/config.md",
     owner: "@z80",
-    last_reviewed: ~D[2026-02-27],
+    last_reviewed: ~D[2026-05-03],
     max_age_days: 60
   },
   %{
@@ -98,7 +98,7 @@
   %{
     path: "docs/extensions.md",
     owner: "@z80",
-    last_reviewed: ~D[2026-02-27],
+    last_reviewed: ~D[2026-05-03],
     max_age_days: 60
   },
   %{

--- a/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
+++ b/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
@@ -1,6 +1,6 @@
 # Lemon ↔ Hermes-Class Agent Harness Parity Scorecard
 
-Status: initial working scorecard for the `harness-parity` branch.
+Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ Track where Lemon already has Hermes-class agent harness behavior, where it is p
 
 Lemon already has the hard architectural primitives: supervised BEAM sessions, channel routing, CLI engine adapters, task/subagent execution, skill registry, memory search, tool policies, approvals, and a control plane. The biggest near-term gaps are mostly harness-contract gaps: making the native Lemon agent reliably use those primitives every run, then adding tests/evals that prevent regressions.
 
-The first code slice from this scorecard is to make `read_skill` available in the default native Lemon tool set, because the system prompt already instructs agents to use `read_skill` when a listed skill applies.
+The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure.
 
 ## Capability scorecard
 
@@ -35,7 +35,8 @@ The first code slice from this scorecard is to make `read_skill` available in th
 - Priority: high.
 - Acceptance tests:
   - Default tool set contains every tool referenced by the system prompt.
-  - Read-only and minimal-core policies allow context-loading tools such as `read_skill`.
+  - Read-only and minimal-core policies allow context-loading tools such as `read_skill` and `search_memory`.
+  - Eval harness includes deterministic contracts for memory scopes, memory-topic scaffolding, and relevant-skill prompt progressive disclosure.
   - Eval catches an agent finalizing after promising an action without calling a tool.
 
 ### Skills lifecycle and procedural memory
@@ -54,14 +55,15 @@ The first code slice from this scorecard is to make `read_skill` available in th
   - `read_skill` can read full content, summaries, sections, and linked files.
   - Install/update audit gates exist.
 - Gaps:
-  - `read_skill` was not exposed through the default coding tool factories / registry before this branch.
   - Missed-skill detection is not yet audited as a run outcome.
   - Skill authoring/patching from the agent loop is not as mature as read-only consumption.
-- Priority: highest first slice.
+  - Per-turn relevant-skill hints are not yet wired into the native session path as an enforced behavior.
+- Priority: high.
 - Acceptance tests:
   - Native Lemon default tools include `read_skill`.
   - System prompt mentions `read_skill` only when the tool is available, or tests enforce both surfaces move together.
-  - A skill-relevant fixture prompt causes the agent/eval harness to call `read_skill` before answering.
+  - Eval harness verifies a skill-relevant fixture prompt surfaces a `<relevant-skills>` block, includes a `read_skill` reminder, and does not inline full skill bodies.
+  - Future behavioral eval: a skill-relevant fixture prompt causes the agent/eval harness to call `read_skill` before answering.
 
 ### Memory and session recall
 
@@ -74,7 +76,7 @@ The first code slice from this scorecard is to make `read_skill` available in th
 - Strengths:
   - Completed runs become structured `MemoryDocument`s.
   - Full-text search supports current/project/home/session/agent/all scopes.
-  - Secret scanning prevents obvious memory leaks.
+  - Ingest-time secret scanning/redaction needs to be verified and hardened before claiming memory storage safety.
   - Skill synthesis can mine successful runs.
 - Gaps:
   - System prompt still mixes workspace memory files, memory topics, and session search in a way that may be confusing.
@@ -82,6 +84,8 @@ The first code slice from this scorecard is to make `read_skill` available in th
   - Need evals that force memory search when users reference prior work.
 - Priority: high.
 - Acceptance tests:
+  - `search_memory` defaults to current scope and searches both project and assistant-home memory without broadening missing contexts.
+  - `memory_topic` scaffolds `memory/topics/<slug>.md` from the workspace template and replaces the slug placeholder.
   - “Last time / remember when” prompts call `search_memory` before answering.
   - Memory-topic creation does not replace procedural skill authoring.
 
@@ -182,12 +186,20 @@ The first code slice from this scorecard is to make `read_skill` available in th
   - Need dashboard panels for skill loads, memory searches, approvals, subagent tree, and cron job runs.
 - Priority: medium.
 
-## First implementation slice
+## Implementation slices so far
 
-1. Expose `read_skill` from `CodingAgent.Tools` and `CodingAgent.ToolRegistry`.
-2. Allow `read_skill` in `read_only` and `minimal_core` policies.
-3. Update docs and tests so the prompt/tool contract stays synchronized.
-4. Add follow-up eval: prompt with a clearly matching skill must call `read_skill` before final answer.
+### Slice 1: Native `read_skill` / `search_memory` availability
+
+1. Exposed `read_skill` from `CodingAgent.Tools` and `CodingAgent.ToolRegistry`.
+2. Allowed `read_skill` and `search_memory` in relevant read/minimal policies.
+3. Updated docs and tests so the prompt/tool contract stays synchronized.
+
+### Slice 2: Memory and skill harness contract evals
+
+1. Added eval checks for default `search_memory` current-scope resolution.
+2. Added eval checks for `memory_topic` scaffold behavior.
+3. Added eval checks for relevant-skill prompt progressive disclosure and `read_skill` guidance.
+4. Added tests that require those checks to appear in `CodingAgent.Evals.Harness.run/1` and `mix lemon.eval` JSON output.
 
 ## Follow-up backlog
 
@@ -196,3 +208,4 @@ The first code slice from this scorecard is to make `read_skill` available in th
 3. Add missed-skill audit warnings based on `LemonSkills.find_relevant/2` and observed tool calls.
 4. Clarify memory/session-search/skills/todos in docs and prompt text.
 5. Add cron parity scorecard and scheduled job prompt validation.
+6. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, async task receipt → `join` before final answer.


### PR DESCRIPTION
## Summary
- Add deterministic eval checks for search_memory current-scope resolution and memory_topic scaffolding
- Add relevant-skill prompt progressive-disclosure eval coverage requiring read_skill guidance without inlining full skill bodies
- Require the new checks in Harness.run/1 and mix lemon.eval JSON output
- Update the CodingAgent README and Hermes parity scorecard

## Test Plan
- mix test apps/coding_agent/test/coding_agent/evals/harness_contract_test.exs apps/coding_agent/test/mix/tasks/lemon.eval_test.exs --include integration
- mix test apps/coding_agent/test/coding_agent/evals/harness_contract_test.exs apps/coding_agent/test/mix/tasks/lemon.eval_test.exs apps/coding_agent/test/coding_agent/system_prompt_test.exs apps/coding_agent/test/coding_agent/prompt_builder_test.exs apps/coding_agent/test/coding_agent/tools/memory_topic_test.exs apps/coding_agent/test/coding_agent/tools/search_memory_test.exs apps/coding_agent/test/coding_agent/tool_policy_test.exs apps/coding_agent/test/coding_agent/tool_registry_test.exs --include integration