### PR TITLE
Preselect relevant skills in session prompts

### DIFF
--- a/apps/agent_core/lib/agent_core/agent.ex
+++ b/apps/agent_core/lib/agent_core/agent.ex
@@ -348,10 +348,12 @@ defmodule AgentCore.Agent do
 
   Steering messages are delivered after the current tool execution completes,
   skipping remaining tool calls. Use this for "steering" the agent while it's working.
+  Pass `system_prompt: prompt` to apply a per-turn prompt refresh when the queued
+  message is consumed by an already-running loop.
   """
-  @spec steer(GenServer.server(), Types.agent_message()) :: :ok
-  def steer(agent, message) do
-    GenServer.cast(agent, {:steer, message})
+  @spec steer(GenServer.server(), Types.agent_message(), keyword()) :: :ok
+  def steer(agent, message, opts \\ []) do
+    GenServer.cast(agent, {:steer, queued_message(message, opts)})
   end
 
   @doc """
@@ -359,11 +361,12 @@ defmodule AgentCore.Agent do
 
   Follow-up messages are delivered only when the agent has no more tool calls
   and no steering messages. Use this for messages that should wait until the
-  agent completes its current work.
+  agent completes its current work. Pass `system_prompt: prompt` to apply a
+  per-turn prompt refresh when the queued message is consumed.
   """
-  @spec follow_up(GenServer.server(), Types.agent_message()) :: :ok
-  def follow_up(agent, message) do
-    GenServer.cast(agent, {:follow_up, message})
+  @spec follow_up(GenServer.server(), Types.agent_message(), keyword()) :: :ok
+  def follow_up(agent, message, opts \\ []) do
+    GenServer.cast(agent, {:follow_up, queued_message(message, opts)})
   end
 
   @doc """
@@ -835,6 +838,13 @@ defmodule AgentCore.Agent do
 
   defp abort_ref_matches?(state_abort_ref, abort_ref) do
     state_abort_ref == abort_ref or state_abort_ref == {:aborted, abort_ref}
+  end
+
+  defp queued_message(message, opts) do
+    case Keyword.get(opts, :system_prompt) do
+      prompt when is_binary(prompt) and prompt != "" -> %{message: message, system_prompt: prompt}
+      _ -> message
+    end
   end
 
   # ============================================================================

--- a/apps/agent_core/lib/agent_core/loop.ex
+++ b/apps/agent_core/lib/agent_core/loop.ex
@@ -564,6 +564,8 @@ defmodule AgentCore.Loop do
   end
 
   defp process_pending_messages(context, new_messages, pending_messages, stream) do
+    {context, pending_messages} = apply_queued_system_prompt(context, pending_messages)
+
     for message <- pending_messages do
       EventStream.push(stream, {:message_start, message})
       EventStream.push(stream, {:message_end, message})
@@ -573,6 +575,28 @@ defmodule AgentCore.Loop do
     new_messages = new_messages ++ pending_messages
 
     {context, new_messages, []}
+  end
+
+  defp apply_queued_system_prompt(context, pending_messages) do
+    {messages, latest_system_prompt} =
+      Enum.map_reduce(pending_messages, nil, fn
+        %{message: message, system_prompt: prompt}, _latest when is_binary(prompt) ->
+          {message, prompt}
+
+        %{message: message}, latest ->
+          {message, latest}
+
+        message, latest ->
+          {message, latest}
+      end)
+
+    context =
+      case latest_system_prompt do
+        prompt when is_binary(prompt) and prompt != "" -> %{context | system_prompt: prompt}
+        _ -> context
+      end
+
+    {context, messages}
   end
 
   # ============================================================================

--- a/apps/agent_core/test/agent_core/loop_test.exs
+++ b/apps/agent_core/test/agent_core/loop_test.exs
@@ -501,6 +501,57 @@ defmodule AgentCore.LoopTest do
       assert length(events) > 0
     end
 
+    test "applies queued system prompt to follow-up turns" do
+      parent = self()
+      context = simple_context(system_prompt: "base prompt")
+
+      follow_up = %{
+        message: user_message("use relevant skills"),
+        system_prompt: "follow-up prompt"
+      }
+
+      {:ok, responses} =
+        Agent.start_link(fn ->
+          [Mocks.assistant_message("first"), Mocks.assistant_message("second")]
+        end)
+
+      {:ok, follow_up_queue} = Agent.start_link(fn -> [follow_up] end)
+
+      stream_fn = fn _model, llm_context, _options ->
+        send(parent, {:seen_system_prompt, llm_context.system_prompt})
+
+        response =
+          Agent.get_and_update(responses, fn
+            [head | tail] -> {head, tail}
+            [] -> {Mocks.assistant_message("done"), []}
+          end)
+
+        {:ok, stream} = Ai.EventStream.start_link()
+
+        Task.start(fn ->
+          Ai.EventStream.push(stream, {:start, response})
+          Ai.EventStream.push(stream, {:done, response.stop_reason, response})
+          Ai.EventStream.complete(stream, response)
+        end)
+
+        {:ok, stream}
+      end
+
+      get_follow_up = fn ->
+        Agent.get_and_update(follow_up_queue, fn
+          [head | tail] -> {[head], tail}
+          [] -> {[], []}
+        end)
+      end
+
+      config = simple_config(stream_fn: stream_fn, get_follow_up_messages: get_follow_up)
+
+      Loop.stream([user_message("initial")], context, config) |> Enum.to_list()
+
+      assert_receive {:seen_system_prompt, "base prompt"}
+      assert_receive {:seen_system_prompt, "follow-up prompt"}
+    end
+
     test "does not skip tool calls when steering messages arrive" do
       echo_tool = Mocks.echo_tool()
       context = simple_context(tools: [echo_tool])

--- a/apps/coding_agent/README.md
+++ b/apps/coding_agent/README.md
@@ -90,7 +90,7 @@ CodingAgent.Supervisor (one_for_one)
 | `CodingAgent.Session.CompactionManager` | Auto-compaction scheduling, overflow recovery state machine, and compaction result application |
 | `CodingAgent.Session.MessageSerialization` | Serializes/deserializes messages between session and agent core formats |
 | `CodingAgent.Session.ModelResolver` | Resolves model structs from string specs, maps, or settings; handles API key lookup via env vars and secrets with OAuth refresh |
-| `CodingAgent.Session.PromptComposer` | Composes the final system prompt by layering base prompt, prompt templates, explicit system prompt, and resource loader instructions |
+| `CodingAgent.Session.PromptComposer` | Composes the final system prompt by layering base prompt, prompt templates, explicit system prompt, current-prompt relevant skill hints, and resource loader instructions |
 | `CodingAgent.Session.WasmBridge` | Bridges WASM sidecar tools into the session tool set |
 | `CodingAgent.SessionManager` | JSONL persistence engine with tree-structured entries (branching, compaction, labels), atomic writes, append-only incremental saves, and version migrations (v1-v3) |
 | `CodingAgent.SessionSupervisor` | DynamicSupervisor for session processes with health check and list capabilities |
@@ -158,7 +158,7 @@ Pure text-only external `codex`/`claude` tasks with no explicit `cwd` and no rol
 | `CodingAgent.Compaction` | Context compaction engine -- finds valid cut points, generates LLM summaries, preserves file context |
 | `CodingAgent.CompactionHooks` | Hooks for compaction lifecycle events |
 | `CodingAgent.Workspace` | Loads bootstrap files (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, BOOTSTRAP.md, MEMORY.md) from the assistant home at `~/.lemon/agent/workspace/` |
-| `CodingAgent.SystemPrompt` | Builds the Lemon base system prompt (assistant-home bootstrap files + skills list + memory workflow + runtime metadata) |
+| `CodingAgent.SystemPrompt` | Builds the Lemon base system prompt (assistant-home bootstrap files + available skills list + current-prompt relevant skill hints + memory workflow + runtime metadata) |
 | `CodingAgent.PromptBuilder` | Higher-level prompt builder adding skills, commands, @mention sections |
 | `CodingAgent.ResourceLoader` | Loads CLAUDE.md/AGENTS.md from cwd hierarchy up to root, then home directory; also loads prompts, themes, and skills |
 

--- a/apps/coding_agent/lib/coding_agent/session.ex
+++ b/apps/coding_agent/lib/coding_agent/session.ex
@@ -578,31 +578,38 @@ defmodule CodingAgent.Session do
       # This also gives the session a chance to receive near-immediate `follow_up/2` and
       # `steer/2` messages before the agent loop does its end-of-turn queue checks in
       # very fast (mocked) runs.
-      timer_ref = Process.send_after(self(), {:do_prompt, user_message}, @prompt_defer_ms)
+      timer_ref =
+        Process.send_after(
+          self(),
+          {:do_prompt, user_message, state.system_prompt},
+          @prompt_defer_ms
+        )
 
       {:reply, :ok, State.begin_prompt(state, timer_ref)}
     end
   end
 
   def handle_call({:handle_async_followup, message_or_attrs}, _from, state) do
-    state = refresh_system_prompt(state)
     message = State.build_async_followup_message(message_or_attrs)
+    state = refresh_system_prompt(state, message_skill_context(message))
     state = persist_message(state, message)
 
     if state.is_streaming do
       case AsyncFollowups.live_delivery_mode(message) do
         :steer ->
-          AgentCore.Agent.steer(state.agent, message)
+          AgentCore.Agent.steer(state.agent, message, system_prompt: state.system_prompt)
           queue = :queue.in(message, state.steering_queue)
           {:reply, :ok, %{state | steering_queue: queue}}
 
         :followup ->
-          AgentCore.Agent.follow_up(state.agent, message)
+          AgentCore.Agent.follow_up(state.agent, message, system_prompt: state.system_prompt)
           queue = :queue.in(message, state.follow_up_queue)
           {:reply, :ok, %{state | follow_up_queue: queue}}
       end
     else
-      timer_ref = Process.send_after(self(), {:do_prompt, message}, @prompt_defer_ms)
+      timer_ref =
+        Process.send_after(self(), {:do_prompt, message, state.system_prompt}, @prompt_defer_ms)
+
       {:reply, :ok, State.begin_prompt(state, timer_ref)}
     end
   end
@@ -831,7 +838,7 @@ defmodule CodingAgent.Session do
       timestamp: System.system_time(:millisecond)
     }
 
-    AgentCore.Agent.steer(state.agent, message)
+    AgentCore.Agent.steer(state.agent, message, system_prompt: state.system_prompt)
     queue = :queue.in(message, state.steering_queue)
 
     {:noreply, %{state | steering_queue: queue}}
@@ -846,7 +853,7 @@ defmodule CodingAgent.Session do
       timestamp: System.system_time(:millisecond)
     }
 
-    AgentCore.Agent.follow_up(state.agent, message)
+    AgentCore.Agent.follow_up(state.agent, message, system_prompt: state.system_prompt)
     queue = :queue.in(message, state.follow_up_queue)
 
     {:noreply, %{state | follow_up_queue: queue}}
@@ -957,24 +964,34 @@ defmodule CodingAgent.Session do
     end
   end
 
-  def handle_info({:do_prompt, %Ai.Types.UserMessage{} = user_message}, state) do
+  def handle_info({:do_prompt, %Ai.Types.UserMessage{} = user_message, system_prompt}, state) do
     if state.pending_prompt_timer_ref do
+      :ok = AgentCore.Agent.set_system_prompt(state.agent, system_prompt)
       # Send to agent (user message will be persisted on :message_end event)
       _ = AgentCore.Agent.prompt(state.agent, user_message)
-      {:noreply, %{state | pending_prompt_timer_ref: nil}}
+      {:noreply, %{state | pending_prompt_timer_ref: nil, system_prompt: system_prompt}}
     else
       # Prompt was canceled (e.g. via abort/reset) before deferred dispatch.
       {:noreply, state}
     end
   end
 
-  def handle_info({:do_prompt, %CustomMessage{} = message}, state) do
+  def handle_info({:do_prompt, %CustomMessage{} = message, system_prompt}, state) do
     if state.pending_prompt_timer_ref do
+      :ok = AgentCore.Agent.set_system_prompt(state.agent, system_prompt)
       _ = AgentCore.Agent.prompt(state.agent, message)
-      {:noreply, %{state | pending_prompt_timer_ref: nil}}
+      {:noreply, %{state | pending_prompt_timer_ref: nil, system_prompt: system_prompt}}
     else
       {:noreply, state}
     end
+  end
+
+  def handle_info({:do_prompt, %Ai.Types.UserMessage{} = user_message}, state) do
+    handle_info({:do_prompt, user_message, state.system_prompt}, state)
+  end
+
+  def handle_info({:do_prompt, %CustomMessage{} = message}, state) do
+    handle_info({:do_prompt, message, state.system_prompt}, state)
   end
 
   def handle_info(_msg, state) do
@@ -1011,9 +1028,35 @@ defmodule CodingAgent.Session do
   # Private Functions
   # ============================================================================
 
-  @spec refresh_system_prompt(t()) :: t()
+  defp message_skill_context(%Ai.Types.UserMessage{content: content}),
+    do: content_skill_context(content)
+
+  defp message_skill_context(%CustomMessage{content: content, display: display}) do
+    [content_skill_context(content), content_skill_context(display)]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join("\n")
+  end
+
+  defp message_skill_context(_message), do: ""
+
+  defp content_skill_context(content) when is_binary(content), do: content
+
+  defp content_skill_context(content) when is_list(content) do
+    content
+    |> Enum.map(fn
+      %Ai.Types.TextContent{text: text} when is_binary(text) -> text
+      %{text: text} when is_binary(text) -> text
+      text when is_binary(text) -> text
+      _ -> ""
+    end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp content_skill_context(_content), do: ""
+
   @spec refresh_system_prompt(t(), String.t()) :: t()
-  defp refresh_system_prompt(state, skill_context \\ "") do
+  defp refresh_system_prompt(state, skill_context) do
     case PromptComposer.maybe_refresh_system_prompt(
            state.cwd,
            state.explicit_system_prompt,

--- a/apps/coding_agent/lib/coding_agent/session.ex
+++ b/apps/coding_agent/lib/coding_agent/session.ex
@@ -569,7 +569,7 @@ defmodule CodingAgent.Session do
     if state.is_streaming do
       {:reply, {:error, :already_streaming}, state}
     else
-      state = refresh_system_prompt(state)
+      state = refresh_system_prompt(state, text)
       user_message = State.build_prompt_message(text, opts)
 
       # Defer the actual prompt slightly after we reply so callers can subscribe immediately
@@ -823,7 +823,7 @@ defmodule CodingAgent.Session do
   @spec handle_cast(term(), t()) :: {:noreply, t()}
   @impl true
   def handle_cast({:steer, text}, state) do
-    state = refresh_system_prompt(state)
+    state = refresh_system_prompt(state, text)
 
     message = %Ai.Types.UserMessage{
       role: :user,
@@ -838,7 +838,7 @@ defmodule CodingAgent.Session do
   end
 
   def handle_cast({:follow_up, text}, state) do
-    state = refresh_system_prompt(state)
+    state = refresh_system_prompt(state, text)
 
     message = %Ai.Types.UserMessage{
       role: :user,
@@ -1012,14 +1012,16 @@ defmodule CodingAgent.Session do
   # ============================================================================
 
   @spec refresh_system_prompt(t()) :: t()
-  defp refresh_system_prompt(state) do
+  @spec refresh_system_prompt(t(), String.t()) :: t()
+  defp refresh_system_prompt(state, skill_context \\ "") do
     case PromptComposer.maybe_refresh_system_prompt(
            state.cwd,
            state.explicit_system_prompt,
            state.prompt_template,
            state.workspace_dir,
            state.session_scope,
-           state.system_prompt
+           state.system_prompt,
+           skill_context
          ) do
       :unchanged ->
         state

--- a/apps/coding_agent/lib/coding_agent/session/prompt_composer.ex
+++ b/apps/coding_agent/lib/coding_agent/session/prompt_composer.ex
@@ -26,9 +26,17 @@ defmodule CodingAgent.Session.PromptComposer do
           String.t() | nil,
           String.t() | nil,
           String.t(),
-          :main | :subagent
+          :main | :subagent,
+          String.t()
         ) :: String.t()
-  def compose_system_prompt(cwd, explicit_prompt, prompt_template, workspace_dir, session_scope) do
+  def compose_system_prompt(
+        cwd,
+        explicit_prompt,
+        prompt_template,
+        workspace_dir,
+        session_scope,
+        skill_context \\ ""
+      ) do
     # Load prompt template if specified
     template_content =
       case prompt_template do
@@ -46,7 +54,8 @@ defmodule CodingAgent.Session.PromptComposer do
     base_prompt =
       CodingAgent.SystemPrompt.build(cwd, %{
         workspace_dir: workspace_dir,
-        session_scope: session_scope
+        session_scope: session_scope,
+        skill_context: skill_context
       })
 
     # Load instructions (CLAUDE.md, AGENTS.md) from cwd and parent directories
@@ -101,6 +110,7 @@ defmodule CodingAgent.Session.PromptComposer do
           String.t() | nil,
           String.t(),
           :main | :subagent,
+          String.t(),
           String.t()
         ) :: {:changed, String.t()} | :unchanged
   def maybe_refresh_system_prompt(
@@ -109,7 +119,8 @@ defmodule CodingAgent.Session.PromptComposer do
         prompt_template,
         workspace_dir,
         session_scope,
-        current_prompt
+        current_prompt,
+        skill_context \\ ""
       ) do
     next_prompt =
       compose_system_prompt(
@@ -117,7 +128,8 @@ defmodule CodingAgent.Session.PromptComposer do
         explicit_system_prompt,
         prompt_template,
         workspace_dir,
-        session_scope
+        session_scope,
+        skill_context
       )
 
     if next_prompt == current_prompt do

--- a/apps/coding_agent/lib/coding_agent/system_prompt.ex
+++ b/apps/coding_agent/lib/coding_agent/system_prompt.ex
@@ -14,7 +14,9 @@ defmodule CodingAgent.SystemPrompt do
   @type opts :: %{
           optional(:workspace_dir) => String.t(),
           optional(:bootstrap_max_chars) => pos_integer(),
-          optional(:session_scope) => :main | :subagent | String.t()
+          optional(:session_scope) => :main | :subagent | String.t(),
+          optional(:skill_context) => String.t(),
+          optional(:max_relevant_skills) => pos_integer()
         }
 
   @doc """
@@ -28,6 +30,8 @@ defmodule CodingAgent.SystemPrompt do
     workspace_dir = Map.get(opts, :workspace_dir, Workspace.workspace_dir())
     max_chars = Map.get(opts, :bootstrap_max_chars, Workspace.default_max_chars())
     session_scope = normalize_session_scope(Map.get(opts, :session_scope, :main))
+    skill_context = Map.get(opts, :skill_context, "")
+    max_relevant_skills = Map.get(opts, :max_relevant_skills, 3)
 
     bootstrap_files =
       Workspace.load_bootstrap_files(
@@ -39,6 +43,7 @@ defmodule CodingAgent.SystemPrompt do
     sections = [
       "You are a personal assistant running inside Lemon.",
       build_runtime_section(session_scope),
+      build_relevant_skills_section(cwd, skill_context, max_relevant_skills),
       build_skills_section(cwd),
       build_memory_workflow_section(session_scope),
       build_workspace_section(cwd, workspace_dir),
@@ -69,6 +74,18 @@ defmodule CodingAgent.SystemPrompt do
   # ============================================================================
   # Sections
   # ============================================================================
+
+  defp build_relevant_skills_section(_cwd, context, _max_skills) when context in [nil, ""], do: ""
+
+  defp build_relevant_skills_section(cwd, context, max_skills) when is_binary(context) do
+    views =
+      context
+      |> LemonSkills.find_relevant(cwd: cwd, max_results: max_skills, refresh: true)
+      |> Enum.map(&LemonSkills.SkillView.from_entry(&1, cwd: cwd))
+      |> Enum.filter(&LemonSkills.SkillView.displayable?/1)
+
+    PromptView.render_relevant_skills(views)
+  end
 
   defp build_skills_section(cwd) do
     PromptView.render_for_prompt(cwd)

--- a/apps/coding_agent/lib/coding_agent/system_prompt.ex
+++ b/apps/coding_agent/lib/coding_agent/system_prompt.ex
@@ -80,7 +80,7 @@ defmodule CodingAgent.SystemPrompt do
   defp build_relevant_skills_section(cwd, context, max_skills) when is_binary(context) do
     views =
       context
-      |> LemonSkills.find_relevant(cwd: cwd, max_results: max_skills, refresh: true)
+      |> LemonSkills.find_relevant(cwd: cwd, max_results: max_skills, refresh: false)
       |> Enum.map(&LemonSkills.SkillView.from_entry(&1, cwd: cwd))
       |> Enum.filter(&LemonSkills.SkillView.displayable?/1)
 

--- a/apps/coding_agent/test/coding_agent/prompt_builder_test.exs
+++ b/apps/coding_agent/test/coding_agent/prompt_builder_test.exs
@@ -6,6 +6,42 @@ defmodule CodingAgent.PromptBuilderTest do
   @moduletag :tmp_dir
 
   describe "build/2" do
+    test "passes context through to relevance-selected skill hints", %{tmp_dir: tmp_dir} do
+      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "github-pr-workflow"])
+      File.mkdir_p!(skill_dir)
+
+      File.write!(
+        Path.join(skill_dir, "SKILL.md"),
+        """
+        ---
+        name: github-pr-workflow
+        description: GitHub pull request lifecycle and CI checks
+        keywords:
+          - github
+          - pull request
+          - ci
+        ---
+
+        Full body should not be inlined.
+        """
+      )
+
+      result =
+        PromptBuilder.build(tmp_dir, %{
+          base_prompt: "Base.",
+          context: "open a github pull request and monitor ci",
+          include_skills: true,
+          include_commands: false,
+          include_mentions: false
+        })
+
+      assert String.contains?(result, "Base.")
+      assert String.contains?(result, "<relevant-skills>")
+      assert String.contains?(result, "github-pr-workflow")
+      assert String.contains?(result, "Use `read_skill` with <key>")
+      refute String.contains?(result, "Full body should not be inlined.")
+    end
+
     test "returns base prompt when no extras", %{tmp_dir: tmp_dir} do
       result =
         PromptBuilder.build(tmp_dir, %{

--- a/apps/coding_agent/test/coding_agent/session/prompt_composer_test.exs
+++ b/apps/coding_agent/test/coding_agent/session/prompt_composer_test.exs
@@ -1,0 +1,49 @@
+defmodule CodingAgent.Session.PromptComposerTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAgent.Session.PromptComposer
+
+  @moduletag :tmp_dir
+
+  test "compose_system_prompt/6 injects relevant skills for current prompt context", %{
+    tmp_dir: tmp_dir
+  } do
+    workspace_dir = Path.join(tmp_dir, "workspace")
+    File.mkdir_p!(workspace_dir)
+    File.write!(Path.join(workspace_dir, "AGENTS.md"), "workspace agents")
+
+    skill_dir = Path.join([tmp_dir, ".lemon", "skill", "github-pr-workflow"])
+    File.mkdir_p!(skill_dir)
+
+    File.write!(
+      Path.join(skill_dir, "SKILL.md"),
+      """
+      ---
+      name: github-pr-workflow
+      description: GitHub pull request lifecycle, CI checks, branches, commits, PR creation
+      keywords:
+        - github
+        - pull request
+        - ci
+      ---
+
+      Full body should stay behind read_skill.
+      """
+    )
+
+    prompt =
+      PromptComposer.compose_system_prompt(
+        tmp_dir,
+        nil,
+        nil,
+        workspace_dir,
+        :main,
+        "please open a GitHub pull request and monitor CI"
+      )
+
+    assert String.contains?(prompt, "<relevant-skills>")
+    assert String.contains?(prompt, "github-pr-workflow")
+    assert String.contains?(prompt, "Use `read_skill` with <key>")
+    refute String.contains?(prompt, "Full body should stay behind read_skill.")
+  end
+end

--- a/apps/coding_agent/test/coding_agent/system_prompt_test.exs
+++ b/apps/coding_agent/test/coding_agent/system_prompt_test.exs
@@ -71,6 +71,79 @@ defmodule CodingAgent.SystemPromptTest do
   end
 
   @tag :tmp_dir
+  test "includes relevance-selected skill hints when skill context matches", %{tmp_dir: tmp_dir} do
+    workspace_dir = Path.join(tmp_dir, "workspace")
+    File.mkdir_p!(workspace_dir)
+    File.write!(Path.join(workspace_dir, "AGENTS.md"), "agents")
+
+    skill_dir = Path.join([tmp_dir, ".lemon", "skill", "github-pr-workflow"])
+    File.mkdir_p!(skill_dir)
+
+    skill_body = "Follow the complete GitHub PR lifecycle details."
+
+    File.write!(
+      Path.join(skill_dir, "SKILL.md"),
+      """
+      ---
+      name: github-pr-workflow
+      description: GitHub pull request lifecycle, CI checks, branches, commits, PR creation, merge readiness
+      keywords:
+        - github
+        - pull request
+        - pr
+        - ci
+      ---
+
+      #{skill_body}
+      """
+    )
+
+    prompt =
+      SystemPrompt.build(tmp_dir, %{
+        workspace_dir: workspace_dir,
+        session_scope: :main,
+        skill_context: "please create a GitHub pull request and watch CI"
+      })
+
+    assert String.contains?(prompt, "<relevant-skills>")
+    assert String.contains?(prompt, "github-pr-workflow")
+    assert String.contains?(prompt, "Use `read_skill` with <key>")
+    refute String.contains?(prompt, skill_body)
+  end
+
+  @tag :tmp_dir
+  test "omits relevance-selected skill hints without skill context", %{tmp_dir: tmp_dir} do
+    workspace_dir = Path.join(tmp_dir, "workspace")
+    File.mkdir_p!(workspace_dir)
+    File.write!(Path.join(workspace_dir, "AGENTS.md"), "agents")
+
+    skill_dir = Path.join([tmp_dir, ".lemon", "skill", "github-pr-workflow"])
+    File.mkdir_p!(skill_dir)
+
+    File.write!(
+      Path.join(skill_dir, "SKILL.md"),
+      """
+      ---
+      name: github-pr-workflow
+      description: GitHub pull request lifecycle
+      ---
+
+      Follow the full workflow.
+      """
+    )
+
+    prompt =
+      SystemPrompt.build(tmp_dir, %{
+        workspace_dir: workspace_dir,
+        session_scope: :main
+      })
+
+    refute String.contains?(prompt, "<relevant-skills>")
+    assert String.contains?(prompt, "<available_skills>")
+    assert String.contains?(prompt, "github-pr-workflow")
+  end
+
+  @tag :tmp_dir
   test "subagent scope excludes memory and soul context", %{tmp_dir: tmp_dir} do
     workspace_dir = Path.join(tmp_dir, "workspace")
     File.mkdir_p!(workspace_dir)

--- a/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
+++ b/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
@@ -1,6 +1,6 @@
 # Lemon ↔ Hermes-Class Agent Harness Parity Scorecard
 
-Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills.
+Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, and third slice wires relevant-skill preselection into the native session prompt path.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ Track where Lemon already has Hermes-class agent harness behavior, where it is p
 
 Lemon already has the hard architectural primitives: supervised BEAM sessions, channel routing, CLI engine adapters, task/subagent execution, skill registry, memory search, tool policies, approvals, and a control plane. The biggest near-term gaps are mostly harness-contract gaps: making the native Lemon agent reliably use those primitives every run, then adding tests/evals that prevent regressions.
 
-The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure.
+The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`.
 
 ## Capability scorecard
 
@@ -52,12 +52,13 @@ The first code slice from this scorecard made `read_skill` available in the defa
   - Registry supports global, project, and `.agents/skills` compatibility paths.
   - Relevance scoring exists.
   - Prompt renderer lists available skills and tells the agent to load relevant skills.
+  - Native session prompt refresh passes the current user prompt into relevance scoring and renders concise `<relevant-skills>` hints per turn.
   - `read_skill` can read full content, summaries, sections, and linked files.
   - Install/update audit gates exist.
 - Gaps:
   - Missed-skill detection is not yet audited as a run outcome.
   - Skill authoring/patching from the agent loop is not as mature as read-only consumption.
-  - Per-turn relevant-skill hints are not yet wired into the native session path as an enforced behavior.
+  - Per-turn relevant-skill hints are guided, but not yet enforced through observed tool-call telemetry.
 - Priority: high.
 - Acceptance tests:
   - Native Lemon default tools include `read_skill`.
@@ -201,11 +202,16 @@ The first code slice from this scorecard made `read_skill` available in the defa
 3. Added eval checks for relevant-skill prompt progressive disclosure and `read_skill` guidance.
 4. Added tests that require those checks to appear in `CodingAgent.Evals.Harness.run/1` and `mix lemon.eval` JSON output.
 
+### Slice 3: Native relevant-skill preselection
+
+1. Extended `CodingAgent.SystemPrompt.build/2` with `:skill_context` and `:max_relevant_skills` options.
+2. Updated session prompt refresh to pass the current user prompt/steer/follow-up text into skill relevance scoring.
+3. Added contract tests for system-prompt, prompt-builder, and session prompt-composer paths that require concise `<relevant-skills>` hints and keep full skill bodies behind `read_skill`.
+
 ## Follow-up backlog
 
-1. Add a “prompt-contract integrity” test that fails when system prompt references a tool not in default tools.
-2. Add skill-load telemetry fields to run events or session metadata.
-3. Add missed-skill audit warnings based on `LemonSkills.find_relevant/2` and observed tool calls.
-4. Clarify memory/session-search/skills/todos in docs and prompt text.
-5. Add cron parity scorecard and scheduled job prompt validation.
-6. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, async task receipt → `join` before final answer.
+1. Add skill-load telemetry fields to run events or session metadata.
+2. Add missed-skill audit warnings based on `LemonSkills.find_relevant/2` and observed tool calls.
+3. Clarify memory/session-search/skills/todos in docs and prompt text.
+4. Add cron parity scorecard and scheduled job prompt validation.
+5. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, async task receipt → `join` before final answer.


### PR DESCRIPTION
## Summary
- pass the current user prompt/steer/follow-up text into native session prompt composition
- render concise <relevant-skills> hints from LemonSkills relevance scoring while keeping full skill bodies behind read_skill
- add contract coverage for SystemPrompt, PromptBuilder, and PromptComposer paths
- update CodingAgent docs and the Hermes parity scorecard for slice 3

## Validation
- mix test apps/coding_agent/test/coding_agent/system_prompt_test.exs apps/coding_agent/test/coding_agent/prompt_builder_test.exs apps/coding_agent/test/coding_agent/session/prompt_composer_test.exs apps/coding_agent/test/coding_agent/evals/harness_contract_test.exs apps/coding_agent/test/coding_agent/evals/harness_test.exs apps/coding_agent/test/mix/tasks/lemon.eval_test.exs
- mix lemon.quality

Stacked on PR #25 because it adds the harness contract eval baseline this slice builds on.