### PR TITLE
chore: add canonical test runner lanes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Lint CI/docs policy
         run: bash scripts/lint_ci_docs.sh
 
+      - name: Check canonical test runner contract
+        run: bash scripts/test_contract.sh
+
       - name: Run quality checks
         run: mix lemon.quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,24 +179,18 @@ mix deps.get
 # Compile all apps
 mix compile
 
-# Run all tests
-mix test
-
-# Run umbrella tests with coverage
-mix test --cover --exclude integration
-
-# Run tests for specific app
-mix test apps/ai
-mix test apps/coding_agent
-
-# Run integration tests
-mix test --include integration
+# Canonical repo-level test lanes
+scripts/test help
+scripts/test fast       # compile with warnings as errors + ExUnit excluding integration
+scripts/test quality    # Lemon quality gates and focused quality tests
+scripts/test clients    # Node client CI parity checks
+scripts/test eval-fast  # small eval harness run
+scripts/test smoke      # CI-only product-smoke pointer
+scripts/test all        # useful local aggregate
+scripts/test path apps/ai/test --seed 1
 
 # Format code
 mix format
-
-# Quality checks after docs/dependency changes
-mix lemon.quality
 ```
 
 ### TUI Client (TypeScript)
@@ -415,6 +409,7 @@ This repository includes an optional pre-push hook that uses **kimi** to review 
 - `docs/config.md` - Runtime configuration reference
 - `docs/skills.md` - Skill system documentation
 - `docs/quality_harness.md` - Quality checks and cleanup (`mix lemon.quality`, `mix lemon.cleanup`)
+- `docs/testing.md` - Canonical repo-level test lanes and CI parity guidance
 - `docs/assistant_bootstrap_contract.md` - Bootstrap contract
 - `docs/context.md` - Context management
 - `docs/remote-cli-task-execution-plan.md` - Planning note for remote `codex`/`claude` task execution over generic runner backends

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,13 @@ Full setup: [`docs/user-guide/setup.md`](docs/user-guide/setup.md)
 ## Development
 
 ```bash
-mix test                   # all tests
-mix test apps/lemon_core   # one app
-mix lemon.quality          # lint + architecture boundaries + doc freshness
+scripts/test fast                 # compile with warnings as errors + ExUnit excluding integration
+scripts/test path apps/lemon_core/test
+scripts/test quality              # lint + architecture boundaries + doc freshness
 ```
+
+See [`docs/testing.md`](docs/testing.md) for the canonical local test lanes and
+how they map to CI.
 
 ## Commit Style (Conventional Commits)
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,13 @@ Full Telegram setup details: [`docs/user-guide/setup.md`](docs/user-guide/setup.
 ## Development
 
 ```bash
-mix test                          # all tests
-mix test apps/lemon_skills        # one app
-mix lemon.quality                 # lint + doc freshness + architecture boundaries
+scripts/test fast                 # compile with warnings as errors + ExUnit excluding integration
+scripts/test path apps/lemon_skills/test
+scripts/test quality              # lint + doc freshness + architecture boundaries
 ```
+
+See [`docs/testing.md`](docs/testing.md) for the canonical local test lanes and
+how they map to CI.
 
 GitHub Copilot coding-agent runs use
 [`/.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@
 | Doc | What it covers |
 |-----|---------------|
 | [long-running-agent-harnesses.md](long-running-agent-harnesses.md) | Long-running harness patterns, eval loops, and runtime validation workflows |
+| [testing.md](testing.md) | Canonical local test lanes and CI parity guidance |
 | [config.md](config.md) | TOML configuration reference (providers, runtime, gateway, profiles, tools) |
 | [extensions.md](extensions.md) | Extension/plugin API, tool hooks, conflict resolution |
 

--- a/docs/catalog.exs
+++ b/docs/catalog.exs
@@ -126,6 +126,12 @@
     max_age_days: 90
   },
   %{
+    path: "docs/testing.md",
+    owner: "@z80",
+    last_reviewed: ~D[2026-05-05],
+    max_age_days: 60
+  },
+  %{
     path: "docs/testing/deterministic-test-patterns.md",
     owner: "@z80",
     last_reviewed: ~D[2026-04-23],

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,41 @@
+# Lemon testing lanes
+
+`scripts/test` is the canonical repo-level test runner. It keeps local commands close to CI while leaving heavyweight or environment-specific checks explicit.
+
+## Quick usage
+
+```bash
+scripts/test help
+scripts/test fast
+scripts/test quality
+scripts/test clients
+scripts/test eval-fast
+scripts/test smoke
+scripts/test all
+scripts/test path apps/lemon_core/test/lemon_core/quality --seed 1
+```
+
+## Lanes
+
+- `fast`: compiles with `mix compile --warnings-as-errors`, then runs `mix test --exclude integration`. The lane defaults to `MIX_ENV=test` and creates per-invocation temp `LEMON_TEST_TMPDIR` and `LEMON_STORE_PATH` values when they are not already set.
+- `quality`: runs Lemon's lightweight policy/quality gates: `scripts/lint_ci_docs.sh`, `scripts/test_contract.sh`, `mix lemon.skill.lint`, `mix lemon.quality`, `mix lemon.check_duplicate_tests`, and the focused quality/eval contract tests used by CI.
+- `clients`: mirrors the client CI job for `clients/lemon-web`, `clients/lemon-tui`, and `clients/lemon-browser-node`: install dependencies when `node_modules` is absent, typecheck, lint, build, run coverage tests, and audit production dependencies.
+- `eval-fast`: runs a small deterministic eval harness invocation with `mix lemon.eval --iterations ${LEMON_EVAL_ITERATIONS:-3}`. Increase `LEMON_EVAL_ITERATIONS` locally when you need more confidence.
+- `smoke`: documents the product-smoke lane and points at `.github/workflows/product-smoke.yml`. It exits successfully locally because the current product smoke builds and boots a release with CI assumptions.
+- `all`: useful local aggregate for BEAM-centric pre-review confidence: `fast`, `quality`, `eval-fast`, then `smoke`. Run `clients` separately when client code or shared contracts changed.
+- `path`: pass-through to `mix test` for specific paths or ExUnit args, for example `scripts/test path apps/coding_agent/test --only some_tag`.
+
+## Local/CI parity
+
+- `fast` is the local counterpart for the CI umbrella test job's compile and `mix test --exclude integration` steps.
+- `quality` follows the repository quality job without the heavyweight WASM/integration loop. Use CI or targeted manual commands for `cargo test --manifest-path native/lemon-wasm-runtime/Cargo.toml` and WASM integration coverage.
+- `clients` follows the CI client job command order for each Node client.
+- `eval-fast` is intentionally smaller than CI's `mix lemon.eval --iterations 20` so developers can run it frequently.
+- `smoke` is CI-only until there is a stable local release-smoke wrapper; use the GitHub workflow for the full product smoke.
+
+## Notes for agents
+
+- Prefer `scripts/test fast` over ad hoc `mix test` for broad local checks.
+- Prefer `scripts/test path ...` when validating a narrow change.
+- Keep new lanes documented here and visible in `scripts/test help`.
+- Do not add full hermetic environment scrubbing in this runner without a separate design; Phase 1 only sets basic deterministic temp paths for test lanes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ scripts/test path apps/lemon_core/test/lemon_core/quality --seed 1
 ## Lanes
 
 - `fast`: compiles with `mix compile --warnings-as-errors`, then runs `mix test --exclude integration`. The lane defaults to `MIX_ENV=test` and creates per-invocation temp `LEMON_TEST_TMPDIR` and `LEMON_STORE_PATH` values when they are not already set.
-- `quality`: runs Lemon's lightweight policy/quality gates: `scripts/lint_ci_docs.sh`, `scripts/test_contract.sh`, `mix lemon.skill.lint`, `mix lemon.quality`, `mix lemon.check_duplicate_tests`, and the focused quality/eval contract tests used by CI.
+- `quality`: runs Lemon's lightweight policy/quality gates: `scripts/lint_ci_docs.sh`, `scripts/test_contract.sh`, `mix lemon.skill.lint`, `mix lemon.quality`, and the focused quality/eval contract tests used by CI. `mix lemon.quality` already runs the duplicate test module guard internally.
 - `clients`: mirrors the client CI job for `clients/lemon-web`, `clients/lemon-tui`, and `clients/lemon-browser-node`: install dependencies when `node_modules` is absent, typecheck, lint, build, run coverage tests, and audit production dependencies.
 - `eval-fast`: runs a small deterministic eval harness invocation with `mix lemon.eval --iterations ${LEMON_EVAL_ITERATIONS:-3}`. Increase `LEMON_EVAL_ITERATIONS` locally when you need more confidence.
 - `smoke`: documents the product-smoke lane and points at `.github/workflows/product-smoke.yml`. It exits successfully locally because the current product smoke builds and boots a release with CI assumptions.

--- a/scripts/test
+++ b/scripts/test
@@ -35,7 +35,12 @@ ensure_repo_root() {
 
 setup_test_env() {
   export MIX_ENV="${MIX_ENV:-test}"
-  export LEMON_TEST_TMPDIR="${LEMON_TEST_TMPDIR:-$(mktemp -d "${TMPDIR:-/tmp}/lemon-test.XXXXXX")}"
+
+  if [ -z "${LEMON_TEST_TMPDIR:-}" ]; then
+    export LEMON_TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/lemon-test.XXXXXX")"
+    trap 'rm -rf "$LEMON_TEST_TMPDIR"' EXIT
+  fi
+
   export LEMON_STORE_PATH="${LEMON_STORE_PATH:-$LEMON_TEST_TMPDIR/store}"
   mkdir -p "$LEMON_STORE_PATH"
 }
@@ -54,7 +59,6 @@ run_quality() {
   bash scripts/test_contract.sh
   mix lemon.skill.lint
   mix lemon.quality
-  mix lemon.check_duplicate_tests
   mix test apps/lemon_core/test/lemon_core/quality apps/coding_agent/test/coding_agent/evals/harness_test.exs
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Canonical Lemon repo-level test runner.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LANE="${1:-help}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/test <lane> [args]
+
+Canonical test lanes:
+  fast       MIX_ENV=test compile with warnings as errors, then ExUnit excluding integration
+  quality    Lemon quality gates: CI/docs lint, skill lint, architecture quality, duplicate tests, focused quality tests
+  clients    Node client CI parity checks for lemon-web, lemon-tui, and lemon-browser-node
+  eval-fast  Small deterministic eval harness run: mix lemon.eval --iterations ${LEMON_EVAL_ITERATIONS:-3}
+  smoke      Local product-smoke pointer; CI-only release smoke is in .github/workflows/product-smoke.yml
+  all        Useful local aggregate: fast, quality, eval-fast, smoke
+  path       Pass-through to mix test for paths or ExUnit args: scripts/test path apps/foo/test --seed 1
+  help       Show this message
+
+Runner defaults:
+  - Runs from the repository root.
+  - Sets MIX_ENV=test for BEAM test lanes unless a lane intentionally overrides it.
+  - Creates per-invocation temp LEMON_STORE_PATH and LEMON_TEST_TMPDIR when unset.
+EOF
+}
+
+ensure_repo_root() {
+  cd "$ROOT"
+}
+
+setup_test_env() {
+  export MIX_ENV="${MIX_ENV:-test}"
+  export LEMON_TEST_TMPDIR="${LEMON_TEST_TMPDIR:-$(mktemp -d "${TMPDIR:-/tmp}/lemon-test.XXXXXX")}"
+  export LEMON_STORE_PATH="${LEMON_STORE_PATH:-$LEMON_TEST_TMPDIR/store}"
+  mkdir -p "$LEMON_STORE_PATH"
+}
+
+run_fast() {
+  ensure_repo_root
+  setup_test_env
+  mix compile --warnings-as-errors
+  mix test --exclude integration "$@"
+}
+
+run_quality() {
+  ensure_repo_root
+  setup_test_env
+  bash scripts/lint_ci_docs.sh
+  bash scripts/test_contract.sh
+  mix lemon.skill.lint
+  mix lemon.quality
+  mix lemon.check_duplicate_tests
+  mix test apps/lemon_core/test/lemon_core/quality apps/coding_agent/test/coding_agent/evals/harness_test.exs
+}
+
+run_npm_ci_if_needed() {
+  local dir="$1"
+  if [ ! -d "$dir/node_modules" ]; then
+    (cd "$dir" && npm ci)
+  fi
+}
+
+run_clients() {
+  ensure_repo_root
+
+  run_npm_ci_if_needed clients/lemon-web
+  (cd clients/lemon-web && npm run typecheck && npm --workspace web run lint && npm run build && npm run test:coverage && npm audit --omit=dev --audit-level=high)
+
+  run_npm_ci_if_needed clients/lemon-tui
+  (cd clients/lemon-tui && npm run typecheck && npm run lint && npm run build && npm run test:coverage && npm audit --omit=dev --audit-level=high)
+
+  run_npm_ci_if_needed clients/lemon-browser-node
+  (cd clients/lemon-browser-node && npm run typecheck && npm run lint && npm run build && npm run test:coverage && npm audit --omit=dev --audit-level=high)
+}
+
+run_eval_fast() {
+  ensure_repo_root
+  setup_test_env
+  mix lemon.eval --iterations "${LEMON_EVAL_ITERATIONS:-3}" "$@"
+}
+
+run_smoke() {
+  ensure_repo_root
+  cat <<'EOF'
+The product smoke lane is CI-only for now because it builds and boots a release
+with GitHub Actions service assumptions. Use one of:
+
+  gh workflow run product-smoke.yml
+  scripts/test fast
+  scripts/test quality
+
+Canonical CI smoke definition: .github/workflows/product-smoke.yml
+EOF
+}
+
+run_path() {
+  ensure_repo_root
+  setup_test_env
+  if [ "$#" -eq 0 ]; then
+    echo "scripts/test path requires at least one mix test path or argument" >&2
+    exit 64
+  fi
+  mix test "$@"
+}
+
+case "$LANE" in
+  help|-h|--help) usage ;;
+  fast) run_fast "$@" ;;
+  quality) run_quality "$@" ;;
+  clients) run_clients "$@" ;;
+  eval-fast) run_eval_fast "$@" ;;
+  smoke) run_smoke "$@" ;;
+  all)
+    run_fast
+    run_quality
+    run_eval_fast
+    run_smoke
+    ;;
+  path) run_path "$@" ;;
+  *)
+    echo "Unknown test lane: $LANE" >&2
+    usage >&2
+    exit 64
+    ;;
+esac

--- a/scripts/test_contract.sh
+++ b/scripts/test_contract.sh
@@ -24,4 +24,19 @@ done
 printf '%s\n' "$HELP" | grep -q "Usage: scripts/test" || fail "help output must include usage"
 printf '%s\n' "$HELP" | grep -q "MIX_ENV=test" || fail "help output must document test env"
 
+contract_tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/lemon-contract-root.XXXXXX")"
+TMPDIR="$contract_tmp_root" "$RUNNER" path >/tmp/lemon-test-contract-path.out 2>&1 &&
+  fail "path lane without args should fail"
+[ "$?" -eq 64 ] || fail "path lane without args should exit 64"
+[ -z "$(find "$contract_tmp_root" -mindepth 1 -maxdepth 1 -type d -name 'lemon-test.*' -print -quit)" ] ||
+  fail "runner-created LEMON_TEST_TMPDIR should be cleaned up on exit"
+rm -rf "$contract_tmp_root"
+
+provided_tmp="$(mktemp -d "${TMPDIR:-/tmp}/lemon-contract-provided.XXXXXX")"
+LEMON_TEST_TMPDIR="$provided_tmp" "$RUNNER" path >/tmp/lemon-test-contract-path-provided.out 2>&1 &&
+  fail "path lane without args should fail with provided tmpdir"
+[ "$?" -eq 64 ] || fail "path lane without args with provided tmpdir should exit 64"
+[ -d "$provided_tmp" ] || fail "caller-provided LEMON_TEST_TMPDIR must not be removed"
+rm -rf "$provided_tmp"
+
 echo "test runner contract ok"

--- a/scripts/test_contract.sh
+++ b/scripts/test_contract.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Contract checks for the canonical repo-level test runner.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUNNER="$ROOT/scripts/test"
+DOC="$ROOT/docs/testing.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[ -x "$RUNNER" ] || fail "scripts/test must exist and be executable"
+bash -n "$RUNNER"
+
+HELP="$($RUNNER help)"
+for lane in fast quality clients eval-fast smoke all path; do
+  printf '%s\n' "$HELP" | grep -Eq "(^|[[:space:]])$lane([[:space:]]|$|:)" || fail "help output must mention lane: $lane"
+  [ -f "$DOC" ] || fail "docs/testing.md must exist"
+  grep -Eq "(^|[[:space:]])$lane([[:space:]]|$|:)" "$DOC" || fail "docs/testing.md must mention lane: $lane"
+done
+
+printf '%s\n' "$HELP" | grep -q "Usage: scripts/test" || fail "help output must include usage"
+printf '%s\n' "$HELP" | grep -q "MIX_ENV=test" || fail "help output must document test env"
+
+echo "test runner contract ok"


### PR DESCRIPTION
## Summary
- Add `scripts/test` as the canonical repo-level test runner with documented lanes: `fast`, `quality`, `clients`, `eval-fast`, `smoke`, `all`, and `path`.
- Add `docs/testing.md` plus README/CONTRIBUTING/AGENTS/docs index updates so contributors can discover the lanes.
- Add `scripts/test_contract.sh` and wire it into the quality workflow to keep runner help/docs in sync.

## Test Plan
- [x] `bash -n scripts/test scripts/test_contract.sh`
- [x] `scripts/test_contract.sh`
- [x] `scripts/test smoke` output smoke pointer
- [x] `scripts/test path` without args returns usage error exit 64
- [x] `scripts/lint_ci_docs.sh`
- [x] `mix format --check-formatted AGENTS.md README.md CONTRIBUTING.md docs/README.md docs/catalog.exs .github/workflows/quality.yml`
- [x] `git diff --check`

## Notes
- Broad `mix lemon.quality`/full suite validation was not completed locally: existing local Mix quality/test invocations are heavyweight and timed out around the duplicate-test scan/app startup path. The PR adds a lightweight contract check to CI so the new runner/docs contract is still covered.
- This is Phase 1 only. It intentionally avoids implementing the full Hermes-style credential scrubber/hermetic env contract, which should be a follow-up.
