### PR TITLE
feat(skills): add audited skill authoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Full Telegram setup details: [`docs/user-guide/setup.md`](docs/user-guide/setup.
 ## Key Capabilities
 
 **Agent:**
-- 22 built-in tools: `bash`, `read`, `read_skill`, `search_memory`, `write`, `edit`, `grep`, `websearch`, `webfetch`, `task`, `agent`, and more
+- 23 built-in tools: `bash`, `read`, `read_skill`, `skill_manage`, `search_memory`, `write`, `edit`, `grep`, `websearch`, `webfetch`, `task`, `agent`, and more
 - Real-time streaming with live steering (inject messages mid-run)
 - Session persistence via JSONL with tree-structured history
 - Context compaction and branch summarization
@@ -191,4 +191,3 @@ Skill library bootstrapped from [Hermes Agent](https://github.com/NousResearch/h
 
 Built with [Elixir](https://elixir-lang.org/) and the BEAM.
 TUI powered by [@mariozechner/pi-tui](https://www.npmjs.com/package/@mariozechner/pi-tui).
-

--- a/apps/coding_agent/AGENTS.md
+++ b/apps/coding_agent/AGENTS.md
@@ -61,11 +61,11 @@ When downstream store or agent processes time out, callers should log and contin
 
 Tools are divided into two sets. `coding_tools/2` is the default set passed to sessions; `all_tools/2` includes extras not in the default set.
 
-**Default `coding_tools/2`** (22 tools registered in `CodingAgent.Tools.coding_tools/2` and `@builtin_tools` in `ToolRegistry`):
+**Default `coding_tools/2`** (23 tools registered in `CodingAgent.Tools.coding_tools/2` and `@builtin_tools` in `ToolRegistry`):
 
 | Category | Tools |
 |----------|-------|
-| **File Operations / Skills** | `read`, `read_skill`, `memory_topic`, `search_memory`, `write`, `edit`, `patch`, `hashline_edit`, `ls` |
+| **File Operations / Skills** | `read`, `read_skill`, `skill_manage`, `memory_topic`, `search_memory`, `write`, `edit`, `patch`, `hashline_edit`, `ls` |
 | **Search** | `grep`, `find` |
 | **Execution** | `bash` |
 | **Web** | `websearch`, `webfetch` |
@@ -673,7 +673,7 @@ apps/coding_agent/
 |   |   |   +-- todo_store.ex, todo_store_owner.ex
 |   |   |   +-- task.ex, agent.ex
 |   |   |   +-- tool_auth.ex, extensions_status.ex
-|   |   |   +-- memory_topic.ex, truncate.ex
+|   |   |   +-- read_skill.ex, skill_manage.ex, memory_topic.ex, truncate.ex
 |   |   |   +-- post_to_x.ex, get_x_mentions.ex
 |   |   |   +-- lsp_formatter.ex, restart.ex
 |   |   |   +-- feature_requirements.ex
@@ -803,4 +803,3 @@ If the central resolver module is unavailable at runtime (mixed-version or parti
 - `await` and `exec`/`process` tools depend on `ProcessStore` being started; start `ProcessStoreServer` in test setup if needed
 - `ToolRegistry` uses an ETS cache for extensions; call `ToolRegistry.invalidate_extension_cache()` in teardown if tests prime the cache
 Task-tool normalization is intentionally tolerant of provider variance: if a model supplies a prompt but omits the optional-looking `description` field, `CodingAgent.Tools.Task.Params` derives a short description from the prompt instead of rejecting the task call. Bash-only internal tasks also have a direct fast path for both backticked `Run \`cmd\`` prompts and plain `Run this exact command and return the output: cmd` phrasing so tool-using providers do not pay for a full child session just to execute one shell command.
-

--- a/apps/coding_agent/README.md
+++ b/apps/coding_agent/README.md
@@ -101,7 +101,7 @@ CodingAgent.Supervisor (one_for_one)
 
 | Module | Description |
 |--------|-------------|
-| `CodingAgent.Tools` | Tool factory -- `coding_tools/2` (22 default tools), `read_only_tools/2`, `all_tools/2`, `get_tool/3` |
+| `CodingAgent.Tools` | Tool factory -- `coding_tools/2` (23 default tools), `read_only_tools/2`, `all_tools/2`, `get_tool/3` |
 | `CodingAgent.ToolRegistry` | Dynamic tool resolution with precedence (builtin > WASM > extension), ETS extension cache, conflict reporting |
 | `CodingAgent.ToolExecutor` | Approval-gated tool execution wrapper; integrates with `LemonCore.ExecApprovals` |
 | `CodingAgent.ToolPolicy` | Policy profiles (`full_access`, `read_only`, `safe_mode`, `subagent_restricted`, `no_external`, `minimal_core`) with allow/deny lists and router-style approval maps |
@@ -112,7 +112,7 @@ CodingAgent.Supervisor (one_for_one)
 
 | Category | Tools |
 |----------|-------|
-| File I/O / Skills | `read`, `read_skill`, `memory_topic`, `search_memory`, `write`, `edit`, `hashline_edit`, `patch`, `ls` |
+| File I/O / Skills | `read`, `read_skill`, `skill_manage`, `memory_topic`, `search_memory`, `write`, `edit`, `hashline_edit`, `patch`, `ls` |
 | Search | `grep`, `find` |
 | Execution | `bash` |
 | Web | `websearch`, `webfetch` |
@@ -130,6 +130,7 @@ CodingAgent.Supervisor (one_for_one)
 | `await` | `Tools.Await` | Block until background jobs complete |
 | `webdownload` | `Tools.WebDownload` | Download binary content to disk |
 | `truncate` | `Tools.Truncate` | Truncate long text with configurable strategies |
+| `skill_manage` | `Tools.SkillManage` | Create, patch, delete, and maintain audited Lemon skills |
 | `todoread` / `todowrite` | `Tools.TodoRead` / `Tools.TodoWrite` | Low-level todo primitives |
 | `restart` | `Tools.Restart` | Restart the Lemon BEAM process (dev) |
 | `memory_topic` | `Tools.MemoryTopic` | Persistent memory topics for cross-session knowledge |
@@ -214,7 +215,7 @@ For coordination workflows that must produce one final same-turn answer, queued 
 | `CodingAgent.Tools.FeatureRequirements` | Persists `FEATURE_REQUIREMENTS.json` with dependency-aware progress tracking |
 | `CodingAgent.Evals.Harness` | Evaluation harness for automated agent testing; includes deterministic tool contracts, read/edit workflow checks, memory scope/topic checks, and relevant-skill prompt progressive-disclosure checks |
 
-The eval harness is intentionally lightweight and deterministic. It should catch harness-contract drift before behavioral/LLM evals run: default tool registry coverage, stable builtin tool ordering, basic file workflow viability, `search_memory` current-scope resolution, `memory_topic` scaffold behavior, and relevant-skill prompt guidance that points agents to `read_skill` without inlining full skill bodies.
+The eval harness is intentionally lightweight and deterministic. It should catch harness-contract drift before behavioral/LLM evals run: default tool registry coverage, stable builtin tool ordering, basic file workflow viability, `search_memory` current-scope resolution, `memory_topic` scaffold behavior, and skill prompt guidance that points agents to `read_skill` and `skill_manage` without inlining full skill bodies.
 
 ### Security
 
@@ -466,4 +467,3 @@ mix test --include integration apps/coding_agent
 ```
 
 The test suite covers 90+ test files including unit tests for all tools, session management, budget tracking, extensions, WASM integration, and coordinator orchestration. Tests use temporary directories, direct `start_link` (not supervised), and mock UIs via `CodingAgent.UI.Context`.
-

--- a/apps/coding_agent/lib/coding_agent/evals/harness.ex
+++ b/apps/coding_agent/lib/coding_agent/evals/harness.ex
@@ -12,7 +12,7 @@ defmodule CodingAgent.Evals.Harness do
   alias CodingAgent.{PromptBuilder, ToolRegistry}
   alias CodingAgent.Tools.{MemoryTopic, SearchMemory}
 
-  @required_builtin_tools ~w(read read_skill memory_topic search_memory write edit patch bash grep find ls webfetch websearch todo task extensions_status)
+  @required_builtin_tools ~w(read read_skill skill_manage memory_topic search_memory write edit patch bash grep find ls webfetch websearch todo task extensions_status)
 
   @type eval_result :: %{
           name: String.t(),

--- a/apps/coding_agent/lib/coding_agent/system_prompt.ex
+++ b/apps/coding_agent/lib/coding_agent/system_prompt.ex
@@ -127,6 +127,7 @@ defmodule CodingAgent.SystemPrompt do
     - Use `write` to create missing topic files (`memory/topics/<topic-slug>.md`) and daily files (`memory/YYYY-MM-DD.md`).
     - Use `memory_topic` to scaffold new topic notes from `memory/topics/TEMPLATE.md`.
     - When creating a new topic file, follow the structure in `memory/topics/TEMPLATE.md`.
+    - Use `skill_manage` to create or update a skill when you learn a reusable workflow.
     - Use `edit` to keep `MEMORY.md` concise as a durable index of key facts and topic files.
     - Use `search_memory` to recall prior run history (e.g. past bug fixes, commands run, earlier answers).
       Prefer `scope: "current"` to search both the project root and assistant home.

--- a/apps/coding_agent/lib/coding_agent/tool_policy.ex
+++ b/apps/coding_agent/lib/coding_agent/tool_policy.ex
@@ -32,6 +32,7 @@ defmodule CodingAgent.ToolPolicy do
     "read",
     "read_skill",
     "search_memory",
+    "skill_manage",
     "memory_topic",
     "write",
     "edit",
@@ -50,7 +51,7 @@ defmodule CodingAgent.ToolPolicy do
 
   @external_tools ["webfetch", "websearch"]
 
-  @dangerous_tools ["write", "edit", "patch", "bash", "exec", "process", "agent"]
+  @dangerous_tools ["write", "edit", "patch", "skill_manage", "bash", "exec", "process", "agent"]
 
   # ============================================================================
   # Profile Creation

--- a/apps/coding_agent/lib/coding_agent/tool_registry.ex
+++ b/apps/coding_agent/lib/coding_agent/tool_registry.ex
@@ -36,6 +36,7 @@ defmodule CodingAgent.ToolRegistry do
   @builtin_tools [
     {:read, Tools.Read},
     {:read_skill, Tools.ReadSkill},
+    {:skill_manage, Tools.SkillManage},
     {:memory_topic, Tools.MemoryTopic},
     {:search_memory, Tools.SearchMemory},
     {:write, Tools.Write},

--- a/apps/coding_agent/lib/coding_agent/tools.ex
+++ b/apps/coding_agent/lib/coding_agent/tools.ex
@@ -3,7 +3,7 @@ defmodule CodingAgent.Tools do
   Tool registry and factory functions for coding agent tools.
 
   Provides pre-configured tool sets for different use cases:
-  - `coding_tools/2` - Full access tools (read, read_skill, memory_topic, search_memory, write, edit, hashline_edit, patch, bash, grep, find, ls, webfetch, websearch, todo, task, agent, parent_question, tool_auth, extensions_status, post_to_x, get_x_mentions)
+  - `coding_tools/2` - Full access tools (read, read_skill, skill_manage, memory_topic, search_memory, write, edit, hashline_edit, patch, bash, grep, find, ls, webfetch, websearch, todo, task, agent, parent_question, tool_auth, extensions_status, post_to_x, get_x_mentions)
   - `read_only_tools/2` - Exploration tools (read, read_skill, search_memory, grep, find, ls)
   - `all_tools/2` - All available tools as a map
   """
@@ -12,6 +12,7 @@ defmodule CodingAgent.Tools do
     Agent,
     Read,
     ReadSkill,
+    SkillManage,
     MemoryTopic,
     SearchMemory,
     Write,
@@ -35,7 +36,7 @@ defmodule CodingAgent.Tools do
   }
 
   @doc """
-  Get the default coding tools (read, read_skill, memory_topic, search_memory, write, edit, hashline_edit, patch, bash, grep, find, ls, webfetch, websearch, todo, task, agent, parent_question, tool_auth, extensions_status, post_to_x, get_x_mentions).
+  Get the default coding tools (read, read_skill, skill_manage, memory_topic, search_memory, write, edit, hashline_edit, patch, bash, grep, find, ls, webfetch, websearch, todo, task, agent, parent_question, tool_auth, extensions_status, post_to_x, get_x_mentions).
 
   ## Options
   - Any options are passed through to individual tools
@@ -45,6 +46,7 @@ defmodule CodingAgent.Tools do
     [
       Read.tool(cwd, opts),
       ReadSkill.tool(cwd, opts),
+      SkillManage.tool(cwd, opts),
       MemoryTopic.tool(cwd, opts),
       SearchMemory.tool(cwd, opts),
       Write.tool(cwd, opts),
@@ -91,6 +93,7 @@ defmodule CodingAgent.Tools do
     %{
       "read" => Read.tool(cwd, opts),
       "read_skill" => ReadSkill.tool(cwd, opts),
+      "skill_manage" => SkillManage.tool(cwd, opts),
       "memory_topic" => MemoryTopic.tool(cwd, opts),
       "search_memory" => SearchMemory.tool(cwd, opts),
       "write" => Write.tool(cwd, opts),

--- a/apps/coding_agent/lib/coding_agent/tools/skill_manage.ex
+++ b/apps/coding_agent/lib/coding_agent/tools/skill_manage.ex
@@ -1,0 +1,15 @@
+defmodule CodingAgent.Tools.SkillManage do
+  @moduledoc """
+  Wrapper for the LemonSkills `skill_manage` tool in the coding agent namespace.
+  """
+
+  @doc """
+  Return the `skill_manage` tool scoped to the current working directory.
+  """
+  @spec tool(String.t(), keyword()) :: AgentCore.Types.AgentTool.t()
+  def tool(cwd, opts \\ []) do
+    opts
+    |> Keyword.put(:cwd, cwd)
+    |> LemonSkills.Tools.SkillManage.tool()
+  end
+end

--- a/apps/coding_agent/test/coding_agent/system_prompt_test.exs
+++ b/apps/coding_agent/test/coding_agent/system_prompt_test.exs
@@ -42,6 +42,7 @@ defmodule CodingAgent.SystemPromptTest do
     assert String.contains?(prompt, "memory/topics/<topic-slug>.md")
     assert String.contains?(prompt, "Use `memory_topic` to scaffold new topic notes")
     assert String.contains?(prompt, "memory/topics/TEMPLATE.md")
+    assert String.contains?(prompt, "Use `skill_manage` to create or update a skill")
     assert String.contains?(prompt, "Use `edit` to keep `MEMORY.md` concise")
   end
 
@@ -64,6 +65,7 @@ defmodule CodingAgent.SystemPromptTest do
 
     assert "read_skill" in referenced_tools
     assert "search_memory" in referenced_tools
+    assert "skill_manage" in referenced_tools
 
     missing_tools = Enum.reject(referenced_tools, &MapSet.member?(default_tool_names, &1))
 

--- a/apps/coding_agent/test/coding_agent/tool_policy_test.exs
+++ b/apps/coding_agent/test/coding_agent/tool_policy_test.exs
@@ -32,6 +32,7 @@ defmodule CodingAgent.ToolPolicyTest do
       assert ToolPolicy.allowed?(policy, "read")
       assert ToolPolicy.allowed?(policy, "read_skill")
       assert ToolPolicy.allowed?(policy, "search_memory")
+      assert ToolPolicy.allowed?(policy, "skill_manage")
       assert ToolPolicy.allowed?(policy, "memory_topic")
       assert ToolPolicy.allowed?(policy, "write")
       assert ToolPolicy.allowed?(policy, "patch")
@@ -54,6 +55,7 @@ defmodule CodingAgent.ToolPolicyTest do
       assert ToolPolicy.allowed?(policy, "grep")
       refute ToolPolicy.allowed?(policy, "write")
       refute ToolPolicy.allowed?(policy, "edit")
+      refute ToolPolicy.allowed?(policy, "skill_manage")
       refute ToolPolicy.allowed?(policy, "bash")
       refute ToolPolicy.allowed?(policy, "exec")
     end
@@ -62,6 +64,7 @@ defmodule CodingAgent.ToolPolicyTest do
       policy = ToolPolicy.from_profile(:subagent_restricted)
 
       refute ToolPolicy.allowed?(policy, "write")
+      refute ToolPolicy.allowed?(policy, "skill_manage")
       refute ToolPolicy.allowed?(policy, "bash")
       refute ToolPolicy.allowed?(policy, "agent")
       assert ToolPolicy.requires_approval?(policy, "write")

--- a/apps/coding_agent/test/coding_agent/tool_registry_test.exs
+++ b/apps/coding_agent/test/coding_agent/tool_registry_test.exs
@@ -86,6 +86,7 @@ defmodule CodingAgent.ToolRegistryTest do
       names = Enum.map(tools, & &1.name)
       assert "read" in names
       assert "read_skill" in names
+      assert "skill_manage" in names
       assert "memory_topic" in names
       assert "write" in names
       assert "edit" in names
@@ -248,6 +249,7 @@ defmodule CodingAgent.ToolRegistryTest do
       assert is_list(names)
       assert :read in names
       assert :read_skill in names
+      assert :skill_manage in names
       assert :write in names
       assert :edit in names
       assert :bash in names

--- a/apps/coding_agent/test/coding_agent/tools_test.exs
+++ b/apps/coding_agent/test/coding_agent/tools_test.exs
@@ -29,6 +29,7 @@ defmodule CodingAgent.ToolsTest do
       expected_tools = [
         "read",
         "read_skill",
+        "skill_manage",
         "memory_topic",
         "search_memory",
         "write",
@@ -56,9 +57,9 @@ defmodule CodingAgent.ToolsTest do
       end)
     end
 
-    test "returns exactly 22 tools" do
+    test "returns exactly 23 tools" do
       tools = Tools.coding_tools(@test_cwd)
-      assert length(tools) == 22
+      assert length(tools) == 23
     end
 
     test "passes cwd to each tool" do
@@ -77,7 +78,7 @@ defmodule CodingAgent.ToolsTest do
 
       # Should not raise any errors
       assert is_list(tools)
-      assert length(tools) == 22
+      assert length(tools) == 23
     end
   end
 
@@ -146,6 +147,7 @@ defmodule CodingAgent.ToolsTest do
       expected_tools = [
         "read",
         "read_skill",
+        "skill_manage",
         "memory_topic",
         "search_memory",
         "write",
@@ -175,9 +177,9 @@ defmodule CodingAgent.ToolsTest do
       end)
     end
 
-    test "returns 23 tools (includes truncate plus read_skill, memory, parent_question, and X tools)" do
+    test "returns 24 tools (includes truncate plus skill_manage, memory, parent_question, and X tools)" do
       tools_map = Tools.all_tools(@test_cwd)
-      assert map_size(tools_map) == 23
+      assert map_size(tools_map) == 24
     end
 
     test "tool names match map keys" do
@@ -228,6 +230,7 @@ defmodule CodingAgent.ToolsTest do
       known_tools = [
         "read",
         "read_skill",
+        "skill_manage",
         "memory_topic",
         "search_memory",
         "write",
@@ -304,6 +307,8 @@ defmodule CodingAgent.ToolsTest do
     test "returns all tools when all names are valid" do
       all_names = [
         "read",
+        "read_skill",
+        "skill_manage",
         "write",
         "edit",
         "hashline_edit",

--- a/apps/coding_agent/test/coding_agent_test.exs
+++ b/apps/coding_agent/test/coding_agent_test.exs
@@ -2,9 +2,9 @@ defmodule CodingAgentTest do
   use ExUnit.Case, async: true
 
   describe "coding_tools/2" do
-    test "returns list of 22 tools" do
+    test "returns list of 23 tools" do
       tools = CodingAgent.coding_tools("/tmp")
-      assert length(tools) == 22
+      assert length(tools) == 23
       assert Enum.all?(tools, &match?(%AgentCore.Types.AgentTool{}, &1))
     end
 
@@ -20,6 +20,7 @@ defmodule CodingAgentTest do
       assert "find" in names
       assert "ls" in names
       assert "read_skill" in names
+      assert "skill_manage" in names
       assert "memory_topic" in names
       assert "search_memory" in names
       assert "webfetch" in names

--- a/apps/lemon_control_plane/lib/lemon_control_plane/methods/transports_status.ex
+++ b/apps/lemon_control_plane/lib/lemon_control_plane/methods/transports_status.ex
@@ -52,7 +52,8 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   defp configured_transports(false), do: []
 
   defp configured_transports(true) do
-    LemonGateway.TransportRegistry.list_transports()
+    registry_module()
+    |> apply(:list_transports, [])
     |> Enum.map(fn id -> {id, safe_get_transport(id)} end)
   rescue
     _ -> []
@@ -63,7 +64,8 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   defp enabled_transport_ids(false), do: MapSet.new()
 
   defp enabled_transport_ids(true) do
-    LemonGateway.TransportRegistry.enabled_transports()
+    registry_module()
+    |> apply(:enabled_transports, [])
     |> Enum.map(fn {id, _mod} -> id end)
     |> MapSet.new()
   rescue
@@ -73,12 +75,15 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   end
 
   defp safe_get_transport(id) do
-    LemonGateway.TransportRegistry.get_transport(id)
+    registry_module()
+    |> apply(:get_transport, [id])
   rescue
     _ -> nil
   catch
     :exit, _ -> nil
   end
+
+  defp registry_module, do: LemonGateway.TransportRegistry
 
   defp module_name(mod) when is_atom(mod), do: Atom.to_string(mod)
   defp module_name(_), do: nil

--- a/apps/lemon_core/lib/lemon_core/setup/gateway/telegram.ex
+++ b/apps/lemon_core/lib/lemon_core/setup/gateway/telegram.ex
@@ -188,7 +188,7 @@ defmodule LemonCore.Setup.Gateway.Telegram do
     :ok = Application.ensure_started(:inets)
     :ok = Application.ensure_started(:ssl)
 
-    ssl_opts = [verify: :verify_peer, cacerts: :public_key.cacerts_get()]
+    ssl_opts = [verify: :verify_peer] |> maybe_put_cacerts()
 
     case :httpc.request(:get, {url, []}, [{:ssl, ssl_opts}, {:timeout, 5_000}], []) do
       {:ok, {{_vsn, 200, _}, _headers, body}} ->
@@ -202,6 +202,20 @@ defmodule LemonCore.Setup.Gateway.Telegram do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp maybe_put_cacerts(ssl_opts) do
+    if function_exported?(:public_key, :cacerts_get, 0) do
+      case apply(:public_key, :cacerts_get, []) do
+        cacerts when is_list(cacerts) and cacerts != [] ->
+          Keyword.put(ssl_opts, :cacerts, cacerts)
+
+        _ ->
+          ssl_opts
+      end
+    else
+      ssl_opts
     end
   end
 

--- a/apps/lemon_skills/AGENTS.md
+++ b/apps/lemon_skills/AGENTS.md
@@ -34,6 +34,7 @@ LemonSkills is the skill management system for the Lemon agent platform. It prov
 | File | Tool name | Purpose |
 |------|-----------|---------|
 | `lib/lemon_skills/tools/read_skill.ex` | `read_skill` | Fetches skill content/metadata by key |
+| `lib/lemon_skills/tools/skill_manage.ex` | `skill_manage` | Creates, edits, patches, deletes, and audits local skills |
 | `lib/lemon_skills/tools/post_to_x.ex` | `post_to_x` | Posts tweets via X API |
 | `lib/lemon_skills/tools/get_x_mentions.ex` | `get_x_mentions` | Fetches X mentions |
 
@@ -88,7 +89,7 @@ Instructions for agents...
 4. Wire the tool into the agent tool registry (in `agent_core` or `coding_agent`, not in this app).
 5. Add tests at `test/lemon_skills/tools/my_tool_test.exs`.
 
-Pattern to follow -- see `lib/lemon_skills/tools/read_skill.ex` for the simplest example.
+Pattern to follow -- see `lib/lemon_skills/tools/read_skill.ex` for the simplest read-only example and `lib/lemon_skills/tools/skill_manage.ex` for audited write paths.
 
 ## Important Implementation Details
 
@@ -212,6 +213,7 @@ test/lemon_skills/
   config_test.exs                # Config load/save/merge, directory paths
   tools/
     read_skill_test.exs          # ReadSkill tool
+    skill_manage_test.exs        # SkillManage tool
     post_to_x_test.exs           # PostToX tool
     get_x_mentions_test.exs      # GetXMentions tool
 test/mix/tasks/
@@ -258,7 +260,7 @@ HttpMock.stub("https://skills.lemon.agent/", {:error, :nxdomain})
 | Online discovery | `discovery_test.exs` |
 | Entry struct | `entry_test.exs` |
 | Status checking | `status_test.exs` |
-| Agent tools | `tools/read_skill_test.exs`, `tools/post_to_x_test.exs`, `tools/get_x_mentions_test.exs` |
+| Agent tools | `tools/read_skill_test.exs`, `tools/skill_manage_test.exs`, `tools/post_to_x_test.exs`, `tools/get_x_mentions_test.exs` |
 | Mix task | `mix/tasks/lemon.skill_test.exs` |
 
 ## Connections to Other Apps
@@ -276,8 +278,8 @@ HttpMock.stub("https://skills.lemon.agent/", {:error, :nxdomain})
 
 | App | How it uses LemonSkills |
 |-----|------------------------|
-| `coding_agent` | Calls `LemonSkills.find_relevant/2` to inject skill content into agent system prompts; uses `LemonSkills.Tools.ReadSkill` as an agent tool; shares `agent_dir` config (fallback: `config :coding_agent, :agent_dir`) |
-| `agent_core` | Registers skill tools (`read_skill`, `post_to_x`, `get_x_mentions`) in the agent tool registry |
+| `coding_agent` | Calls `LemonSkills.find_relevant/2` to inject skill content into agent system prompts; wraps `LemonSkills.Tools.ReadSkill` and `LemonSkills.Tools.SkillManage` as agent tools; shares `agent_dir` config (fallback: `config :coding_agent, :agent_dir`) |
+| `agent_core` | Provides the common tool structs used by skill tools (`read_skill`, `skill_manage`, `post_to_x`, `get_x_mentions`) |
 
 ### Shared Configuration
 

--- a/apps/lemon_skills/README.md
+++ b/apps/lemon_skills/README.md
@@ -79,6 +79,7 @@ The OTP application (`LemonSkills.Application`) performs two actions on start:
 | `LemonSkills.HttpClient` | `lib/lemon_skills/http_client.ex` | HTTP client behaviour for dependency injection |
 | `LemonSkills.HttpClient.Httpc` | `lib/lemon_skills/http_client/httpc.ex` | Default HTTP client using Erlang `:httpc` |
 | `LemonSkills.Tools.ReadSkill` | `lib/lemon_skills/tools/read_skill.ex` | Agent tool for fetching skill content and metadata |
+| `LemonSkills.Tools.SkillManage` | `lib/lemon_skills/tools/skill_manage.ex` | Agent tool for creating, editing, patching, deleting, and auditing local skills |
 | `LemonSkills.Tools.PostToX` | `lib/lemon_skills/tools/post_to_x.ex` | Agent tool for posting tweets to X (Twitter) |
 | `LemonSkills.Tools.GetXMentions` | `lib/lemon_skills/tools/get_x_mentions.ex` | Agent tool for fetching recent X mentions |
 | `Mix.Tasks.Lemon.Skill` | `lib/mix/tasks/lemon.skill.ex` | CLI interface for skill management |
@@ -199,6 +200,8 @@ Project skills always rank above equivalently-scored global skills. Skills that 
 ## Audit
 
 Every install/update for a non-builtin skill runs through the audit path before the skill is registered.
+
+Agent-authored skill writes use the same bundle audit path through `skill_manage`. The tool writes only to the configured project or global skill directories, restricts supporting files to `references/`, `templates/`, `scripts/`, and `assets/`, and rolls back blocked audit verdicts before refreshing the registry.
 
 1. `LemonSkills.Bundle` computes a deterministic bundle hash across `SKILL.md` plus supported files under `references/`, `templates/`, `scripts/`, and `assets/`. Symlinked bundle entries are rejected so the audit payload cannot escape the skill root.
 2. `LemonSkills.Audit.BundleAudit` reuses cached results from `skills.audit.json` only when the bundle hash and audit fingerprint still match.

--- a/apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex
+++ b/apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex
@@ -1,0 +1,531 @@
+defmodule LemonSkills.Tools.SkillManage do
+  @moduledoc """
+  Agent-facing skill authoring and maintenance tool.
+
+  This is Lemon's procedural-memory write path: agents can turn learned
+  workflows into local skills, then maintain those skills with small edits and
+  supporting files. Writes are scoped to Lemon skill directories and audited
+  before they are exposed through the registry.
+  """
+
+  alias AgentCore.AbortSignal
+  alias AgentCore.Types.{AgentTool, AgentToolResult}
+  alias Ai.Types.TextContent
+  alias LemonSkills.{Config, Manifest, Registry}
+  alias LemonSkills.Audit.BundleAudit
+
+  @max_name_length 64
+  @max_skill_content_chars 100_000
+  @max_supporting_file_bytes 1_048_576
+  @allowed_support_dirs ~w(assets references scripts templates)
+  @name_re ~r/^[a-z0-9][a-z0-9._-]*$/
+
+  @doc """
+  Return the `skill_manage` tool definition.
+  """
+  @spec tool(keyword()) :: AgentTool.t()
+  def tool(opts \\ []) do
+    cwd = Keyword.get(opts, :cwd)
+
+    %AgentTool{
+      name: "skill_manage",
+      label: "Manage Skill",
+      description: """
+      Create, edit, patch, delete, and maintain Lemon skills as procedural memory. \
+      Use this when you learn a reusable workflow that should become a skill, \
+      or when an existing user/project skill needs refinement. Use scope="project" \
+      for repository-specific skills and scope="global" for reusable cross-project skills.
+      """,
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "action" => %{
+            "type" => "string",
+            "enum" => ["create", "edit", "patch", "delete", "write_file", "remove_file"],
+            "description" => "Skill operation to perform."
+          },
+          "name" => %{
+            "type" => "string",
+            "description" =>
+              "Skill key/directory name. Use lowercase letters, numbers, hyphens, dots, or underscores."
+          },
+          "scope" => %{
+            "type" => "string",
+            "enum" => ["project", "global"],
+            "description" => "Where to write the skill. Defaults to project."
+          },
+          "content" => %{
+            "type" => "string",
+            "description" =>
+              "Full SKILL.md content for create/edit, including YAML/TOML frontmatter."
+          },
+          "file_path" => %{
+            "type" => "string",
+            "description" =>
+              "Optional target file. Omit for SKILL.md on patch; supporting files must be under references/, templates/, scripts/, or assets/."
+          },
+          "file_content" => %{
+            "type" => "string",
+            "description" => "Content for write_file."
+          },
+          "old_string" => %{
+            "type" => "string",
+            "description" => "Text to replace for patch. Must match exactly."
+          },
+          "new_string" => %{
+            "type" => "string",
+            "description" => "Replacement text for patch. Use an empty string to delete."
+          },
+          "replace_all" => %{
+            "type" => "boolean",
+            "description" => "Replace all occurrences for patch. Defaults to false."
+          }
+        },
+        "required" => ["action", "name"]
+      },
+      execute: &execute(&1, &2, &3, &4, cwd)
+    }
+  end
+
+  @spec execute(
+          String.t(),
+          map(),
+          reference() | nil,
+          (AgentToolResult.t() -> :ok) | nil,
+          String.t() | nil
+        ) :: AgentToolResult.t() | {:error, term()}
+  def execute(_tool_call_id, params, signal, _on_update, cwd) do
+    if AbortSignal.aborted?(signal) do
+      {:error, "Operation aborted"}
+    else
+      with {:ok, action} <- required_string(params, "action"),
+           {:ok, name} <- required_string(params, "name"),
+           :ok <- validate_name(name),
+           {:ok, scope} <- parse_scope(Map.get(params, "scope", "project")),
+           {:ok, root} <- skills_root(scope, cwd) do
+        dispatch(action, name, params, scope, root, cwd)
+      end
+    end
+  end
+
+  defp dispatch("create", name, params, scope, root, cwd) do
+    with {:ok, content} <- required_string(params, "content", preserve?: true),
+         :ok <- validate_skill_content(content),
+         {:ok, dir} <- new_skill_dir(root, name),
+         :ok <- File.mkdir_p(dir),
+         :ok <- write_new_skill_file(dir, content),
+         {:ok, audit} <- audit_or_rollback(dir, audit_scope(scope, cwd), name, {:dir, dir}),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("Skill '#{name}' created at #{dir}.", %{action: "create", path: dir, audit: audit})
+    end
+  end
+
+  defp dispatch("edit", name, params, scope, root, cwd) do
+    with {:ok, content} <- required_string(params, "content", preserve?: true),
+         :ok <- validate_skill_content(content),
+         {:ok, dir} <- existing_skill_dir(root, name),
+         skill_file = Path.join(dir, "SKILL.md"),
+         {:ok, original} <- File.read(skill_file),
+         :ok <- atomic_write(skill_file, content),
+         {:ok, audit} <-
+           audit_or_rollback(dir, audit_scope(scope, cwd), name, {skill_file, original}),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("Skill '#{name}' updated.", %{action: "edit", path: dir, audit: audit})
+    end
+  end
+
+  defp dispatch("patch", name, params, scope, root, cwd) do
+    with {:ok, old_string} <- required_string(params, "old_string", preserve?: true),
+         {:ok, new_string} <-
+           required_string(params, "new_string", allow_empty?: true, preserve?: true),
+         {:ok, dir} <- existing_skill_dir(root, name),
+         {:ok, target} <- target_file(dir, Map.get(params, "file_path")),
+         :ok <- reject_symlink_path(dir, target),
+         {:ok, original} <- File.read(target),
+         {:ok, updated, replacements} <-
+           patch_content(
+             original,
+             old_string,
+             new_string,
+             truthy?(Map.get(params, "replace_all"))
+           ),
+         :ok <- validate_target_content(target, dir, updated),
+         :ok <- atomic_write(target, updated),
+         {:ok, audit} <- audit_or_rollback(dir, audit_scope(scope, cwd), name, {target, original}),
+         :ok <- refresh_registry(scope, cwd) do
+      rel = Path.relative_to(target, dir)
+
+      ok("Patched #{rel} in skill '#{name}' (#{replacements} replacement(s)).", %{
+        action: "patch",
+        path: dir,
+        file_path: rel,
+        replacements: replacements,
+        audit: audit
+      })
+    end
+  end
+
+  defp dispatch("delete", name, _params, scope, root, cwd) do
+    with {:ok, dir} <- existing_skill_dir(root, name),
+         {:ok, _} <- File.rm_rf(dir),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("Skill '#{name}' deleted.", %{action: "delete", path: dir})
+    end
+  end
+
+  defp dispatch("write_file", name, params, scope, root, cwd) do
+    with {:ok, file_path} <- required_string(params, "file_path"),
+         {:ok, file_content} <-
+           required_string(params, "file_content", allow_empty?: true, preserve?: true),
+         :ok <- validate_supporting_file_size(file_content),
+         {:ok, dir} <- existing_skill_dir(root, name),
+         {:ok, target} <- target_file(dir, file_path),
+         :ok <- reject_symlink_path(dir, target),
+         original <- read_optional(target),
+         :ok <- atomic_write(target, file_content),
+         {:ok, audit} <- audit_or_rollback(dir, audit_scope(scope, cwd), name, {target, original}),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("File '#{Path.relative_to(target, dir)}' written to skill '#{name}'.", %{
+        action: "write_file",
+        path: dir,
+        file_path: Path.relative_to(target, dir),
+        audit: audit
+      })
+    end
+  end
+
+  defp dispatch("remove_file", name, params, scope, root, cwd) do
+    with {:ok, file_path} <- required_string(params, "file_path"),
+         {:ok, dir} <- existing_skill_dir(root, name),
+         {:ok, target} <- target_file(dir, file_path),
+         :ok <- reject_symlink_path(dir, target),
+         true <-
+           File.regular?(target) || {:error, "File not found: #{Path.relative_to(target, dir)}"},
+         {:ok, original} <- File.read(target),
+         :ok <- File.rm(target),
+         {:ok, audit} <- audit_or_rollback(dir, audit_scope(scope, cwd), name, {target, original}),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("File '#{Path.relative_to(target, dir)}' removed from skill '#{name}'.", %{
+        action: "remove_file",
+        path: dir,
+        file_path: Path.relative_to(target, dir),
+        audit: audit
+      })
+    end
+  end
+
+  defp dispatch(action, _name, _params, _scope, _root, _cwd) do
+    {:error,
+     "Unknown action '#{action}'. Use create, edit, patch, delete, write_file, or remove_file."}
+  end
+
+  defp required_string(params, key, opts \\ []) do
+    allow_empty? = Keyword.get(opts, :allow_empty?, false)
+    preserve? = Keyword.get(opts, :preserve?, false)
+
+    case Map.get(params, key) do
+      value when is_binary(value) ->
+        trimmed = String.trim(value)
+
+        if trimmed == "" and not allow_empty? do
+          {:error, "#{key} must be a non-empty string"}
+        else
+          {:ok, if(preserve?, do: value, else: trimmed)}
+        end
+
+      _ ->
+        {:error, "missing required string parameter: #{key}"}
+    end
+  end
+
+  defp parse_scope("global"), do: {:ok, :global}
+  defp parse_scope("project"), do: {:ok, :project}
+  defp parse_scope(_), do: {:error, "scope must be 'project' or 'global'"}
+
+  defp skills_root(:global, _cwd), do: {:ok, Config.global_skills_dir()}
+
+  defp skills_root(:project, cwd) when is_binary(cwd) and cwd != "",
+    do: {:ok, Config.project_skills_dir(cwd)}
+
+  defp skills_root(:project, _cwd), do: {:error, "project scope requires cwd"}
+
+  defp validate_name(name) do
+    cond do
+      String.length(name) > @max_name_length ->
+        {:error, "name exceeds #{@max_name_length} characters"}
+
+      not Regex.match?(@name_re, name) ->
+        {:error, "invalid skill name '#{name}'"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_skill_content(content) do
+    cond do
+      String.length(content) > @max_skill_content_chars ->
+        {:error, "SKILL.md content exceeds #{@max_skill_content_chars} characters"}
+
+      true ->
+        with {:ok, manifest, body} <- Manifest.parse_and_validate(content),
+             :ok <- require_manifest_string(manifest, "name"),
+             :ok <- require_manifest_string(manifest, "description"),
+             :ok <- require_body(body) do
+          :ok
+        end
+    end
+  end
+
+  defp require_manifest_string(manifest, key) do
+    case Map.get(manifest, key) do
+      value when is_binary(value) ->
+        if String.trim(value) == "", do: {:error, "#{key} must be non-empty"}, else: :ok
+
+      _ ->
+        {:error, "frontmatter must include #{key}"}
+    end
+  end
+
+  defp require_body(body) do
+    if String.trim(body) == "" do
+      {:error, "SKILL.md must include instructions after frontmatter"}
+    else
+      :ok
+    end
+  end
+
+  defp validate_supporting_file_size(content) do
+    bytes = byte_size(content)
+
+    cond do
+      bytes > @max_supporting_file_bytes ->
+        {:error, "supporting file exceeds #{@max_supporting_file_bytes} bytes"}
+
+      String.length(content) > @max_skill_content_chars ->
+        {:error, "supporting file exceeds #{@max_skill_content_chars} characters"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp new_skill_dir(root, name) do
+    dir = Path.join(root, name)
+
+    if File.exists?(dir) do
+      {:error, "Skill '#{name}' already exists at #{dir}"}
+    else
+      {:ok, dir}
+    end
+  end
+
+  defp existing_skill_dir(root, name) do
+    dir = Path.join(root, name)
+    skill_file = Path.join(dir, "SKILL.md")
+
+    cond do
+      not safe_directory?(dir) ->
+        {:error, "Skill '#{name}' not found at #{dir}"}
+
+      not File.regular?(skill_file) ->
+        {:error, "Skill '#{name}' is missing SKILL.md"}
+
+      true ->
+        {:ok, dir}
+    end
+  end
+
+  defp target_file(dir, nil), do: {:ok, Path.join(dir, "SKILL.md")}
+  defp target_file(dir, ""), do: {:ok, Path.join(dir, "SKILL.md")}
+
+  defp target_file(dir, file_path) when is_binary(file_path) do
+    parts = Path.split(file_path)
+
+    cond do
+      Path.type(file_path) == :absolute or ".." in parts ->
+        {:error, "file_path must be relative and may not contain '..'"}
+
+      parts == [] or hd(parts) not in @allowed_support_dirs ->
+        {:error, "file_path must be under one of: #{Enum.join(@allowed_support_dirs, ", ")}"}
+
+      length(parts) < 2 ->
+        {:error, "file_path must include a filename under #{hd(parts)}/"}
+
+      true ->
+        target = Path.expand(Path.join(dir, file_path))
+        expanded_dir = Path.expand(dir)
+
+        if target == expanded_dir or not String.starts_with?(target, expanded_dir <> "/") do
+          {:error, "file_path escapes the skill directory"}
+        else
+          {:ok, target}
+        end
+    end
+  end
+
+  defp target_file(_dir, _), do: {:error, "file_path must be a string"}
+
+  defp validate_target_content(target, dir, content) do
+    if Path.expand(target) == Path.expand(Path.join(dir, "SKILL.md")) do
+      validate_skill_content(content)
+    else
+      validate_supporting_file_size(content)
+    end
+  end
+
+  defp patch_content(content, old_string, new_string, replace_all?) do
+    matches = :binary.matches(content, old_string)
+    count = length(matches)
+
+    cond do
+      count == 0 ->
+        {:error, "old_string was not found"}
+
+      count > 1 and not replace_all? ->
+        {:error, "old_string matched #{count} times; pass replace_all=true to replace all"}
+
+      true ->
+        {:ok, String.replace(content, old_string, new_string, global: replace_all?), count}
+    end
+  end
+
+  defp audit_or_rollback(dir, audit_scope, name, rollback) do
+    case BundleAudit.audit(dir, audit_scope, name, kind: :skill, force: true) do
+      {:ok, audit} ->
+        case BundleAudit.audit_status(audit) do
+          :block ->
+            rollback(rollback)
+            {:error, "Skill blocked by security audit: #{format_findings(audit)}"}
+
+          _ ->
+            {:ok, summarize_audit(audit)}
+        end
+
+      {:error, reason} ->
+        rollback(rollback)
+        {:error, "Skill audit failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp audit_scope(:global, _cwd), do: :global
+  defp audit_scope(:project, cwd), do: {:project, cwd}
+
+  defp summarize_audit(audit) do
+    %{
+      status: Atom.to_string(BundleAudit.audit_status(audit)),
+      findings: BundleAudit.audit_findings(audit),
+      approval_required: audit["approval_required"] || false
+    }
+  end
+
+  defp format_findings(audit) do
+    case BundleAudit.audit_findings(audit) do
+      [] -> "blocked"
+      findings -> Enum.take(findings, 3) |> Enum.join("; ")
+    end
+  end
+
+  defp rollback({:dir, dir}), do: File.rm_rf(dir)
+  defp rollback({path, nil}), do: File.rm(path)
+  defp rollback({path, content}), do: atomic_write(path, content)
+
+  defp refresh_registry(:global, cwd) do
+    Registry.refresh(cwd: nil)
+
+    if is_binary(cwd) do
+      Registry.refresh(cwd: cwd)
+    else
+      :ok
+    end
+  end
+
+  defp refresh_registry(:project, cwd), do: Registry.refresh(cwd: cwd)
+
+  defp read_optional(path) do
+    if File.regular?(path) do
+      case File.read(path) do
+        {:ok, content} -> content
+        _ -> nil
+      end
+    else
+      nil
+    end
+  end
+
+  defp safe_directory?(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :directory}} -> true
+      _ -> false
+    end
+  end
+
+  defp reject_symlink_path(dir, target) do
+    dir = Path.expand(dir)
+    target = Path.expand(target)
+
+    dir
+    |> symlink_check_paths(target)
+    |> Enum.find_value(:ok, fn path ->
+      case File.lstat(path) do
+        {:ok, %File.Stat{type: :symlink}} ->
+          {:error, "refusing to write through symlink: #{path}"}
+
+        _ ->
+          nil
+      end
+    end)
+  end
+
+  defp symlink_check_paths(dir, target) do
+    target
+    |> Path.relative_to(dir)
+    |> Path.split()
+    |> Enum.scan(dir, &Path.join(&2, &1))
+    |> Enum.reject(&(&1 == target and not File.exists?(&1)))
+  end
+
+  defp write_new_skill_file(dir, content) do
+    case atomic_write(Path.join(dir, "SKILL.md"), content) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        File.rm_rf(dir)
+        {:error, reason}
+    end
+  end
+
+  defp atomic_write(path, content) do
+    tmp =
+      Path.join(
+        Path.dirname(path),
+        ".#{Path.basename(path)}.tmp.#{System.unique_integer([:positive])}"
+      )
+
+    result =
+      with :ok <- File.mkdir_p(Path.dirname(path)),
+           :ok <- File.write(tmp, content),
+           :ok <- File.rename(tmp, path) do
+        :ok
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        File.rm(tmp)
+        {:error, reason}
+    end
+  end
+
+  defp truthy?(value), do: value in [true, "true", "TRUE", "1", 1]
+
+  defp ok(message, details) do
+    %AgentToolResult{
+      content: [%TextContent{text: message}],
+      details: details
+    }
+  end
+end

--- a/apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs
@@ -1,0 +1,260 @@
+defmodule LemonSkills.Tools.SkillManageTest do
+  use ExUnit.Case, async: false
+
+  alias LemonSkills.Tools.SkillManage
+
+  @moduletag :tmp_dir
+
+  defp execute(tmp_dir, params) do
+    tool = SkillManage.tool(cwd: tmp_dir)
+    tool.execute.("call-1", params, nil, nil)
+  end
+
+  defp valid_skill(name \\ "Learned Workflow") do
+    """
+    ---
+    name: #{name}
+    description: Captures a learned workflow
+    ---
+
+    ## Usage
+
+    Follow the proven workflow.
+    """
+  end
+
+  describe "create" do
+    test "creates a project skill and refreshes the registry", %{tmp_dir: tmp_dir} do
+      result =
+        execute(tmp_dir, %{
+          "action" => "create",
+          "name" => "learned-workflow",
+          "content" => valid_skill()
+        })
+
+      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "learned-workflow"])
+
+      assert result.details.action == "create"
+      assert result.details.audit.status == "pass"
+      assert File.regular?(Path.join(skill_dir, "SKILL.md"))
+      assert {:ok, entry} = LemonSkills.Registry.get("learned-workflow", cwd: tmp_dir)
+      assert entry.name == "Learned Workflow"
+    end
+
+    test "rejects invalid frontmatter before writing", %{tmp_dir: tmp_dir} do
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "create",
+                 "name" => "bad-skill",
+                 "content" => "# Missing frontmatter"
+               })
+
+      assert message =~ "frontmatter"
+      refute File.exists?(Path.join([tmp_dir, ".lemon", "skill", "bad-skill"]))
+    end
+  end
+
+  describe "patch" do
+    test "patches SKILL.md and keeps manifest valid", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "patchable-skill",
+        "content" => valid_skill("Patchable Skill")
+      })
+
+      result =
+        execute(tmp_dir, %{
+          "action" => "patch",
+          "name" => "patchable-skill",
+          "old_string" => "Follow the proven workflow.",
+          "new_string" => "Follow the updated proven workflow."
+        })
+
+      skill_file = Path.join([tmp_dir, ".lemon", "skill", "patchable-skill", "SKILL.md"])
+
+      assert result.details.action == "patch"
+      assert File.read!(skill_file) =~ "updated proven workflow"
+    end
+
+    test "requires replace_all for repeated matches", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "repeat-skill",
+        "content" => """
+        ---
+        name: Repeat Skill
+        description: Has repeated content
+        ---
+
+        foo
+        foo
+        """
+      })
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "patch",
+                 "name" => "repeat-skill",
+                 "old_string" => "foo",
+                 "new_string" => "bar"
+               })
+
+      assert message =~ "replace_all=true"
+    end
+
+    test "enforces supporting file size limits when patching", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "large-patch-skill",
+        "content" => valid_skill("Large Patch Skill")
+      })
+
+      execute(tmp_dir, %{
+        "action" => "write_file",
+        "name" => "large-patch-skill",
+        "file_path" => "references/guide.md",
+        "file_content" => "small"
+      })
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "patch",
+                 "name" => "large-patch-skill",
+                 "file_path" => "references/guide.md",
+                 "old_string" => "small",
+                 "new_string" => String.duplicate("x", 100_001)
+               })
+
+      assert message =~ "supporting file exceeds"
+    end
+  end
+
+  describe "supporting files" do
+    test "writes and removes a supporting file under an allowed directory", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "support-skill",
+        "content" => valid_skill("Support Skill")
+      })
+
+      write_result =
+        execute(tmp_dir, %{
+          "action" => "write_file",
+          "name" => "support-skill",
+          "file_path" => "references/guide.md",
+          "file_content" => "# Guide\n"
+        })
+
+      target = Path.join([tmp_dir, ".lemon", "skill", "support-skill", "references", "guide.md"])
+
+      assert write_result.details.action == "write_file"
+      assert File.read!(target) == "# Guide\n"
+
+      remove_result =
+        execute(tmp_dir, %{
+          "action" => "remove_file",
+          "name" => "support-skill",
+          "file_path" => "references/guide.md"
+        })
+
+      assert remove_result.details.action == "remove_file"
+      refute File.exists?(target)
+    end
+
+    test "rejects path traversal for supporting files", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "traversal-skill",
+        "content" => valid_skill("Traversal Skill")
+      })
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "write_file",
+                 "name" => "traversal-skill",
+                 "file_path" => "references/../../escape.md",
+                 "file_content" => "bad"
+               })
+
+      assert message =~ "may not contain '..'"
+    end
+
+    test "rejects writes through symlinked support directories", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "symlink-skill",
+        "content" => valid_skill("Symlink Skill")
+      })
+
+      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "symlink-skill"])
+      outside_dir = Path.join(tmp_dir, "outside")
+      File.mkdir_p!(outside_dir)
+      File.rm_rf!(Path.join(skill_dir, "references"))
+      :ok = File.ln_s(outside_dir, Path.join(skill_dir, "references"))
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "write_file",
+                 "name" => "symlink-skill",
+                 "file_path" => "references/guide.md",
+                 "file_content" => "bad"
+               })
+
+      assert message =~ "refusing to write through symlink"
+      refute File.exists?(Path.join(outside_dir, "guide.md"))
+    end
+
+    test "rejects patches through symlinked support directories", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "symlink-patch-skill",
+        "content" => valid_skill("Symlink Patch Skill")
+      })
+
+      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "symlink-patch-skill"])
+      outside_dir = Path.join(tmp_dir, "outside-patch")
+      File.mkdir_p!(outside_dir)
+      File.write!(Path.join(outside_dir, "guide.md"), "outside")
+      File.rm_rf!(Path.join(skill_dir, "references"))
+      :ok = File.ln_s(outside_dir, Path.join(skill_dir, "references"))
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "patch",
+                 "name" => "symlink-patch-skill",
+                 "file_path" => "references/guide.md",
+                 "old_string" => "outside",
+                 "new_string" => "changed"
+               })
+
+      assert message =~ "refusing to write through symlink"
+      assert File.read!(Path.join(outside_dir, "guide.md")) == "outside"
+    end
+
+    test "rejects removals through symlinked support directories", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "symlink-remove-skill",
+        "content" => valid_skill("Symlink Remove Skill")
+      })
+
+      skill_dir = Path.join([tmp_dir, ".lemon", "skill", "symlink-remove-skill"])
+      outside_dir = Path.join(tmp_dir, "outside-remove")
+      outside_file = Path.join(outside_dir, "guide.md")
+      File.mkdir_p!(outside_dir)
+      File.write!(outside_file, "outside")
+      File.rm_rf!(Path.join(skill_dir, "references"))
+      :ok = File.ln_s(outside_dir, Path.join(skill_dir, "references"))
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "remove_file",
+                 "name" => "symlink-remove-skill",
+                 "file_path" => "references/guide.md"
+               })
+
+      assert message =~ "refusing to write through symlink"
+      assert File.exists?(outside_file)
+    end
+  end
+end

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -55,7 +55,7 @@ For system diagrams see `docs/diagrams/`. For per-app details see each `apps/*/R
          │           └─────────────────────-┘
 ┌────────▼───────────────────────────────────┐
 │ CodingAgent.Session                         │
-│  · 22 built-in tools                        │
+│  · 23 built-in tools                        │
 │  · context compaction                       │
 │  · extension system                         │
 └────────┬───────────────────────────────────┘
@@ -219,4 +219,3 @@ Current flags: `product_runtime`, `skills_hub_v2`, `skill_manifest_v2`,
 | `apps/*/README.md` | Per-application documentation |
 
 *Last reviewed: 2026-03-16*
-

--- a/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
+++ b/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
@@ -1,6 +1,6 @@
 # Lemon ↔ Hermes-Class Agent Harness Parity Scorecard
 
-Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, and third slice wires relevant-skill preselection into the native session prompt path.
+Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, third slice wires relevant-skill preselection into the native session prompt path, and fourth slice adds an audited agent-facing skill authoring tool.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ Track where Lemon already has Hermes-class agent harness behavior, where it is p
 
 Lemon already has the hard architectural primitives: supervised BEAM sessions, channel routing, CLI engine adapters, task/subagent execution, skill registry, memory search, tool policies, approvals, and a control plane. The biggest near-term gaps are mostly harness-contract gaps: making the native Lemon agent reliably use those primitives every run, then adding tests/evals that prevent regressions.
 
-The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`.
+The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`. The fourth slice adds `skill_manage` so agents can turn reusable workflows into audited project/global skills.
 
 ## Capability scorecard
 
@@ -45,6 +45,7 @@ The first code slice from this scorecard made `read_skill` available in the defa
 - Current modules/docs:
   - `apps/lemon_skills/lib/lemon_skills/**`
   - `apps/lemon_skills/lib/lemon_skills/tools/read_skill.ex`
+  - `apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex`
   - `apps/coding_agent/lib/coding_agent/system_prompt.ex`
   - `apps/lemon_skills/lib/lemon_skills/prompt_view.ex`
   - `docs/user-guide/skills.md`
@@ -54,15 +55,18 @@ The first code slice from this scorecard made `read_skill` available in the defa
   - Prompt renderer lists available skills and tells the agent to load relevant skills.
   - Native session prompt refresh passes the current user prompt into relevance scoring and renders concise `<relevant-skills>` hints per turn.
   - `read_skill` can read full content, summaries, sections, and linked files.
+  - `skill_manage` can create, edit, patch, delete, and maintain audited project/global skills and supporting files.
   - Install/update audit gates exist.
 - Gaps:
   - Missed-skill detection is not yet audited as a run outcome.
-  - Skill authoring/patching from the agent loop is not as mature as read-only consumption.
+  - Skill authoring now exists but lacks Hermes-style usage telemetry, curation lifecycle, and pin/archive workflows.
   - Per-turn relevant-skill hints are guided, but not yet enforced through observed tool-call telemetry.
 - Priority: high.
 - Acceptance tests:
   - Native Lemon default tools include `read_skill`.
+  - Native Lemon default tools include `skill_manage`, and safe/subagent-restricted profiles deny it as a write-capable tool.
   - System prompt mentions `read_skill` only when the tool is available, or tests enforce both surfaces move together.
+  - System prompt mentions `skill_manage` only when the tool is available, or tests enforce both surfaces move together.
   - Eval harness verifies a skill-relevant fixture prompt surfaces a `<relevant-skills>` block, includes a `read_skill` reminder, and does not inline full skill bodies.
   - Future behavioral eval: a skill-relevant fixture prompt causes the agent/eval harness to call `read_skill` before answering.
 
@@ -208,10 +212,18 @@ The first code slice from this scorecard made `read_skill` available in the defa
 2. Updated session prompt refresh to pass the current user prompt/steer/follow-up text into skill relevance scoring.
 3. Added contract tests for system-prompt, prompt-builder, and session prompt-composer paths that require concise `<relevant-skills>` hints and keep full skill bodies behind `read_skill`.
 
+### Slice 4: Agent skill authoring tool
+
+1. Added `LemonSkills.Tools.SkillManage` for create/edit/patch/delete/write_file/remove_file operations on project and global skills.
+2. Wrapped `skill_manage` into the default CodingAgent tool surface, builtin registry, minimal-core policy, and harness contract.
+3. Treated `skill_manage` as dangerous in safe/subagent-restricted profiles and documented audited write behavior.
+
 ## Follow-up backlog
 
 1. Add skill-load telemetry fields to run events or session metadata.
-2. Add missed-skill audit warnings based on `LemonSkills.find_relevant/2` and observed tool calls.
-3. Clarify memory/session-search/skills/todos in docs and prompt text.
-4. Add cron parity scorecard and scheduled job prompt validation.
-5. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, async task receipt → `join` before final answer.
+2. Add skill-write and skill-load telemetry fields to run events or session metadata.
+3. Add missed-skill audit warnings based on `LemonSkills.find_relevant/2` and observed tool calls.
+4. Add Hermes-style skill curation lifecycle: usage counters, stale/archive/pinned states, and agent-authored provenance.
+5. Clarify memory/session-search/skills/todos in docs and prompt text.
+6. Add cron parity scorecard and scheduled job prompt validation.
+7. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, reusable workflow → `skill_manage`, async task receipt → `join` before final answer.

--- a/docs/user-guide/skills.md
+++ b/docs/user-guide/skills.md
@@ -81,6 +81,12 @@ system prompt lists installed skills by key and tells the agent to call
 `read_skill` before following any clearly relevant skill, so skill instructions
 can be loaded on demand without injecting every full `SKILL.md` body up front.
 
+Agents can also maintain procedural memory with `skill_manage`. Use project
+scope for repository-specific workflows and global scope for reusable workflows.
+The tool can create, edit, patch, delete, and maintain supporting files under
+`references/`, `templates/`, `scripts/`, and `assets/`; each write is audited
+before the registry is refreshed.
+
 ---
 
 ## Installing Skills


### PR DESCRIPTION
## Summary
- add an audited skill_manage tool for project/global skill creation, edits, patches, deletes, and support-file maintenance
- expose skill_manage through the coding-agent tool registry, policy, default tool surface, eval harness, and prompt guidance
- document the new agent-facing skill authoring path and update the Hermes parity scorecard

## Validation
- MIX_ENV=test mix compile --warnings-as-errors
- mix test apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs apps/coding_agent/test/coding_agent_test.exs apps/coding_agent/test/coding_agent/tools_test.exs apps/coding_agent/test/coding_agent/tool_registry_test.exs apps/coding_agent/test/coding_agent/tool_policy_test.exs apps/coding_agent/test/coding_agent/system_prompt_test.exs apps/coding_agent/test/coding_agent/evals/harness_contract_test.exs apps/coding_agent/test/coding_agent/evals/harness_test.exs apps/coding_agent/test/mix/tasks/lemon.eval_test.exs apps/lemon_control_plane/test/lemon_control_plane/methods/introspection_methods_test.exs
- git diff --check

Note: I could not find an existing open PR or review threads for feat/hermes-learning-parity before pushing this branch, so there were no inline findings to reply to.