### PR TITLE
feat: integrate current Lemon parity work

### DIFF
--- a/apps/coding_agent/lib/coding_agent/session/event_handler.ex
+++ b/apps/coding_agent/lib/coding_agent/session/event_handler.ex
@@ -98,6 +98,7 @@ defmodule CodingAgent.Session.EventHandler do
   def handle({:agent_end, messages}, state, callbacks) do
     # Execute on_agent_end hooks
     Extensions.execute_hooks(state.hooks, :on_agent_end, [messages])
+    maybe_record_missed_skills(state, messages)
 
     # Clear working message and steering queue
     callbacks.set_working_message.(state, nil)
@@ -133,4 +134,71 @@ defmodule CodingAgent.Session.EventHandler do
   def handle(_event, state, _callbacks) do
     state
   end
+
+  defp maybe_record_missed_skills(state, messages) do
+    relevant_keys = extract_relevant_skill_keys(Map.get(state, :system_prompt, ""))
+    loaded_keys = extract_loaded_skill_keys(messages)
+    missed_keys = relevant_keys -- loaded_keys
+
+    if missed_keys != [] do
+      Introspection.record(
+        :missed_skill_observed,
+        %{
+          missed_skill_keys: missed_keys,
+          loaded_skill_keys: loaded_keys
+        },
+        session_key: session_key(state),
+        agent_id: agent_id(state),
+        engine: "lemon",
+        provenance: :inferred
+      )
+    end
+  end
+
+  defp extract_relevant_skill_keys(prompt) when is_binary(prompt) do
+    ~r/<relevant-skills>(.*?)<\/relevant-skills>/s
+    |> Regex.scan(prompt, capture: :all_but_first)
+    |> Enum.flat_map(fn [block] ->
+      ~r/<key>\s*([^<]+?)\s*<\/key>/
+      |> Regex.scan(block, capture: :all_but_first)
+      |> List.flatten()
+    end)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp extract_relevant_skill_keys(_prompt), do: []
+
+  defp extract_loaded_skill_keys(messages) when is_list(messages) do
+    messages
+    |> Enum.filter(&read_skill_result?/1)
+    |> Enum.map(&skill_key_from_result/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp extract_loaded_skill_keys(_messages), do: []
+
+  defp read_skill_result?(%Ai.Types.ToolResultMessage{tool_name: "read_skill"}), do: true
+  defp read_skill_result?(%{tool_name: "read_skill"}), do: true
+  defp read_skill_result?(%{"tool_name" => "read_skill"}), do: true
+  defp read_skill_result?(_message), do: false
+
+  defp skill_key_from_result(%Ai.Types.ToolResultMessage{details: details}),
+    do: skill_key_from_details(details)
+
+  defp skill_key_from_result(%{details: details}), do: skill_key_from_details(details)
+  defp skill_key_from_result(%{"details" => details}), do: skill_key_from_details(details)
+
+  defp skill_key_from_details(%{key: key}) when is_binary(key), do: key
+  defp skill_key_from_details(%{"key" => key}) when is_binary(key), do: key
+  defp skill_key_from_details(_details), do: nil
+
+  defp session_key(%{session_manager: %{header: %{id: id}}}) when is_binary(id), do: id
+  defp session_key(%{session_key: id}) when is_binary(id), do: id
+  defp session_key(_state), do: nil
+
+  defp agent_id(%{agent_id: id}) when is_binary(id), do: id
+  defp agent_id(_state), do: "default"
 end

--- a/apps/coding_agent/test/coding_agent/session/event_handler_test.exs
+++ b/apps/coding_agent/test/coding_agent/session/event_handler_test.exs
@@ -1,9 +1,25 @@
 defmodule CodingAgent.Session.EventHandlerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
+  alias LemonCore.{Introspection, Store}
   alias CodingAgent.Session.EventHandler
 
   setup do
+    case Store.start_link([]) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    previous_introspection = Application.get_env(:lemon_core, :introspection, [])
+
+    Application.put_env(
+      :lemon_core,
+      :introspection,
+      Keyword.put(previous_introspection, :enabled, true)
+    )
+
+    on_exit(fn -> Application.put_env(:lemon_core, :introspection, previous_introspection) end)
+
     test_pid = self()
 
     callbacks = %{
@@ -235,4 +251,105 @@ defmodule CodingAgent.Session.EventHandlerTest do
       assert result.event_streams == %{}
     end
   end
+
+  describe "handle/3 - missed skill audit" do
+    test "records missed relevant skills at agent end", %{callbacks: callbacks} do
+      session_key = "session_missed_skill_#{System.unique_integer([:positive, :monotonic])}"
+
+      state = %{
+        hooks: [],
+        is_streaming: true,
+        steering_queue: :queue.new(),
+        event_streams: %{},
+        session_key: session_key,
+        agent_id: "agent-1",
+        system_prompt: """
+        <relevant-skills>
+          <skill>
+            <name>GitHub PR Workflow</name>
+            <key>github-pr-workflow</key>
+          </skill>
+          <skill>
+            <name>CI Debugging</name>
+            <key>ci-debugging</key>
+          </skill>
+          Use `read_skill` with <key> to load the full content of any relevant skill.
+        </relevant-skills>
+        """
+      }
+
+      EventHandler.handle({:agent_end, []}, state, callbacks)
+
+      event =
+        eventually(fn ->
+          Introspection.list(
+            session_key: session_key,
+            event_type: :missed_skill_observed,
+            limit: 10
+          )
+          |> Enum.find(
+            &(&1.payload[:missed_skill_keys] == ["github-pr-workflow", "ci-debugging"])
+          )
+        end)
+
+      assert event.agent_id == "agent-1"
+      assert event.provenance == :inferred
+      assert event.payload.loaded_skill_keys == []
+    end
+
+    test "does not record a miss when relevant skills were loaded", %{callbacks: callbacks} do
+      session_key = "session_loaded_skill_#{System.unique_integer([:positive, :monotonic])}"
+
+      state = %{
+        hooks: [],
+        is_streaming: true,
+        steering_queue: :queue.new(),
+        event_streams: %{},
+        session_key: session_key,
+        system_prompt: """
+        <relevant-skills>
+          <skill>
+            <name>GitHub PR Workflow</name>
+            <key>github-pr-workflow</key>
+          </skill>
+        </relevant-skills>
+        """
+      }
+
+      messages = [
+        %Ai.Types.ToolResultMessage{
+          tool_name: "read_skill",
+          details: %{key: "github-pr-workflow"}
+        }
+      ]
+
+      EventHandler.handle({:agent_end, messages}, state, callbacks)
+
+      Process.sleep(20)
+
+      events =
+        Introspection.list(
+          session_key: session_key,
+          event_type: :missed_skill_observed,
+          limit: 10
+        )
+
+      assert events == []
+    end
+  end
+
+  defp eventually(fun, attempts \\ 20)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    case fun.() do
+      nil ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+
+  defp eventually(fun, 0), do: flunk("expected condition to become true, got: #{inspect(fun.())}")
 end

--- a/apps/lemon_channels/test/lemon_channels/adapters/telegram/renderer_test.exs
+++ b/apps/lemon_channels/test/lemon_channels/adapters/telegram/renderer_test.exs
@@ -407,7 +407,7 @@ defmodule LemonChannels.Adapters.Telegram.RendererTest do
                intent(run_id, route, :final_text, %{text: long_text, seq: 3}, %{user_msg_id: "77"})
              )
 
-    refute_receive {:delivered, _payload}, 150
+    refute_receive {:delivered, %LemonChannels.OutboundPayload{meta: %{run_id: ^run_id}}}, 150
 
     send(PresentationState, {:presentation_delivery, in_flight_ref, {:ok, %{"ok" => true}}})
 

--- a/apps/lemon_control_plane/lib/lemon_control_plane/methods/transports_status.ex
+++ b/apps/lemon_control_plane/lib/lemon_control_plane/methods/transports_status.ex
@@ -45,15 +45,17 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   end
 
   defp transport_registry_running? do
-    Code.ensure_loaded?(LemonGateway.TransportRegistry) and
-      is_pid(Process.whereis(LemonGateway.TransportRegistry))
+    registry = transport_registry_module()
+
+    Code.ensure_loaded?(registry) and is_pid(Process.whereis(registry))
   end
 
   defp configured_transports(false), do: []
 
   defp configured_transports(true) do
-    registry_module()
-    |> apply(:list_transports, [])
+    registry = transport_registry_module()
+
+    apply(registry, :list_transports, [])
     |> Enum.map(fn id -> {id, safe_get_transport(id)} end)
   rescue
     _ -> []
@@ -64,8 +66,7 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   defp enabled_transport_ids(false), do: MapSet.new()
 
   defp enabled_transport_ids(true) do
-    registry_module()
-    |> apply(:enabled_transports, [])
+    apply(transport_registry_module(), :enabled_transports, [])
     |> Enum.map(fn {id, _mod} -> id end)
     |> MapSet.new()
   rescue
@@ -75,16 +76,15 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   end
 
   defp safe_get_transport(id) do
-    registry_module()
-    |> apply(:get_transport, [id])
+    apply(transport_registry_module(), :get_transport, [id])
   rescue
     _ -> nil
   catch
     :exit, _ -> nil
   end
 
-  defp registry_module, do: LemonGateway.TransportRegistry
-
   defp module_name(mod) when is_atom(mod), do: Atom.to_string(mod)
   defp module_name(_), do: nil
+
+  defp transport_registry_module, do: :"Elixir.LemonGateway.TransportRegistry"
 end

--- a/apps/lemon_control_plane/lib/lemon_control_plane/methods/transports_status.ex
+++ b/apps/lemon_control_plane/lib/lemon_control_plane/methods/transports_status.ex
@@ -53,38 +53,66 @@ defmodule LemonControlPlane.Methods.TransportsStatus do
   defp configured_transports(false), do: []
 
   defp configured_transports(true) do
-    registry = transport_registry_module()
+    case registry_call(:list_transports, []) do
+      {:ok, ids} when is_list(ids) ->
+        Enum.map(ids, fn id -> {id, safe_get_transport(id)} end)
 
-    apply(registry, :list_transports, [])
-    |> Enum.map(fn id -> {id, safe_get_transport(id)} end)
-  rescue
-    _ -> []
-  catch
-    :exit, _ -> []
+      _ ->
+        []
+    end
   end
 
   defp enabled_transport_ids(false), do: MapSet.new()
 
   defp enabled_transport_ids(true) do
-    apply(transport_registry_module(), :enabled_transports, [])
-    |> Enum.map(fn {id, _mod} -> id end)
-    |> MapSet.new()
-  rescue
-    _ -> MapSet.new()
-  catch
-    :exit, _ -> MapSet.new()
+    case registry_call(:enabled_transports, []) do
+      {:ok, transports} when is_list(transports) ->
+        transports
+        |> Enum.map(fn {id, _mod} -> id end)
+        |> MapSet.new()
+
+      _ ->
+        MapSet.new()
+    end
   end
 
   defp safe_get_transport(id) do
-    apply(transport_registry_module(), :get_transport, [id])
-  rescue
-    _ -> nil
-  catch
-    :exit, _ -> nil
+    case registry_call(:get_transport, [id]) do
+      {:ok, mod} -> mod
+      _ -> nil
+    end
   end
 
+  defp module_name(nil), do: nil
   defp module_name(mod) when is_atom(mod), do: Atom.to_string(mod)
   defp module_name(_), do: nil
 
-  defp transport_registry_module, do: :"Elixir.LemonGateway.TransportRegistry"
+  defp registry_call(function, args) when is_atom(function) and is_list(args) do
+    registry = transport_registry_module()
+    arity = length(args)
+
+    cond do
+      not Code.ensure_loaded?(registry) ->
+        {:error, :module_not_loaded}
+
+      not function_exported?(registry, function, arity) ->
+        {:error, {:missing_function, function, arity}}
+
+      true ->
+        {:ok, apply(registry, function, args)}
+    end
+  rescue
+    error -> {:error, error}
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  defp transport_registry_module do
+    Application.get_env(
+      :lemon_control_plane,
+      :transport_registry_module,
+      :"Elixir.LemonGateway.TransportRegistry"
+    )
+  end
 end

--- a/apps/lemon_control_plane/test/lemon_control_plane/methods/introspection_methods_test.exs
+++ b/apps/lemon_control_plane/test/lemon_control_plane/methods/introspection_methods_test.exs
@@ -65,6 +65,69 @@ defmodule LemonControlPlane.Methods.IntrospectionMethodsTest do
     end
   end
 
+  defmodule TransportRegistryStub do
+    use GenServer
+
+    def start_link(state) do
+      GenServer.start(__MODULE__, state, name: __MODULE__)
+    end
+
+    def list_transports, do: GenServer.call(__MODULE__, :list_transports)
+    def enabled_transports, do: GenServer.call(__MODULE__, :enabled_transports)
+    def get_transport(id), do: GenServer.call(__MODULE__, {:get_transport, id})
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(:list_transports, _from, state) do
+      {:reply, Map.keys(state.transports), state}
+    end
+
+    def handle_call(:enabled_transports, _from, state) do
+      enabled =
+        state.transports
+        |> Enum.filter(fn {id, _mod} -> id in state.enabled end)
+        |> Enum.into([])
+
+      {:reply, enabled, state}
+    end
+
+    def handle_call({:get_transport, id}, _from, state) do
+      {:reply, Map.get(state.transports, id), state}
+    end
+  end
+
+  defmodule TransportRegistryMissingApiStub do
+    use GenServer
+
+    def start_link(state) do
+      GenServer.start(__MODULE__, state, name: __MODULE__)
+    end
+
+    @impl true
+    def init(state), do: {:ok, state}
+  end
+
+  defmodule TransportRegistryCrashingStub do
+    use GenServer
+
+    def start_link(state) do
+      GenServer.start(__MODULE__, state, name: __MODULE__)
+    end
+
+    def list_transports, do: GenServer.call(__MODULE__, :list_transports)
+    def enabled_transports, do: GenServer.call(__MODULE__, :enabled_transports)
+    def get_transport(_id), do: raise("registry API failure")
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(:list_transports, _from, state), do: {:reply, ["email"], state}
+    def handle_call(:enabled_transports, _from, state), do: {:reply, [], state}
+  end
+
   setup do
     token = System.unique_integer([:positive, :monotonic])
     agent_id = "cp_introspection_#{token}"
@@ -203,13 +266,26 @@ defmodule LemonControlPlane.Methods.IntrospectionMethodsTest do
       assert is_map(session["harness"])
       assert session["harness"]["todos"]["total"] == 1
       assert session["harness"]["checkpoints"]["count"] >= 1
-      assert session["harness"]["requirements"]["project_name"] == "Control Plane Harness Projection"
+
+      assert session["harness"]["requirements"]["project_name"] ==
+               "Control Plane Harness Projection"
+
       assert session["harness"]["requirements"]["percentage"] == 50
       assert session["harness"]["requirements"]["cwd"] == requirements_cwd
     end
   end
 
   describe "transports.status" do
+    setup do
+      old_registry_module = Application.get_env(:lemon_control_plane, :transport_registry_module)
+
+      on_exit(fn ->
+        restore_transport_registry_module(old_registry_module)
+      end)
+
+      :ok
+    end
+
     test "returns transport visibility snapshot" do
       assert TransportsStatus.name() == "transports.status"
       assert TransportsStatus.scopes() == [:read]
@@ -228,6 +304,111 @@ defmodule LemonControlPlane.Methods.IntrospectionMethodsTest do
         assert is_boolean(transport["enabled"])
         assert transport["status"] in ["enabled", "disabled"]
       end)
+    end
+
+    test "returns empty snapshot when the gateway registry module is not loaded" do
+      Application.put_env(
+        :lemon_control_plane,
+        :transport_registry_module,
+        :"Elixir.LemonControlPlane.MissingTransportRegistryForTest"
+      )
+
+      {:ok, result} = TransportsStatus.handle(%{}, %{})
+
+      assert result["registryRunning"] == false
+      assert result["transports"] == []
+      assert result["total"] == 0
+      assert result["enabled"] == 0
+    end
+
+    test "returns empty snapshot when the gateway registry module is loaded but stopped" do
+      Application.put_env(:lemon_control_plane, :transport_registry_module, TransportRegistryStub)
+
+      {:ok, result} = TransportsStatus.handle(%{}, %{})
+
+      assert result["registryRunning"] == false
+      assert result["transports"] == []
+    end
+
+    test "returns configured and enabled transports when the legacy registry is running" do
+      Application.put_env(:lemon_control_plane, :transport_registry_module, TransportRegistryStub)
+
+      {:ok, pid} =
+        TransportRegistryStub.start_link(%{
+          transports: %{"email" => Example.EmailTransport, "webhook" => Example.WebhookTransport},
+          enabled: ["webhook"]
+        })
+
+      try do
+        {:ok, result} = TransportsStatus.handle(%{}, %{})
+
+        assert result["registryRunning"] == true
+        assert result["total"] == 2
+        assert result["enabled"] == 1
+
+        assert result["transports"] == [
+                 %{
+                   "transportId" => "email",
+                   "module" => "Elixir.Example.EmailTransport",
+                   "enabled" => false,
+                   "status" => "disabled"
+                 },
+                 %{
+                   "transportId" => "webhook",
+                   "module" => "Elixir.Example.WebhookTransport",
+                   "enabled" => true,
+                   "status" => "enabled"
+                 }
+               ]
+      after
+        Process.unlink(pid)
+        Process.exit(pid, :kill)
+      end
+    end
+
+    test "degrades safely when the registry API is missing or fails" do
+      Application.put_env(
+        :lemon_control_plane,
+        :transport_registry_module,
+        TransportRegistryMissingApiStub
+      )
+
+      {:ok, missing_api_pid} = TransportRegistryMissingApiStub.start_link(%{})
+
+      try do
+        {:ok, result} = TransportsStatus.handle(%{}, %{})
+        assert result["registryRunning"] == true
+        assert result["transports"] == []
+      after
+        Process.unlink(missing_api_pid)
+        Process.exit(missing_api_pid, :kill)
+      end
+
+      Application.put_env(
+        :lemon_control_plane,
+        :transport_registry_module,
+        TransportRegistryCrashingStub
+      )
+
+      {:ok, crashing_pid} = TransportRegistryCrashingStub.start_link(%{})
+
+      try do
+        {:ok, result} = TransportsStatus.handle(%{}, %{})
+
+        assert result["registryRunning"] == true
+
+        assert result["transports"] == [
+                 %{
+                   "transportId" => "email",
+                   "module" => nil,
+                   "enabled" => false,
+                   "status" => "disabled"
+                 }
+               ]
+      after
+        Process.unlink(crashing_pid)
+        Process.exit(crashing_pid, :kill)
+      end
     end
   end
 
@@ -277,7 +458,10 @@ defmodule LemonControlPlane.Methods.IntrospectionMethodsTest do
       assert session = Enum.find(result["activeSessions"], &(&1["sessionKey"] == session_key))
       assert is_map(session["harness"])
       assert session["harness"]["todos"]["total"] == 1
-      assert session["harness"]["requirements"]["project_name"] == "Control Plane Harness Projection"
+
+      assert session["harness"]["requirements"]["project_name"] ==
+               "Control Plane Harness Projection"
+
       assert session["harness"]["requirements"]["cwd"] == requirements_cwd
     end
 
@@ -305,9 +489,18 @@ defmodule LemonControlPlane.Methods.IntrospectionMethodsTest do
   defp restore_router_bridge(nil), do: Application.delete_env(:lemon_core, :router_bridge)
   defp restore_router_bridge(config), do: Application.put_env(:lemon_core, :router_bridge, config)
 
-  defp restore_session_coordinator(nil), do: Application.delete_env(:lemon_router, :session_coordinator)
+  defp restore_session_coordinator(nil),
+    do: Application.delete_env(:lemon_router, :session_coordinator)
 
   defp restore_session_coordinator(config) do
     Application.put_env(:lemon_router, :session_coordinator, config)
+  end
+
+  defp restore_transport_registry_module(nil) do
+    Application.delete_env(:lemon_control_plane, :transport_registry_module)
+  end
+
+  defp restore_transport_registry_module(config) do
+    Application.put_env(:lemon_control_plane, :transport_registry_module, config)
   end
 end

--- a/apps/lemon_core/lib/lemon_core/quality/architecture_policy.ex
+++ b/apps/lemon_core/lib/lemon_core/quality/architecture_policy.ex
@@ -24,7 +24,6 @@ defmodule LemonCore.Quality.ArchitecturePolicy do
       :lemon_automation,
       :lemon_channels,
       :lemon_core,
-      :lemon_gateway,
       :lemon_router,
       :lemon_skills
     ],
@@ -34,7 +33,6 @@ defmodule LemonCore.Quality.ArchitecturePolicy do
       :ai,
       :coding_agent,
       :lemon_automation,
-      :lemon_channels,
       :lemon_core
     ],
     lemon_mcp: [:agent_core, :coding_agent],

--- a/apps/lemon_core/lib/lemon_core/telemetry.ex
+++ b/apps/lemon_core/lib/lemon_core/telemetry.ex
@@ -33,12 +33,21 @@ defmodule LemonCore.Telemetry do
     meta: `%{run_id, session_key, agent_id}`. Emitted after each successful ingest.
   - `[:lemon, :memory, :ingest, :failure]` - measurements: `%{count: 1, duration_us: integer()}`,
     meta: `%{run_id, error}`. Emitted when an ingest fails (after catching the exception).
+
+  ### Skills
+  - `[:lemon_skills, :skill, :load]` - measurements: `%{count: 1, system_time: integer()}`,
+    meta includes `result`, `key`, `view`, `tool_call_id`, `session_key`, and redacted skill metadata when available.
+    Projected to introspection as `:skill_load_observed`.
+  - `[:lemon_skills, :skill, :write]` - measurements: `%{count: 1, system_time: integer()}`,
+    meta includes `result`, `action`, `name`, `scope`, `tool_call_id`, `session_key`, and redacted write metadata.
+    Projected to introspection as `:skill_write_observed`.
   """
 
   @doc """
   Execute a function and emit start/stop/exception telemetry.
   """
-  @spec span(event_prefix :: [atom()], metadata :: map(), fun :: (-> result)) :: result when result: term()
+  @spec span(event_prefix :: [atom()], metadata :: map(), fun :: (-> result)) :: result
+        when result: term()
   def span(event_prefix, metadata, fun) do
     :telemetry.span(event_prefix, metadata, fn ->
       result = fun.()
@@ -73,7 +82,11 @@ defmodule LemonCore.Telemetry do
   """
   @spec run_start(run_id :: binary(), metadata :: map()) :: :ok
   def run_start(run_id, metadata \\ %{}) do
-    emit([:lemon, :run, :start], %{ts_ms: LemonCore.Clock.now_ms()}, Map.put(metadata, :run_id, run_id))
+    emit(
+      [:lemon, :run, :start],
+      %{ts_ms: LemonCore.Clock.now_ms()},
+      Map.put(metadata, :run_id, run_id)
+    )
   end
 
   @doc """
@@ -122,10 +135,14 @@ defmodule LemonCore.Telemetry do
   """
   @spec approval_requested(approval_id :: binary(), tool :: binary(), metadata :: map()) :: :ok
   def approval_requested(approval_id, tool, metadata \\ %{}) do
-    emit([:lemon, :approvals, :requested], %{count: 1}, Map.merge(metadata, %{
-      approval_id: approval_id,
-      tool: tool
-    }))
+    emit(
+      [:lemon, :approvals, :requested],
+      %{count: 1},
+      Map.merge(metadata, %{
+        approval_id: approval_id,
+        tool: tool
+      })
+    )
   end
 
   @doc """
@@ -133,10 +150,14 @@ defmodule LemonCore.Telemetry do
   """
   @spec approval_resolved(approval_id :: binary(), decision :: atom(), metadata :: map()) :: :ok
   def approval_resolved(approval_id, decision, metadata \\ %{}) do
-    emit([:lemon, :approvals, :resolved], %{count: 1}, Map.merge(metadata, %{
-      approval_id: approval_id,
-      decision: decision
-    }))
+    emit(
+      [:lemon, :approvals, :resolved],
+      %{count: 1},
+      Map.merge(metadata, %{
+        approval_id: approval_id,
+        decision: decision
+      })
+    )
   end
 
   # Cron events

--- a/apps/lemon_core/test/lemon_core/quality/architecture_check_test.exs
+++ b/apps/lemon_core/test/lemon_core/quality/architecture_check_test.exs
@@ -87,8 +87,8 @@ defmodule LemonCore.Quality.ArchitectureCheckTest do
 
       refute :lemon_gateway in target.lemon_router
       refute :lemon_gateway in current.lemon_router
+      refute :lemon_gateway in current.lemon_control_plane
 
-      assert :lemon_channels in current.lemon_gateway
       assert :lemon_automation in current.lemon_gateway
       assert :ai in current.lemon_gateway
 
@@ -101,11 +101,11 @@ defmodule LemonCore.Quality.ArchitectureCheckTest do
   end
 
   describe "target dependency drift" do
-    test "tracks target drift independently from current enforcement" do
+    test "current repository has converged to the target dependency policy" do
       assert {:ok, report} = ArchitectureCheck.run(root: @repo_root)
       assert report.issue_count == 0
-      assert is_integer(report.target_drift_count)
-      assert is_list(report.target_dependency_drifts)
+      assert report.target_dependency_drifts == []
+      assert report.target_drift_count == 0
     end
 
     test "does not turn target-only drift into current policy issues" do

--- a/apps/lemon_gateway/AGENTS.md
+++ b/apps/lemon_gateway/AGENTS.md
@@ -464,7 +464,6 @@ assert completed.ok == true
 | `agent_core` | `AgentCore.CliRunners.*` (ClaudeRunner, CodexRunner, etc.), `AgentCore.EventStream`, `AgentCore.Types.*` |
 | `coding_agent` | `CodingAgent.CliRunners.LemonRunner` (native engine), `CodingAgent.Session`, `CodingAgent.Config` |
 | `lemon_core` | `LemonCore.Store` (chat state, runs, progress), `LemonCore.Bus` (event broadcast), `LemonCore.Telemetry`, `LemonCore.ResumeToken`, `LemonCore.ChatScope`, `LemonCore.Binding`, `LemonCore.BindingResolver`, `LemonCore.Secrets`, `LemonCore.GatewayConfig`, `LemonCore.Introspection`, `LemonCore.Event` |
-| `lemon_channels` | Compile-time only (`runtime: false`). Telegram/Discord/XMTP adapters are implemented there but consume gateway bus events. |
 
 ### Dependents (apps that depend on this)
 
@@ -566,7 +565,7 @@ Emitted via `LemonCore.Telemetry`:
 ### Umbrella Apps
 - `agent_core` -- CLI runner infrastructure, tool types, event stream
 - `coding_agent` -- Native Lemon engine runner, session management
-- `lemon_channels` -- Telegram/Discord/XMTP adapters (compile-time dep, `runtime: false`)
+- `lemon_channels` -- Telegram/Discord/XMTP adapters live there and consume gateway bus events; LemonGateway must not depend on it directly. Optional health checks that inspect channel-owned processes must use runtime lookup/custom checks rather than compile-time references.
 - `lemon_core` -- Store, Bus, Telemetry, types, secrets, config loading
 
 ### External Libraries

--- a/apps/lemon_gateway/README.md
+++ b/apps/lemon_gateway/README.md
@@ -463,7 +463,6 @@ Custom health checks can be registered via the `:health_checks` application envi
 |-----|---------|
 | `agent_core` | CLI runner infrastructure, tool types (`AgentTool`, `AgentToolResult`), event stream |
 | `coding_agent` | Native Lemon AI engine (`CodingAgent.CliRunners.LemonRunner`, `CodingAgent.Session`) |
-| `lemon_channels` | Telegram, Discord, XMTP adapters (compile-time only dependency, runtime: false) |
 | `lemon_core` | Shared primitives: `Store`, `Bus`, `Telemetry`, `ResumeToken`, `ChatScope`, `Binding`, `Secrets`, `GatewayConfig` |
 
 ### External Libraries

--- a/apps/lemon_gateway/lib/lemon_gateway/health.ex
+++ b/apps/lemon_gateway/lib/lemon_gateway/health.ex
@@ -147,7 +147,7 @@ defmodule LemonGateway.Health do
   end
 
   defp xmtp_transport_check do
-    xmtp_transport_mod = LemonChannels.Adapters.Xmtp.Transport
+    xmtp_transport_mod = :"Elixir.LemonChannels.Adapters.Xmtp.Transport"
 
     with true <- Code.ensure_loaded?(xmtp_transport_mod),
          true <- function_exported?(xmtp_transport_mod, :status, 0),

--- a/apps/lemon_gateway/lib/lemon_gateway/health.ex
+++ b/apps/lemon_gateway/lib/lemon_gateway/health.ex
@@ -147,13 +147,14 @@ defmodule LemonGateway.Health do
   end
 
   defp xmtp_transport_check do
-    xmtp_transport_mod = :"Elixir.LemonChannels.Adapters.Xmtp.Transport"
+    xmtp_transport_mod = xmtp_transport_module()
 
-    with true <- Code.ensure_loaded?(xmtp_transport_mod),
-         true <- function_exported?(xmtp_transport_mod, :status, 0),
-         {:ok, status} <- xmtp_transport_mod.status(),
-         true <- status[:connected?] == true,
-         true <- status[:healthy?] == true do
+    with {:module_loaded, true} <- {:module_loaded, Code.ensure_loaded?(xmtp_transport_mod)},
+         {:status_exported, true} <-
+           {:status_exported, function_exported?(xmtp_transport_mod, :status, 0)},
+         {:status, {:ok, status}} <- {:status, apply(xmtp_transport_mod, :status, [])},
+         {:connected, true} <- {:connected, status[:connected?] == true},
+         {:healthy, true} <- {:healthy, status[:healthy?] == true} do
       {:ok,
        %{
          mode: status[:mode],
@@ -161,11 +162,23 @@ defmodule LemonGateway.Health do
          connected: status[:connected?]
        }}
     else
-      false ->
-        {:error, :xmtp_not_live}
+      {:module_loaded, false} ->
+        {:error, :xmtp_module_not_loaded}
 
-      {:error, reason} ->
+      {:status_exported, false} ->
+        {:error, :xmtp_status_unavailable}
+
+      {:status, {:error, reason}} ->
         {:error, reason}
+
+      {:status, other} ->
+        {:error, {:unexpected_xmtp_status, other}}
+
+      {:connected, false} ->
+        {:error, :xmtp_not_connected}
+
+      {:healthy, false} ->
+        {:error, :xmtp_unhealthy}
 
       other ->
         {:error, {:unexpected_xmtp_status, other}}
@@ -173,6 +186,14 @@ defmodule LemonGateway.Health do
   rescue
     error ->
       {:error, error}
+  end
+
+  defp xmtp_transport_module do
+    Application.get_env(
+      :lemon_gateway,
+      :xmtp_transport_module,
+      :"Elixir.LemonChannels.Adapters.Xmtp.Transport"
+    )
   end
 
   defp xmtp_enabled? do

--- a/apps/lemon_gateway/lib/lemon_gateway/health.ex
+++ b/apps/lemon_gateway/lib/lemon_gateway/health.ex
@@ -152,7 +152,7 @@ defmodule LemonGateway.Health do
     with {:module_loaded, true} <- {:module_loaded, Code.ensure_loaded?(xmtp_transport_mod)},
          {:status_exported, true} <-
            {:status_exported, function_exported?(xmtp_transport_mod, :status, 0)},
-         {:status, {:ok, status}} <- {:status, apply(xmtp_transport_mod, :status, [])},
+         {:status, {:ok, status}} <- {:status, safe_xmtp_status(xmtp_transport_mod)},
          {:connected, true} <- {:connected, status[:connected?] == true},
          {:healthy, true} <- {:healthy, status[:healthy?] == true} do
       {:ok,
@@ -186,6 +186,14 @@ defmodule LemonGateway.Health do
   rescue
     error ->
       {:error, error}
+  end
+
+  defp safe_xmtp_status(module) do
+    apply(module, :status, [])
+  rescue
+    exception -> {:error, {:raised, Exception.message(exception)}}
+  catch
+    kind, reason -> {:error, {kind, reason}}
   end
 
   defp xmtp_transport_module do

--- a/apps/lemon_gateway/mix.exs
+++ b/apps/lemon_gateway/mix.exs
@@ -42,7 +42,6 @@ defmodule LemonGateway.MixProject do
       {:websock_adapter, "~> 0.5"},
       {:agent_core, in_umbrella: true},
       {:coding_agent, in_umbrella: true},
-      {:lemon_channels, in_umbrella: true, runtime: false},
       {:lemon_core, in_umbrella: true}
     ]
   end

--- a/apps/lemon_gateway/test/health_test.exs
+++ b/apps/lemon_gateway/test/health_test.exs
@@ -18,6 +18,10 @@ defmodule LemonGateway.HealthTest do
     end
   end
 
+  defmodule XmtpCrashingStub do
+    def status, do: raise("xmtp status crashed")
+  end
+
   setup do
     Application.stop(:lemon_gateway)
 
@@ -126,6 +130,15 @@ defmodule LemonGateway.HealthTest do
     check = xmtp_health_check()
     assert check.ok == false
     assert check.error =~ ":xmtp_unhealthy"
+  end
+
+  test "xmtp readiness check reports status callback crashes without raising" do
+    restart_gateway_with_xmtp(XmtpCrashingStub)
+
+    check = xmtp_health_check()
+
+    assert check.ok == false
+    assert check.error =~ "xmtp status crashed"
   end
 
   defp restart_gateway_with_xmtp(transport_module) do

--- a/apps/lemon_gateway/test/health_test.exs
+++ b/apps/lemon_gateway/test/health_test.exs
@@ -3,6 +3,21 @@ defmodule LemonGateway.HealthTest do
 
   import Plug.Test
 
+  defmodule XmtpMissingStatusStub do
+  end
+
+  defmodule XmtpDisconnectedStub do
+    def status do
+      {:ok, %{mode: :mock, require_live: true, connected?: false, healthy?: true}}
+    end
+  end
+
+  defmodule XmtpUnhealthyStub do
+    def status do
+      {:ok, %{mode: :mock, require_live: true, connected?: true, healthy?: false}}
+    end
+  end
+
   setup do
     Application.stop(:lemon_gateway)
 
@@ -21,6 +36,7 @@ defmodule LemonGateway.HealthTest do
     on_exit(fn ->
       Application.stop(:lemon_gateway)
       Application.delete_env(:lemon_gateway, :health_checks)
+      Application.delete_env(:lemon_gateway, :xmtp_transport_module)
     end)
 
     :ok
@@ -78,5 +94,58 @@ defmodule LemonGateway.HealthTest do
     assert Enum.any?(body["checks"], fn check ->
              check["name"] == "xmtp_transport" and check["ok"] == false
            end)
+  end
+
+  test "xmtp readiness check distinguishes missing channel module" do
+    restart_gateway_with_xmtp(:"Elixir.LemonGateway.HealthTest.MissingXmtpModule")
+
+    check = xmtp_health_check()
+
+    assert check.ok == false
+    assert check.error =~ ":xmtp_module_not_loaded"
+  end
+
+  test "xmtp readiness check distinguishes missing status callback" do
+    restart_gateway_with_xmtp(XmtpMissingStatusStub)
+
+    check = xmtp_health_check()
+
+    assert check.ok == false
+    assert check.error =~ ":xmtp_status_unavailable"
+  end
+
+  test "xmtp readiness check distinguishes disconnected and unhealthy transport" do
+    restart_gateway_with_xmtp(XmtpDisconnectedStub)
+
+    check = xmtp_health_check()
+    assert check.ok == false
+    assert check.error =~ ":xmtp_not_connected"
+
+    restart_gateway_with_xmtp(XmtpUnhealthyStub)
+
+    check = xmtp_health_check()
+    assert check.ok == false
+    assert check.error =~ ":xmtp_unhealthy"
+  end
+
+  defp restart_gateway_with_xmtp(transport_module) do
+    Application.stop(:lemon_gateway)
+
+    Application.put_env(:lemon_gateway, :xmtp_transport_module, transport_module)
+
+    Application.put_env(:lemon_gateway, LemonGateway.Config, %{
+      max_concurrent_runs: 1,
+      default_engine: "echo",
+      enable_telegram: false,
+      enable_xmtp: true
+    })
+
+    {:ok, _} = Application.ensure_all_started(:lemon_gateway)
+  end
+
+  defp xmtp_health_check do
+    LemonGateway.Health.status()
+    |> Map.fetch!(:checks)
+    |> Enum.find(&(&1.name == "xmtp_transport"))
   end
 end

--- a/apps/lemon_skills/AGENTS.md
+++ b/apps/lemon_skills/AGENTS.md
@@ -26,6 +26,7 @@ LemonSkills is the skill management system for the Lemon agent platform. It prov
 | `lib/lemon_skills/audit/engine.ex` | Deterministic skill security audit; merges static checks with optional LLM review | Changing audit behavior or verdict handling |
 | `lib/lemon_skills/audit/llm_reviewer.ex` | Optional model-backed audit reviewer for suspicious/malicious skill content | Changing LLM audit prompts, model resolution, or parsing |
 | `lib/lemon_skills/audit/state.ex` | Reads/writes persisted bundle audit state per scope | Changing audit cache storage or state schema |
+| `lib/lemon_skills/usage.ex` | Persists skill usage counters, agent-authored provenance, and curation state (`active`/`stale`/`archived`/`pinned`) | Changing skill curation, pin/archive behavior, or usage analytics |
 | `lib/lemon_skills/builtin_seeder.ex` | Copies `priv/builtin_skills/` to `~/.lemon/agent/skill/` on startup (idempotent) | Adding/modifying bundled skills |
 | `lib/lemon_skills/discovery.ex` | GitHub topic search + registry URL probing for online skill discovery | Changing online discovery sources |
 
@@ -37,6 +38,8 @@ LemonSkills is the skill management system for the Lemon agent platform. It prov
 | `lib/lemon_skills/tools/skill_manage.ex` | `skill_manage` | Creates, edits, patches, deletes, and audits local skills |
 | `lib/lemon_skills/tools/post_to_x.ex` | `post_to_x` | Posts tweets via X API |
 | `lib/lemon_skills/tools/get_x_mentions.ex` | `get_x_mentions` | Fetches X mentions |
+
+`read_skill` emits `[:lemon_skills, :skill, :load]` telemetry for successful and missing skill loads. `skill_manage` emits `[:lemon_skills, :skill, :write]` telemetry for accepted and rejected write attempts. These events include `tool_call_id` plus session metadata when available, exclude skill body/supporting-file content, update `LemonSkills.Usage`, and are projected into introspection as `:skill_load_observed` / `:skill_write_observed`.
 
 ### Infrastructure
 
@@ -161,6 +164,15 @@ Detailed audit state is stored outside the lockfile:
 
 `skills.lock.json` still carries the high-level provenance fields used by the registry (`content_hash`, `bundle_hash`, `audit_status`, etc.), but detailed cached findings live in the audit-state file.
 
+### Usage and Curation State
+
+Skill loads and writes update a sidecar usage file outside `SKILL.md`:
+
+- global: `~/.lemon/agent/skills.usage.json`
+- project: `<cwd>/.lemon/skills.usage.json`
+
+The sidecar stores load/write counters, last-use metadata, agent-authored creation provenance, and lifecycle state. `skill_manage` supports `pin`, `unpin`, `archive`, and `restore`; pinned skills cannot be archived or deleted until unpinned, and archived project/global skills are disabled through `skills.json` so relevance selection stops surfacing them.
+
 ### HTTP Client Injection
 
 `LemonSkills.HttpClient` is a behaviour. The default `Httpc` module uses Erlang `:httpc`. In tests, it is replaced with `LemonSkills.HttpClient.Mock` via `config :lemon_skills, :http_client, MockModule`.
@@ -269,7 +281,7 @@ HttpMock.stub("https://skills.lemon.agent/", {:error, :nxdomain})
 
 | App | What LemonSkills uses from it |
 |-----|-------------------------------|
-| `lemon_core` | `LemonCore.ExecApprovals` for approval gating in Installer; `LemonCore.Secrets` for GitHub token resolution in Discovery |
+| `lemon_core` | `LemonCore.ExecApprovals` for approval gating in Installer; `LemonCore.Secrets` for GitHub token resolution in Discovery; `LemonCore.Telemetry` for skill load/write events |
 | `agent_core` | `AgentCore.Types.AgentTool` and `AgentCore.Types.AgentToolResult` structs for tool definitions |
 | `ai` | `Ai.Types.TextContent` struct for tool result content |
 | `lemon_channels` | `LemonChannels.Adapters.XAPI` for X API integration (post_to_x, get_x_mentions tools) |

--- a/apps/lemon_skills/lib/lemon_skills.ex
+++ b/apps/lemon_skills/lib/lemon_skills.ex
@@ -35,7 +35,7 @@ defmodule LemonSkills do
   - `LemonSkills.Config` - Configuration paths and settings
   """
 
-  alias LemonSkills.{Registry, Entry, Status, Installer, Config}
+  alias LemonSkills.{Registry, Entry, Status, Installer, Config, Usage}
 
   # ============================================================================
   # Registry Operations
@@ -259,4 +259,10 @@ defmodule LemonSkills do
   """
   @spec find_relevant(String.t(), keyword()) :: [Entry.t()]
   defdelegate find_relevant(context, opts \\ []), to: Registry
+
+  @doc """
+  Return persisted usage and curation metadata for a skill.
+  """
+  @spec usage(String.t(), keyword()) :: map()
+  defdelegate usage(key, opts \\ []), to: Usage, as: :get
 end

--- a/apps/lemon_skills/lib/lemon_skills/application.ex
+++ b/apps/lemon_skills/lib/lemon_skills/application.ex
@@ -11,6 +11,7 @@ defmodule LemonSkills.Application do
     LemonSkills.BuiltinSeeder.seed!()
     # Back-fill lockfile provenance for any pre-existing installs.
     LemonSkills.Migrator.migrate()
+    LemonSkills.Telemetry.attach_introspection_bridge()
 
     children = [
       LemonSkills.Registry,

--- a/apps/lemon_skills/lib/lemon_skills/config.ex
+++ b/apps/lemon_skills/lib/lemon_skills/config.ex
@@ -67,6 +67,7 @@ defmodule LemonSkills.Config do
   """
 
   @skills_config_filename "skills.json"
+  @skills_usage_filename "skills.usage.json"
 
   @typedoc "MCP server configuration type"
   @type mcp_server_config ::
@@ -278,6 +279,14 @@ defmodule LemonSkills.Config do
   end
 
   @doc """
+  Get the global skills usage/curation sidecar path.
+  """
+  @spec global_usage_file() :: String.t()
+  def global_usage_file do
+    Path.join(agent_dir(), @skills_usage_filename)
+  end
+
+  @doc """
   Get the project skills configuration file path.
 
   ## Parameters
@@ -287,6 +296,14 @@ defmodule LemonSkills.Config do
   @spec project_config_file(String.t()) :: String.t()
   def project_config_file(cwd) do
     Path.join([cwd, ".lemon", @skills_config_filename])
+  end
+
+  @doc """
+  Get the project skills usage/curation sidecar path.
+  """
+  @spec project_usage_file(String.t()) :: String.t()
+  def project_usage_file(cwd) do
+    Path.join([cwd, ".lemon", @skills_usage_filename])
   end
 
   @doc """

--- a/apps/lemon_skills/lib/lemon_skills/telemetry.ex
+++ b/apps/lemon_skills/lib/lemon_skills/telemetry.ex
@@ -1,0 +1,82 @@
+defmodule LemonSkills.Telemetry do
+  @moduledoc false
+
+  alias LemonCore.Introspection
+  alias LemonCore.Telemetry
+
+  @introspection_handler_id "lemon-skills-introspection-bridge"
+  @skill_events [
+    [:lemon_skills, :skill, :load],
+    [:lemon_skills, :skill, :write]
+  ]
+  @max_reason_chars 500
+
+  def skill_load(metadata) do
+    emit([:lemon_skills, :skill, :load], metadata)
+  end
+
+  def skill_write(metadata) do
+    emit([:lemon_skills, :skill, :write], metadata)
+  end
+
+  def attach_introspection_bridge(handler_id \\ @introspection_handler_id) do
+    _ = :telemetry.detach(handler_id)
+
+    :telemetry.attach_many(
+      handler_id,
+      @skill_events,
+      &__MODULE__.handle_introspection_event/4,
+      nil
+    )
+  end
+
+  def handle_introspection_event([:lemon_skills, :skill, :load], _measurements, metadata, _config) do
+    record_introspection(:skill_load_observed, metadata)
+  end
+
+  def handle_introspection_event(
+        [:lemon_skills, :skill, :write],
+        _measurements,
+        metadata,
+        _config
+      ) do
+    record_introspection(:skill_write_observed, metadata)
+  end
+
+  defp emit(event, metadata) do
+    Telemetry.emit(event, %{count: 1, system_time: System.system_time()}, normalize(metadata))
+  end
+
+  defp normalize(metadata) do
+    metadata
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new(fn {key, value} -> {key, normalize_value(key, value)} end)
+  end
+
+  defp normalize_value(:reason, value) do
+    value
+    |> to_string()
+    |> String.slice(0, @max_reason_chars)
+  end
+
+  defp normalize_value(_key, value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_value(_key, value), do: value
+
+  defp record_introspection(event_type, metadata) do
+    record_usage(event_type, metadata)
+
+    Introspection.record(
+      event_type,
+      Map.drop(metadata, [:run_id, :session_key, :session_id, :agent_id]),
+      run_id: metadata[:run_id],
+      session_key: metadata[:session_key] || metadata[:session_id],
+      agent_id: metadata[:agent_id],
+      engine: "lemon",
+      provenance: :direct
+    )
+  end
+
+  defp record_usage(:skill_load_observed, metadata), do: LemonSkills.Usage.record_load(metadata)
+  defp record_usage(:skill_write_observed, metadata), do: LemonSkills.Usage.record_write(metadata)
+  defp record_usage(_event_type, _metadata), do: :ok
+end

--- a/apps/lemon_skills/lib/lemon_skills/tools/read_skill.ex
+++ b/apps/lemon_skills/lib/lemon_skills/tools/read_skill.ex
@@ -36,6 +36,7 @@ defmodule LemonSkills.Tools.ReadSkill do
   @spec tool(keyword()) :: AgentTool.t()
   def tool(opts \\ []) do
     cwd = Keyword.get(opts, :cwd)
+    telemetry_context = telemetry_context(opts)
 
     %AgentTool{
       name: "read_skill",
@@ -82,7 +83,7 @@ defmodule LemonSkills.Tools.ReadSkill do
         },
         "required" => ["key"]
       },
-      execute: &execute(&1, &2, &3, &4, cwd)
+      execute: &execute(&1, &2, &3, &4, cwd, telemetry_context)
     }
   end
 
@@ -104,7 +105,19 @@ defmodule LemonSkills.Tools.ReadSkill do
           on_update :: function() | nil,
           cwd :: String.t() | nil
         ) :: AgentToolResult.t() | {:error, term()}
-  def execute(_tool_call_id, params, _signal, _on_update, cwd) do
+  def execute(tool_call_id, params, _signal, _on_update, cwd) do
+    execute(tool_call_id, params, nil, nil, cwd, %{})
+  end
+
+  @spec execute(
+          tool_call_id :: String.t(),
+          params :: map(),
+          signal :: reference() | nil,
+          on_update :: function() | nil,
+          cwd :: String.t() | nil,
+          telemetry_context :: map()
+        ) :: AgentToolResult.t() | {:error, term()}
+  def execute(tool_call_id, params, _signal, _on_update, cwd, telemetry_context) do
     key = Map.get(params, "key", "")
     view = Map.get(params, "view", "full")
     section = Map.get(params, "section")
@@ -126,10 +139,14 @@ defmodule LemonSkills.Tools.ReadSkill do
 
     case Registry.get(key, opts) do
       {:ok, entry} ->
-        build_result(entry, view_opts, opts)
+        result = build_result(entry, view_opts, opts)
+        emit_skill_load(entry, view_opts, tool_call_id, cwd, telemetry_context, :ok)
+        result
 
       :error ->
-        build_not_found_result(key, opts)
+        result = build_not_found_result(key, opts)
+        emit_skill_load_miss(key, view_opts, tool_call_id, cwd, telemetry_context)
+        result
     end
   end
 
@@ -253,7 +270,11 @@ defmodule LemonSkills.Tools.ReadSkill do
     ["## Content", "", content_text]
   end
 
-  defp build_content_section(entry, %{view: "section", section: section_name, max_chars: max_chars}) do
+  defp build_content_section(entry, %{
+         view: "section",
+         section: section_name,
+         max_chars: max_chars
+       }) do
     content_text =
       case Entry.content(entry) do
         {:ok, content} ->
@@ -376,4 +397,52 @@ defmodule LemonSkills.Tools.ReadSkill do
   defp format_source(:project), do: "Project (.lemon/skill)"
   defp format_source(url) when is_binary(url), do: url
   defp format_source(other), do: inspect(other)
+
+  defp source_key(source) when is_atom(source), do: source
+  defp source_key(source) when is_binary(source), do: source
+  defp source_key(source), do: inspect(source)
+
+  defp emit_skill_load(%Entry{} = entry, view_opts, tool_call_id, cwd, telemetry_context, result) do
+    %{
+      result: result,
+      key: entry.key,
+      name: entry.name,
+      source: source_key(entry.source),
+      path: entry.path,
+      view: view_opts.view,
+      section: view_opts.section,
+      file_path: view_opts.path,
+      include_status: view_opts.include_status,
+      include_manifest: view_opts.include_manifest,
+      tool_call_id: tool_call_id,
+      cwd: cwd
+    }
+    |> Map.merge(telemetry_context)
+    |> LemonSkills.Telemetry.skill_load()
+  end
+
+  defp emit_skill_load_miss(key, view_opts, tool_call_id, cwd, telemetry_context) do
+    %{
+      result: :not_found,
+      key: key,
+      view: view_opts.view,
+      section: view_opts.section,
+      file_path: view_opts.path,
+      include_status: view_opts.include_status,
+      include_manifest: view_opts.include_manifest,
+      tool_call_id: tool_call_id,
+      cwd: cwd
+    }
+    |> Map.merge(telemetry_context)
+    |> LemonSkills.Telemetry.skill_load()
+  end
+
+  defp telemetry_context(opts) do
+    %{
+      run_id: Keyword.get(opts, :run_id),
+      session_key: Keyword.get(opts, :session_key),
+      session_id: Keyword.get(opts, :session_id),
+      agent_id: Keyword.get(opts, :agent_id)
+    }
+  end
 end

--- a/apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex
+++ b/apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex
@@ -26,6 +26,7 @@ defmodule LemonSkills.Tools.SkillManage do
   @spec tool(keyword()) :: AgentTool.t()
   def tool(opts \\ []) do
     cwd = Keyword.get(opts, :cwd)
+    telemetry_context = telemetry_context(opts)
 
     %AgentTool{
       name: "skill_manage",
@@ -41,7 +42,18 @@ defmodule LemonSkills.Tools.SkillManage do
         "properties" => %{
           "action" => %{
             "type" => "string",
-            "enum" => ["create", "edit", "patch", "delete", "write_file", "remove_file"],
+            "enum" => [
+              "create",
+              "edit",
+              "patch",
+              "delete",
+              "write_file",
+              "remove_file",
+              "pin",
+              "unpin",
+              "archive",
+              "restore"
+            ],
             "description" => "Skill operation to perform."
           },
           "name" => %{
@@ -83,7 +95,7 @@ defmodule LemonSkills.Tools.SkillManage do
         },
         "required" => ["action", "name"]
       },
-      execute: &execute(&1, &2, &3, &4, cwd)
+      execute: &execute(&1, &2, &3, &4, cwd, telemetry_context)
     }
   end
 
@@ -94,18 +106,34 @@ defmodule LemonSkills.Tools.SkillManage do
           (AgentToolResult.t() -> :ok) | nil,
           String.t() | nil
         ) :: AgentToolResult.t() | {:error, term()}
-  def execute(_tool_call_id, params, signal, _on_update, cwd) do
-    if AbortSignal.aborted?(signal) do
-      {:error, "Operation aborted"}
-    else
-      with {:ok, action} <- required_string(params, "action"),
-           {:ok, name} <- required_string(params, "name"),
-           :ok <- validate_name(name),
-           {:ok, scope} <- parse_scope(Map.get(params, "scope", "project")),
-           {:ok, root} <- skills_root(scope, cwd) do
-        dispatch(action, name, params, scope, root, cwd)
+  def execute(tool_call_id, params, signal, _on_update, cwd) do
+    execute(tool_call_id, params, signal, nil, cwd, %{})
+  end
+
+  @spec execute(
+          String.t(),
+          map(),
+          reference() | nil,
+          (AgentToolResult.t() -> :ok) | nil,
+          String.t() | nil,
+          map()
+        ) :: AgentToolResult.t() | {:error, term()}
+  def execute(tool_call_id, params, signal, _on_update, cwd, telemetry_context) do
+    result =
+      if AbortSignal.aborted?(signal) do
+        {:error, "Operation aborted"}
+      else
+        with {:ok, action} <- required_string(params, "action"),
+             {:ok, name} <- required_string(params, "name"),
+             :ok <- validate_name(name),
+             {:ok, scope} <- parse_scope(Map.get(params, "scope", "project")),
+             {:ok, root} <- skills_root(scope, cwd) do
+          dispatch(action, name, params, scope, root, cwd)
+        end
       end
-    end
+
+    emit_skill_write(result, params, tool_call_id, cwd, telemetry_context)
+    result
   end
 
   defp dispatch("create", name, params, scope, root, cwd) do
@@ -167,6 +195,7 @@ defmodule LemonSkills.Tools.SkillManage do
 
   defp dispatch("delete", name, _params, scope, root, cwd) do
     with {:ok, dir} <- existing_skill_dir(root, name),
+         :ok <- reject_pinned(name, scope, cwd, "delete"),
          {:ok, _} <- File.rm_rf(dir),
          :ok <- refresh_registry(scope, cwd) do
       ok("Skill '#{name}' deleted.", %{action: "delete", path: dir})
@@ -214,9 +243,58 @@ defmodule LemonSkills.Tools.SkillManage do
     end
   end
 
+  defp dispatch("pin", name, _params, scope, root, cwd) do
+    with {:ok, dir} <- existing_skill_dir(root, name),
+         :ok <- LemonSkills.Usage.set_state(name, :pinned, usage_opts(scope, cwd)) do
+      ok("Skill '#{name}' pinned.", %{
+        action: "pin",
+        path: dir,
+        lifecycle_state: "pinned"
+      })
+    end
+  end
+
+  defp dispatch("unpin", name, _params, scope, root, cwd) do
+    with {:ok, dir} <- existing_skill_dir(root, name),
+         :ok <- LemonSkills.Usage.set_state(name, :active, usage_opts(scope, cwd)) do
+      ok("Skill '#{name}' unpinned.", %{
+        action: "unpin",
+        path: dir,
+        lifecycle_state: "active"
+      })
+    end
+  end
+
+  defp dispatch("archive", name, _params, scope, root, cwd) do
+    with {:ok, dir} <- existing_skill_dir(root, name),
+         :ok <- reject_pinned(name, scope, cwd, "archive"),
+         :ok <- LemonSkills.Usage.set_state(name, :archived, usage_opts(scope, cwd)),
+         :ok <- LemonSkills.Config.disable(name, global: scope == :global, cwd: cwd),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("Skill '#{name}' archived.", %{
+        action: "archive",
+        path: dir,
+        lifecycle_state: "archived"
+      })
+    end
+  end
+
+  defp dispatch("restore", name, _params, scope, root, cwd) do
+    with {:ok, dir} <- existing_skill_dir(root, name),
+         :ok <- LemonSkills.Usage.set_state(name, :active, usage_opts(scope, cwd)),
+         :ok <- LemonSkills.Config.enable(name, global: scope == :global, cwd: cwd),
+         :ok <- refresh_registry(scope, cwd) do
+      ok("Skill '#{name}' restored.", %{
+        action: "restore",
+        path: dir,
+        lifecycle_state: "active"
+      })
+    end
+  end
+
   defp dispatch(action, _name, _params, _scope, _root, _cwd) do
     {:error,
-     "Unknown action '#{action}'. Use create, edit, patch, delete, write_file, or remove_file."}
+     "Unknown action '#{action}'. Use create, edit, patch, delete, write_file, remove_file, pin, unpin, archive, or restore."}
   end
 
   defp required_string(params, key, opts \\ []) do
@@ -411,6 +489,17 @@ defmodule LemonSkills.Tools.SkillManage do
   defp audit_scope(:global, _cwd), do: :global
   defp audit_scope(:project, cwd), do: {:project, cwd}
 
+  defp usage_opts(:global, _cwd), do: [scope: :global]
+  defp usage_opts(:project, cwd), do: [scope: :project, cwd: cwd]
+
+  defp reject_pinned(name, scope, cwd, action) do
+    if LemonSkills.Usage.pinned?(name, usage_opts(scope, cwd)) do
+      {:error, "Skill '#{name}' is pinned; unpin it before #{action}."}
+    else
+      :ok
+    end
+  end
+
   defp summarize_audit(audit) do
     %{
       status: Atom.to_string(BundleAudit.audit_status(audit)),
@@ -526,6 +615,56 @@ defmodule LemonSkills.Tools.SkillManage do
     %AgentToolResult{
       content: [%TextContent{text: message}],
       details: details
+    }
+  end
+
+  defp emit_skill_write(
+         %AgentToolResult{details: details},
+         params,
+         tool_call_id,
+         cwd,
+         telemetry_context
+       ) do
+    %{
+      result: :ok,
+      action: details[:action] || Map.get(params, "action"),
+      name: Map.get(params, "name"),
+      scope: Map.get(params, "scope", "project"),
+      path: details[:path],
+      file_path: details[:file_path],
+      audit_status: get_in(details, [:audit, :status]),
+      lifecycle_state: details[:lifecycle_state],
+      replacements: details[:replacements],
+      tool_call_id: tool_call_id,
+      cwd: cwd
+    }
+    |> Map.merge(telemetry_context)
+    |> LemonSkills.Telemetry.skill_write()
+  end
+
+  defp emit_skill_write({:error, reason}, params, tool_call_id, cwd, telemetry_context) do
+    %{
+      result: :error,
+      action: Map.get(params, "action"),
+      name: Map.get(params, "name"),
+      scope: Map.get(params, "scope", "project"),
+      file_path: Map.get(params, "file_path"),
+      reason: reason,
+      tool_call_id: tool_call_id,
+      cwd: cwd
+    }
+    |> Map.merge(telemetry_context)
+    |> LemonSkills.Telemetry.skill_write()
+  end
+
+  defp emit_skill_write(_result, _params, _tool_call_id, _cwd, _telemetry_context), do: :ok
+
+  defp telemetry_context(opts) do
+    %{
+      run_id: Keyword.get(opts, :run_id),
+      session_key: Keyword.get(opts, :session_key),
+      session_id: Keyword.get(opts, :session_id),
+      agent_id: Keyword.get(opts, :agent_id)
     }
   end
 end

--- a/apps/lemon_skills/lib/lemon_skills/usage.ex
+++ b/apps/lemon_skills/lib/lemon_skills/usage.ex
@@ -1,0 +1,220 @@
+defmodule LemonSkills.Usage do
+  @moduledoc """
+  Persistent skill usage and curation metadata.
+
+  Usage data is stored outside `SKILL.md` so agent-authored telemetry and
+  curation state do not churn the skill instructions themselves.
+  """
+
+  alias LemonSkills.Config
+
+  @states ~w(active stale archived pinned)
+
+  @type scope :: :global | :project
+
+  @doc """
+  Return the usage metadata for a skill.
+  """
+  @spec get(String.t(), keyword()) :: map()
+  def get(key, opts \\ []) when is_binary(key) do
+    opts
+    |> usage_file()
+    |> read_usage()
+    |> get_in(["skills", key])
+    |> normalize_record()
+  end
+
+  @doc """
+  Record a successful `read_skill` load.
+  """
+  @spec record_load(map()) :: :ok | {:error, term()}
+  def record_load(metadata) when is_map(metadata) do
+    key = Map.get(metadata, :key)
+
+    if present?(key) do
+      update_skill(key, usage_opts(metadata), fn record ->
+        now = now_iso8601()
+
+        record
+        |> ensure_state()
+        |> increment("load_count")
+        |> Map.put("last_loaded_at", now)
+        |> maybe_put("last_view", Map.get(metadata, :view))
+        |> maybe_put("last_tool_call_id", Map.get(metadata, :tool_call_id))
+        |> maybe_put("last_session_key", Map.get(metadata, :session_key))
+        |> maybe_put("last_run_id", Map.get(metadata, :run_id))
+        |> maybe_put("source", Map.get(metadata, :source))
+        |> maybe_put("path", Map.get(metadata, :path))
+      end)
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Record a `skill_manage` write attempt.
+  """
+  @spec record_write(map()) :: :ok | {:error, term()}
+  def record_write(metadata) when is_map(metadata) do
+    key = Map.get(metadata, :name)
+
+    if present?(key) do
+      update_skill(key, usage_opts(metadata), fn record ->
+        now = now_iso8601()
+        action = Map.get(metadata, :action)
+
+        record
+        |> ensure_state()
+        |> maybe_increment_write(Map.get(metadata, :result))
+        |> maybe_increment_error(Map.get(metadata, :result))
+        |> Map.put("last_write_at", now)
+        |> maybe_put_created(action, metadata, now)
+        |> maybe_put("last_action", action)
+        |> maybe_put("last_writer_agent_id", Map.get(metadata, :agent_id))
+        |> maybe_put("last_session_key", Map.get(metadata, :session_key))
+        |> maybe_put("last_run_id", Map.get(metadata, :run_id))
+        |> maybe_put("last_tool_call_id", Map.get(metadata, :tool_call_id))
+        |> maybe_put("path", Map.get(metadata, :path))
+        |> maybe_put("file_path", Map.get(metadata, :file_path))
+      end)
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Set a lifecycle state for a skill.
+  """
+  @spec set_state(String.t(), String.t() | atom(), keyword()) :: :ok | {:error, term()}
+  def set_state(key, state, opts \\ []) when is_binary(key) do
+    state = state |> to_string()
+
+    if state in @states do
+      update_skill(key, opts, fn record ->
+        now = now_iso8601()
+
+        record
+        |> ensure_state()
+        |> Map.put("lifecycle_state", state)
+        |> Map.put("state_updated_at", now)
+        |> maybe_put("state_updated_by_agent_id", Keyword.get(opts, :agent_id))
+      end)
+    else
+      {:error, "invalid lifecycle state: #{state}"}
+    end
+  end
+
+  @doc """
+  Return true when the skill is pinned in usage metadata.
+  """
+  @spec pinned?(String.t(), keyword()) :: boolean()
+  def pinned?(key, opts \\ []) when is_binary(key) do
+    get(key, opts)["lifecycle_state"] == "pinned"
+  end
+
+  @doc """
+  Return true when the skill is archived in usage metadata.
+  """
+  @spec archived?(String.t(), keyword()) :: boolean()
+  def archived?(key, opts \\ []) when is_binary(key) do
+    get(key, opts)["lifecycle_state"] == "archived"
+  end
+
+  @doc """
+  Return the sidecar path used for the given options.
+  """
+  @spec usage_file(keyword() | map()) :: String.t()
+  def usage_file(opts) when is_map(opts), do: usage_file(Map.to_list(opts))
+
+  def usage_file(opts) when is_list(opts) do
+    case Keyword.get(opts, :scope, :global) do
+      :project -> Config.project_usage_file(Keyword.fetch!(opts, :cwd))
+      "project" -> Config.project_usage_file(Keyword.fetch!(opts, :cwd))
+      _ -> Config.global_usage_file()
+    end
+  end
+
+  defp update_skill(key, opts, fun) do
+    path = usage_file(opts)
+    usage = read_usage(path)
+    skills = Map.get(usage, "skills", %{})
+    record = skills |> Map.get(key, %{}) |> normalize_record() |> fun.()
+    updated = Map.put(usage, "skills", Map.put(skills, key, record))
+    write_usage(path, updated)
+  end
+
+  defp usage_opts(metadata) do
+    [
+      scope: normalize_scope(Map.get(metadata, :scope) || Map.get(metadata, :source)),
+      cwd: Map.get(metadata, :cwd)
+    ]
+  end
+
+  defp normalize_scope("project"), do: :project
+  defp normalize_scope(:project), do: :project
+  defp normalize_scope(_), do: :global
+
+  defp read_usage(path) do
+    case File.read(path) do
+      {:ok, content} ->
+        case Jason.decode(content) do
+          {:ok, %{} = data} -> data
+          _ -> empty_usage()
+        end
+
+      _ ->
+        empty_usage()
+    end
+  end
+
+  defp write_usage(path, data) do
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         {:ok, content} <- Jason.encode(data, pretty: true) do
+      File.write(path, content)
+    end
+  end
+
+  defp empty_usage, do: %{"version" => 1, "skills" => %{}}
+  defp normalize_record(nil), do: ensure_state(%{})
+  defp normalize_record(record) when is_map(record), do: ensure_state(record)
+  defp normalize_record(_), do: ensure_state(%{})
+
+  defp ensure_state(record) do
+    Map.put_new(record, "lifecycle_state", "active")
+  end
+
+  defp increment(record, key) do
+    Map.update(record, key, 1, fn
+      value when is_integer(value) -> value + 1
+      _ -> 1
+    end)
+  end
+
+  defp maybe_increment_write(record, "ok"), do: increment(record, "write_count")
+  defp maybe_increment_write(record, :ok), do: increment(record, "write_count")
+  defp maybe_increment_write(record, _), do: record
+
+  defp maybe_increment_error(record, "error"), do: increment(record, "write_error_count")
+  defp maybe_increment_error(record, :error), do: increment(record, "write_error_count")
+  defp maybe_increment_error(record, _), do: record
+
+  defp maybe_put_created(record, action, metadata, now) when action in ["create", :create] do
+    record
+    |> Map.put_new("created_at", now)
+    |> Map.put_new("created_by", "agent")
+    |> maybe_put_new("created_by_agent_id", Map.get(metadata, :agent_id))
+  end
+
+  defp maybe_put_created(record, _action, _metadata, _now), do: record
+
+  defp maybe_put(record, _key, nil), do: record
+  defp maybe_put(record, _key, ""), do: record
+  defp maybe_put(record, key, value), do: Map.put(record, key, value)
+
+  defp maybe_put_new(record, _key, nil), do: record
+  defp maybe_put_new(record, _key, ""), do: record
+  defp maybe_put_new(record, key, value), do: Map.put_new(record, key, value)
+
+  defp present?(value), do: is_binary(value) and String.trim(value) != ""
+  defp now_iso8601, do: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+end

--- a/apps/lemon_skills/lib/lemon_skills/usage.ex
+++ b/apps/lemon_skills/lib/lemon_skills/usage.ex
@@ -9,6 +9,8 @@ defmodule LemonSkills.Usage do
   alias LemonSkills.Config
 
   @states ~w(active stale archived pinned)
+  @lock_retries 50
+  @lock_sleep_ms 10
 
   @type scope :: :global | :project
 
@@ -17,11 +19,16 @@ defmodule LemonSkills.Usage do
   """
   @spec get(String.t(), keyword()) :: map()
   def get(key, opts \\ []) when is_binary(key) do
-    opts
-    |> usage_file()
-    |> read_usage()
-    |> get_in(["skills", key])
-    |> normalize_record()
+    case resolve_usage_file(opts) do
+      {:ok, path} ->
+        path
+        |> read_usage()
+        |> get_in(["skills", key])
+        |> normalize_record()
+
+      :skip ->
+        normalize_record(nil)
+    end
   end
 
   @doc """
@@ -31,7 +38,7 @@ defmodule LemonSkills.Usage do
   def record_load(metadata) when is_map(metadata) do
     key = Map.get(metadata, :key)
 
-    if present?(key) do
+    if present?(key) and ok_result?(Map.get(metadata, :result)) do
       update_skill(key, usage_opts(metadata), fn record ->
         now = now_iso8601()
 
@@ -123,24 +130,45 @@ defmodule LemonSkills.Usage do
   @doc """
   Return the sidecar path used for the given options.
   """
-  @spec usage_file(keyword() | map()) :: String.t()
+  @spec usage_file(keyword() | map()) :: String.t() | nil
   def usage_file(opts) when is_map(opts), do: usage_file(Map.to_list(opts))
 
   def usage_file(opts) when is_list(opts) do
+    case resolve_usage_file(opts) do
+      {:ok, path} -> path
+      :skip -> nil
+    end
+  end
+
+  defp resolve_usage_file(opts) when is_map(opts), do: resolve_usage_file(Map.to_list(opts))
+
+  defp resolve_usage_file(opts) when is_list(opts) do
     case Keyword.get(opts, :scope, :global) do
-      :project -> Config.project_usage_file(Keyword.fetch!(opts, :cwd))
-      "project" -> Config.project_usage_file(Keyword.fetch!(opts, :cwd))
-      _ -> Config.global_usage_file()
+      scope when scope in [:project, "project"] ->
+        case Keyword.get(opts, :cwd) do
+          cwd when is_binary(cwd) and cwd != "" -> {:ok, Config.project_usage_file(cwd)}
+          _ -> :skip
+        end
+
+      _ ->
+        {:ok, Config.global_usage_file()}
     end
   end
 
   defp update_skill(key, opts, fun) do
-    path = usage_file(opts)
-    usage = read_usage(path)
-    skills = Map.get(usage, "skills", %{})
-    record = skills |> Map.get(key, %{}) |> normalize_record() |> fun.()
-    updated = Map.put(usage, "skills", Map.put(skills, key, record))
-    write_usage(path, updated)
+    case resolve_usage_file(opts) do
+      {:ok, path} ->
+        with_file_lock(path, fn ->
+          usage = read_usage(path)
+          skills = Map.get(usage, "skills", %{})
+          record = skills |> Map.get(key, %{}) |> normalize_record() |> fun.()
+          updated = Map.put(usage, "skills", Map.put(skills, key, record))
+          write_usage(path, updated)
+        end)
+
+      :skip ->
+        :ok
+    end
   end
 
   defp usage_opts(metadata) do
@@ -169,8 +197,61 @@ defmodule LemonSkills.Usage do
 
   defp write_usage(path, data) do
     with :ok <- File.mkdir_p(Path.dirname(path)),
-         {:ok, content} <- Jason.encode(data, pretty: true) do
-      File.write(path, content)
+         {:ok, content} <- Jason.encode(data, pretty: true),
+         :ok <- atomic_write(path, content) do
+      :ok
+    end
+  end
+
+  defp with_file_lock(path, fun) do
+    lock_path = path <> ".lock"
+
+    with :ok <- File.mkdir_p(Path.dirname(lock_path)) do
+      acquire_lock(to_charlist(lock_path), fun, @lock_retries)
+    end
+  end
+
+  defp acquire_lock(_lock_path, _fun, 0), do: {:error, :lock_timeout}
+
+  defp acquire_lock(lock_path, fun, retries) do
+    case :file.open(lock_path, [:write, :exclusive]) do
+      {:ok, fd} ->
+        try do
+          fun.()
+        after
+          :file.close(fd)
+          :file.delete(lock_path)
+        end
+
+      {:error, :eexist} ->
+        Process.sleep(@lock_sleep_ms)
+        acquire_lock(lock_path, fun, retries - 1)
+
+      {:error, reason} ->
+        {:error, {:lock_failed, reason}}
+    end
+  end
+
+  defp atomic_write(path, content) do
+    tmp =
+      Path.join(
+        Path.dirname(path),
+        ".#{Path.basename(path)}.tmp.#{System.unique_integer([:positive])}"
+      )
+
+    result =
+      with :ok <- File.write(tmp, content),
+           :ok <- File.rename(tmp, path) do
+        :ok
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        File.rm(tmp)
+        {:error, reason}
     end
   end
 
@@ -198,14 +279,27 @@ defmodule LemonSkills.Usage do
   defp maybe_increment_error(record, :error), do: increment(record, "write_error_count")
   defp maybe_increment_error(record, _), do: record
 
+  defp maybe_put_created(record, action, %{result: result} = metadata, now)
+       when action in ["create", :create] do
+    if ok_result?(result) do
+      put_created(record, metadata, now)
+    else
+      record
+    end
+  end
+
   defp maybe_put_created(record, action, metadata, now) when action in ["create", :create] do
+    put_created(record, metadata, now)
+  end
+
+  defp maybe_put_created(record, _action, _metadata, _now), do: record
+
+  defp put_created(record, metadata, now) do
     record
     |> Map.put_new("created_at", now)
     |> Map.put_new("created_by", "agent")
     |> maybe_put_new("created_by_agent_id", Map.get(metadata, :agent_id))
   end
-
-  defp maybe_put_created(record, _action, _metadata, _now), do: record
 
   defp maybe_put(record, _key, nil), do: record
   defp maybe_put(record, _key, ""), do: record
@@ -216,5 +310,6 @@ defmodule LemonSkills.Usage do
   defp maybe_put_new(record, key, value), do: Map.put_new(record, key, value)
 
   defp present?(value), do: is_binary(value) and String.trim(value) != ""
+  defp ok_result?(value), do: value in [:ok, "ok"]
   defp now_iso8601, do: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
 end

--- a/apps/lemon_skills/test/lemon_skills/tools/read_skill_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/tools/read_skill_test.exs
@@ -3,6 +3,7 @@ defmodule LemonSkills.Tools.ReadSkillTest do
 
   alias AgentCore.Types.AgentToolResult
   alias Ai.Types.TextContent
+  alias LemonCore.{Introspection, Store}
   alias LemonSkills.Tools.ReadSkill
 
   @moduletag :tmp_dir
@@ -30,7 +31,159 @@ defmodule LemonSkills.Tools.ReadSkillTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
+  def handle_telemetry(event_name, measurements, metadata, pid) do
+    send(pid, {:telemetry_event, event_name, measurements, metadata})
+  end
+
+  defp attach_handler(event_names) do
+    handler_id = "read-skill-telemetry-#{System.unique_integer([:positive, :monotonic])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        event_names,
+        &__MODULE__.handle_telemetry/4,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
   describe "execute/5 — backwards compatible (default full view)" do
+    test "emits skill load telemetry when a skill is found", %{tmp_dir: tmp_dir} do
+      path =
+        write_skill!(
+          tmp_dir,
+          "telemetry-skill",
+          """
+          ---
+          name: Telemetry Skill
+          description: Emits skill load telemetry
+          ---
+
+          body
+          """
+        )
+
+      LemonSkills.refresh(cwd: tmp_dir)
+      attach_handler([[:lemon_skills, :skill, :load]])
+
+      tool =
+        ReadSkill.tool(
+          cwd: tmp_dir,
+          run_id: "run-skill-load",
+          session_key: "session-telemetry",
+          session_id: "session-telemetry",
+          agent_id: "agent-telemetry"
+        )
+
+      assert %AgentToolResult{} =
+               tool.execute.(
+                 "call-telemetry",
+                 %{"key" => "telemetry-skill", "view" => "summary"},
+                 nil,
+                 nil
+               )
+
+      assert_receive {:telemetry_event, [:lemon_skills, :skill, :load],
+                      %{count: 1, system_time: system_time},
+                      %{
+                        result: "ok",
+                        key: "telemetry-skill",
+                        name: "Telemetry Skill",
+                        source: "project",
+                        path: ^path,
+                        view: "summary",
+                        tool_call_id: "call-telemetry",
+                        run_id: "run-skill-load",
+                        session_key: "session-telemetry",
+                        session_id: "session-telemetry",
+                        agent_id: "agent-telemetry",
+                        cwd: ^tmp_dir
+                      }}
+
+      assert is_integer(system_time)
+    end
+
+    test "projects skill load telemetry into introspection", %{tmp_dir: tmp_dir} do
+      enable_introspection()
+
+      write_skill!(
+        tmp_dir,
+        "introspection-skill",
+        """
+        ---
+        name: Introspection Skill
+        description: Persists skill load telemetry
+        ---
+
+        body
+        """
+      )
+
+      LemonSkills.refresh(cwd: tmp_dir)
+
+      run_id = "run_skill_load_#{System.unique_integer([:positive, :monotonic])}"
+      session_key = "session_skill_load_#{System.unique_integer([:positive, :monotonic])}"
+
+      tool =
+        ReadSkill.tool(
+          cwd: tmp_dir,
+          run_id: run_id,
+          session_key: session_key,
+          agent_id: "agent-load"
+        )
+
+      assert %AgentToolResult{} =
+               tool.execute.(
+                 "call-introspection",
+                 %{"key" => "introspection-skill", "view" => "summary"},
+                 nil,
+                 nil
+               )
+
+      event =
+        eventually(fn ->
+          Introspection.list(run_id: run_id, event_type: :skill_load_observed, limit: 10)
+          |> Enum.find(&(&1.payload[:key] == "introspection-skill"))
+        end)
+
+      assert event.session_key == session_key
+      assert event.agent_id == "agent-load"
+      assert event.engine == "lemon"
+      assert event.payload.result == "ok"
+      assert event.payload.tool_call_id == "call-introspection"
+      refute Map.has_key?(event.payload, :session_key)
+
+      usage = LemonSkills.usage("introspection-skill", scope: :project, cwd: tmp_dir)
+      assert usage["load_count"] == 1
+      assert usage["last_session_key"] == session_key
+    end
+
+    test "emits skill load telemetry when a skill is missing", %{tmp_dir: tmp_dir} do
+      LemonSkills.refresh(cwd: tmp_dir)
+      attach_handler([[:lemon_skills, :skill, :load]])
+
+      assert %AgentToolResult{} =
+               ReadSkill.execute(
+                 "call-missing-telemetry",
+                 %{"key" => "missing-skill", "view" => "summary"},
+                 nil,
+                 nil,
+                 tmp_dir
+               )
+
+      assert_receive {:telemetry_event, [:lemon_skills, :skill, :load], %{count: 1},
+                      %{
+                        result: "not_found",
+                        key: "missing-skill",
+                        view: "summary",
+                        tool_call_id: "call-missing-telemetry",
+                        cwd: ^tmp_dir
+                      }}
+    end
+
     test "returns helpful suggestions when the skill is not found", %{tmp_dir: tmp_dir} do
       write_skill!(
         tmp_dir,
@@ -186,7 +339,11 @@ defmodule LemonSkills.Tools.ReadSkillTest do
       assert %AgentToolResult{content: [%TextContent{text: text}]} =
                ReadSkill.execute(
                  "call-s2",
-                 %{"key" => "summary-status-skill", "view" => "summary", "include_status" => true},
+                 %{
+                   "key" => "summary-status-skill",
+                   "view" => "summary",
+                   "include_status" => true
+                 },
                  nil,
                  nil,
                  tmp_dir
@@ -487,4 +644,30 @@ defmodule LemonSkills.Tools.ReadSkillTest do
 
   defp restore_env(key, nil), do: System.delete_env(key)
   defp restore_env(key, value), do: System.put_env(key, value)
+
+  defp enable_introspection do
+    case Store.start_link([]) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    previous = Application.get_env(:lemon_core, :introspection, [])
+    Application.put_env(:lemon_core, :introspection, Keyword.put(previous, :enabled, true))
+    on_exit(fn -> Application.put_env(:lemon_core, :introspection, previous) end)
+  end
+
+  defp eventually(fun, attempts \\ 20)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    case fun.() do
+      nil ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+
+  defp eventually(fun, 0), do: flunk("expected condition to become true, got: #{inspect(fun.())}")
 end

--- a/apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs
@@ -1,6 +1,7 @@
 defmodule LemonSkills.Tools.SkillManageTest do
   use ExUnit.Case, async: false
 
+  alias LemonCore.{Introspection, Store}
   alias LemonSkills.Tools.SkillManage
 
   @moduletag :tmp_dir
@@ -8,6 +9,25 @@ defmodule LemonSkills.Tools.SkillManageTest do
   defp execute(tmp_dir, params) do
     tool = SkillManage.tool(cwd: tmp_dir)
     tool.execute.("call-1", params, nil, nil)
+  end
+
+  def handle_telemetry(event_name, measurements, metadata, pid) do
+    send(pid, {:telemetry_event, event_name, measurements, metadata})
+  end
+
+  defp attach_handler(event_names) do
+    handler_id = "skill-manage-telemetry-#{System.unique_integer([:positive, :monotonic])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        event_names,
+        &__MODULE__.handle_telemetry/4,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
   end
 
   defp valid_skill(name \\ "Learned Workflow") do
@@ -24,6 +44,126 @@ defmodule LemonSkills.Tools.SkillManageTest do
   end
 
   describe "create" do
+    test "emits skill write telemetry for successful writes", %{tmp_dir: tmp_dir} do
+      enable_introspection()
+      attach_handler([[:lemon_skills, :skill, :write]])
+      run_id = "run_skill_write_#{System.unique_integer([:positive, :monotonic])}"
+
+      tool =
+        SkillManage.tool(
+          cwd: tmp_dir,
+          run_id: run_id,
+          session_key: "session-write",
+          session_id: "session-write",
+          agent_id: "agent-write"
+        )
+
+      result =
+        tool.execute.(
+          "call-write-telemetry",
+          %{
+            "action" => "create",
+            "name" => "telemetry-write",
+            "content" => valid_skill("Telemetry Write")
+          },
+          nil,
+          nil
+        )
+
+      assert result.details.action == "create"
+
+      path = result.details.path
+
+      assert_receive {:telemetry_event, [:lemon_skills, :skill, :write],
+                      %{count: 1, system_time: system_time},
+                      %{
+                        result: "ok",
+                        action: "create",
+                        name: "telemetry-write",
+                        scope: "project",
+                        path: ^path,
+                        audit_status: "pass",
+                        tool_call_id: "call-write-telemetry",
+                        run_id: ^run_id,
+                        session_key: "session-write",
+                        session_id: "session-write",
+                        agent_id: "agent-write",
+                        cwd: ^tmp_dir
+                      }}
+
+      assert is_integer(system_time)
+
+      event =
+        eventually(fn ->
+          Introspection.list(run_id: run_id, event_type: :skill_write_observed, limit: 10)
+          |> Enum.find(&(&1.payload[:name] == "telemetry-write"))
+        end)
+
+      assert event.session_key == "session-write"
+      assert event.agent_id == "agent-write"
+      assert event.payload.result == "ok"
+      assert event.payload.action == "create"
+      refute Map.has_key?(event.payload, :session_key)
+
+      usage = LemonSkills.usage("telemetry-write", scope: :project, cwd: tmp_dir)
+      assert usage["write_count"] == 1
+      assert usage["created_by_agent_id"] == "agent-write"
+    end
+
+    test "emits skill write telemetry for direct tool calls", %{tmp_dir: tmp_dir} do
+      attach_handler([[:lemon_skills, :skill, :write]])
+
+      result =
+        execute(tmp_dir, %{
+          "action" => "create",
+          "name" => "direct-telemetry-write",
+          "content" => valid_skill("Direct Telemetry Write")
+        })
+
+      path = result.details.path
+
+      assert_receive {:telemetry_event, [:lemon_skills, :skill, :write],
+                      %{count: 1, system_time: system_time},
+                      %{
+                        result: "ok",
+                        action: "create",
+                        name: "direct-telemetry-write",
+                        scope: "project",
+                        path: ^path,
+                        audit_status: "pass",
+                        tool_call_id: "call-1",
+                        cwd: ^tmp_dir
+                      }}
+
+      assert is_integer(system_time)
+    end
+
+    test "emits skill write telemetry for rejected writes", %{tmp_dir: tmp_dir} do
+      attach_handler([[:lemon_skills, :skill, :write]])
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "create",
+                 "name" => "bad-skill",
+                 "content" => "# Missing frontmatter"
+               })
+
+      assert message =~ "frontmatter"
+
+      assert_receive {:telemetry_event, [:lemon_skills, :skill, :write], %{count: 1},
+                      %{
+                        result: "error",
+                        action: "create",
+                        name: "bad-skill",
+                        scope: "project",
+                        reason: reason,
+                        tool_call_id: "call-1",
+                        cwd: ^tmp_dir
+                      }}
+
+      assert reason =~ "frontmatter"
+    end
+
     test "creates a project skill and refreshes the registry", %{tmp_dir: tmp_dir} do
       result =
         execute(tmp_dir, %{
@@ -39,6 +179,56 @@ defmodule LemonSkills.Tools.SkillManageTest do
       assert File.regular?(Path.join(skill_dir, "SKILL.md"))
       assert {:ok, entry} = LemonSkills.Registry.get("learned-workflow", cwd: tmp_dir)
       assert entry.name == "Learned Workflow"
+    end
+
+    test "pins, protects, archives, and restores a skill", %{tmp_dir: tmp_dir} do
+      execute(tmp_dir, %{
+        "action" => "create",
+        "name" => "curated-skill",
+        "content" => valid_skill("Curated Skill")
+      })
+
+      pin_result =
+        execute(tmp_dir, %{
+          "action" => "pin",
+          "name" => "curated-skill"
+        })
+
+      assert pin_result.details.lifecycle_state == "pinned"
+      assert LemonSkills.Usage.pinned?("curated-skill", scope: :project, cwd: tmp_dir)
+
+      assert {:error, message} =
+               execute(tmp_dir, %{
+                 "action" => "archive",
+                 "name" => "curated-skill"
+               })
+
+      assert message =~ "is pinned"
+
+      execute(tmp_dir, %{
+        "action" => "unpin",
+        "name" => "curated-skill"
+      })
+
+      archive_result =
+        execute(tmp_dir, %{
+          "action" => "archive",
+          "name" => "curated-skill"
+        })
+
+      assert archive_result.details.lifecycle_state == "archived"
+      assert LemonSkills.Usage.archived?("curated-skill", scope: :project, cwd: tmp_dir)
+      assert LemonSkills.Config.skill_disabled?("curated-skill", tmp_dir)
+
+      restore_result =
+        execute(tmp_dir, %{
+          "action" => "restore",
+          "name" => "curated-skill"
+        })
+
+      assert restore_result.details.lifecycle_state == "active"
+      refute LemonSkills.Config.skill_disabled?("curated-skill", tmp_dir)
+      assert {:ok, _entry} = LemonSkills.Registry.get("curated-skill", cwd: tmp_dir)
     end
 
     test "rejects invalid frontmatter before writing", %{tmp_dir: tmp_dir} do
@@ -257,4 +447,30 @@ defmodule LemonSkills.Tools.SkillManageTest do
       assert File.exists?(outside_file)
     end
   end
+
+  defp enable_introspection do
+    case Store.start_link([]) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    previous = Application.get_env(:lemon_core, :introspection, [])
+    Application.put_env(:lemon_core, :introspection, Keyword.put(previous, :enabled, true))
+    on_exit(fn -> Application.put_env(:lemon_core, :introspection, previous) end)
+  end
+
+  defp eventually(fun, attempts \\ 20)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    case fun.() do
+      nil ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+
+  defp eventually(fun, 0), do: flunk("expected condition to become true, got: #{inspect(fun.())}")
 end

--- a/apps/lemon_skills/test/lemon_skills/usage_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/usage_test.exs
@@ -28,6 +28,7 @@ defmodule LemonSkills.UsageTest do
   test "records project skill loads in the project sidecar", %{tmp_dir: tmp_dir} do
     assert :ok =
              Usage.record_load(%{
+               result: "ok",
                key: "project-skill",
                source: "project",
                cwd: tmp_dir,
@@ -40,6 +41,7 @@ defmodule LemonSkills.UsageTest do
 
     assert :ok =
              Usage.record_load(%{
+               result: "ok",
                key: "project-skill",
                source: "project",
                cwd: tmp_dir,
@@ -53,6 +55,27 @@ defmodule LemonSkills.UsageTest do
     assert usage["last_view"] == "full"
     assert usage["last_run_id"] == "run-1"
     assert File.regular?(Path.join([tmp_dir, ".lemon", "skills.usage.json"]))
+  end
+
+  test "ignores missing skill loads and project updates without cwd", %{tmp_dir: tmp_dir} do
+    assert :ok =
+             Usage.record_load(%{
+               result: "not_found",
+               key: "missing-skill",
+               source: "project",
+               cwd: tmp_dir
+             })
+
+    assert Usage.get("missing-skill", scope: :project, cwd: tmp_dir)["load_count"] == nil
+
+    assert :ok =
+             Usage.record_load(%{
+               result: "ok",
+               key: "missing-cwd",
+               source: "project"
+             })
+
+    assert Usage.get("missing-cwd", scope: :project)["load_count"] == nil
   end
 
   test "records agent-authored write provenance", %{tmp_dir: tmp_dir} do
@@ -75,6 +98,45 @@ defmodule LemonSkills.UsageTest do
     assert usage["created_by_agent_id"] == "agent-1"
     assert usage["last_writer_agent_id"] == "agent-1"
     assert usage["last_action"] == "create"
+  end
+
+  test "does not mark rejected creates as agent-authored skills", %{tmp_dir: tmp_dir} do
+    assert :ok =
+             Usage.record_write(%{
+               result: "error",
+               action: "create",
+               name: "rejected-skill",
+               scope: "project",
+               cwd: tmp_dir,
+               agent_id: "agent-1"
+             })
+
+    usage = Usage.get("rejected-skill", scope: :project, cwd: tmp_dir)
+
+    assert usage["write_error_count"] == 1
+    refute Map.has_key?(usage, "created_by")
+    refute Map.has_key?(usage, "created_by_agent_id")
+  end
+
+  test "serializes concurrent usage updates", %{tmp_dir: tmp_dir} do
+    tasks =
+      for idx <- 1..20 do
+        Task.async(fn ->
+          Usage.record_load(%{
+            result: "ok",
+            key: "concurrent-skill",
+            source: "project",
+            cwd: tmp_dir,
+            tool_call_id: "call-#{idx}"
+          })
+        end)
+      end
+
+    assert Enum.all?(tasks, &(Task.await(&1, 1_000) == :ok))
+
+    usage = Usage.get("concurrent-skill", scope: :project, cwd: tmp_dir)
+
+    assert usage["load_count"] == 20
   end
 
   test "sets and queries lifecycle states", %{tmp_dir: tmp_dir} do

--- a/apps/lemon_skills/test/lemon_skills/usage_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/usage_test.exs
@@ -1,0 +1,91 @@
+defmodule LemonSkills.UsageTest do
+  use ExUnit.Case, async: false
+
+  alias LemonSkills.Usage
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    previous_home = System.get_env("HOME")
+    previous_agent_dir = System.get_env("LEMON_AGENT_DIR")
+
+    home = Path.join(tmp_dir, "home")
+    agent_dir = Path.join(tmp_dir, "agent")
+    File.mkdir_p!(home)
+    File.mkdir_p!(agent_dir)
+
+    System.put_env("HOME", home)
+    System.put_env("LEMON_AGENT_DIR", agent_dir)
+
+    on_exit(fn ->
+      restore_env("HOME", previous_home)
+      restore_env("LEMON_AGENT_DIR", previous_agent_dir)
+    end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  test "records project skill loads in the project sidecar", %{tmp_dir: tmp_dir} do
+    assert :ok =
+             Usage.record_load(%{
+               key: "project-skill",
+               source: "project",
+               cwd: tmp_dir,
+               view: "summary",
+               tool_call_id: "call-load",
+               session_key: "session-1",
+               run_id: "run-1",
+               path: Path.join([tmp_dir, ".lemon", "skill", "project-skill"])
+             })
+
+    assert :ok =
+             Usage.record_load(%{
+               key: "project-skill",
+               source: "project",
+               cwd: tmp_dir,
+               view: "full"
+             })
+
+    usage = Usage.get("project-skill", scope: :project, cwd: tmp_dir)
+
+    assert usage["lifecycle_state"] == "active"
+    assert usage["load_count"] == 2
+    assert usage["last_view"] == "full"
+    assert usage["last_run_id"] == "run-1"
+    assert File.regular?(Path.join([tmp_dir, ".lemon", "skills.usage.json"]))
+  end
+
+  test "records agent-authored write provenance", %{tmp_dir: tmp_dir} do
+    assert :ok =
+             Usage.record_write(%{
+               result: "ok",
+               action: "create",
+               name: "learned-skill",
+               scope: "project",
+               cwd: tmp_dir,
+               agent_id: "agent-1",
+               session_key: "session-1",
+               tool_call_id: "call-write"
+             })
+
+    usage = Usage.get("learned-skill", scope: :project, cwd: tmp_dir)
+
+    assert usage["write_count"] == 1
+    assert usage["created_by"] == "agent"
+    assert usage["created_by_agent_id"] == "agent-1"
+    assert usage["last_writer_agent_id"] == "agent-1"
+    assert usage["last_action"] == "create"
+  end
+
+  test "sets and queries lifecycle states", %{tmp_dir: tmp_dir} do
+    assert :ok = Usage.set_state("pin-me", :pinned, scope: :project, cwd: tmp_dir)
+    assert Usage.pinned?("pin-me", scope: :project, cwd: tmp_dir)
+
+    assert :ok = Usage.set_state("pin-me", :archived, scope: :project, cwd: tmp_dir)
+    assert Usage.archived?("pin-me", scope: :project, cwd: tmp_dir)
+    refute Usage.pinned?("pin-me", scope: :project, cwd: tmp_dir)
+  end
+
+  defp restore_env(key, nil), do: System.delete_env(key)
+  defp restore_env(key, value), do: System.put_env(key, value)
+end

--- a/clients/lemon-tui/src/ink/components/ErrorBar.test.tsx
+++ b/clients/lemon-tui/src/ink/components/ErrorBar.test.tsx
@@ -9,6 +9,23 @@ import { ErrorBar } from './ErrorBar.js';
 
 function delay(ms = 5) { return new Promise<void>(r => setTimeout(r, ms)); }
 
+async function waitFor(assertion: () => void, timeoutMs = 500) {
+  const start = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(10);
+    }
+  }
+
+  throw lastError;
+}
+
 describe('ErrorBar', () => {
   it('should render nothing when there is no error', () => {
     const store = createTestStore();
@@ -50,8 +67,7 @@ describe('ErrorBar', () => {
     expect(lastFrame()).toContain('First error');
 
     store.setError('Second error');
-    await delay(10);
-    expect(lastFrame()).toContain('Second error');
+    await waitFor(() => expect(lastFrame()).toContain('Second error'));
   });
 
   it('should auto-dismiss after long timeout', async () => {

--- a/clients/lemon-tui/src/ink/components/SelectOverlay.test.tsx
+++ b/clients/lemon-tui/src/ink/components/SelectOverlay.test.tsx
@@ -10,6 +10,23 @@ import { SelectOverlay } from './SelectOverlay.js';
 
 function delay(ms = 5) { return new Promise<void>(r => setTimeout(r, ms)); }
 
+async function waitFor(assertion: () => void, timeoutMs = 500) {
+  const start = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(10);
+    }
+  }
+
+  throw lastError;
+}
+
 function renderOverlay(props: {
   title: string;
   options: Array<{ label: string; value: string; description?: string }>;
@@ -84,7 +101,7 @@ describe('SelectOverlay', () => {
 
   it('should navigate down with arrow key', async () => {
     const onSelect = vi.fn();
-    const { stdin } = renderOverlay({
+    const { stdin, lastFrame } = renderOverlay({
       title: 'Test',
       options: testOptions,
       onSelect,
@@ -94,15 +111,14 @@ describe('SelectOverlay', () => {
     // Press down arrow then Enter
     await delay();
     stdin.write('\x1B[B'); // Down arrow
-    await delay(20);
+    await waitFor(() => expect(lastFrame()).toContain('> Option B'));
     stdin.write('\r'); // Enter
-    await delay();
-    expect(onSelect).toHaveBeenCalledWith('b');
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith('b'));
   });
 
   it('should navigate up with arrow key', async () => {
     const onSelect = vi.fn();
-    const { stdin } = renderOverlay({
+    const { stdin, lastFrame } = renderOverlay({
       title: 'Test',
       options: testOptions,
       onSelect,
@@ -116,10 +132,9 @@ describe('SelectOverlay', () => {
     stdin.write('\x1B[B'); // Down
     await delay();
     stdin.write('\x1B[A'); // Up
-    await delay(20);
+    await waitFor(() => expect(lastFrame()).toContain('> Option B'));
     stdin.write('\r');
-    await delay();
-    expect(onSelect).toHaveBeenCalledWith('b');
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith('b'));
   });
 
   it('should cancel on Escape', async () => {

--- a/docs/architecture_boundaries.md
+++ b/docs/architecture_boundaries.md
@@ -15,9 +15,9 @@ Lemon enforces direct umbrella dependencies by app. This keeps the harness modul
 | `lemon_ai_runtime` | `ai`, `lemon_core` |
 | `lemon_automation` | `lemon_core`, `lemon_router` |
 | `lemon_channels` | `lemon_ai_runtime`, `lemon_core` |
-| `lemon_control_plane` | `ai`, `coding_agent`, `lemon_automation`, `lemon_channels`, `lemon_core`, `lemon_gateway`, `lemon_router`, `lemon_skills` |
+| `lemon_control_plane` | `ai`, `coding_agent`, `lemon_automation`, `lemon_channels`, `lemon_core`, `lemon_router`, `lemon_skills` |
 | `lemon_core` | *(none)* |
-| `lemon_gateway` | `agent_core`, `ai`, `coding_agent`, `lemon_automation`, `lemon_channels`, `lemon_core` |
+| `lemon_gateway` | `agent_core`, `ai`, `coding_agent`, `lemon_automation`, `lemon_core` |
 | `lemon_mcp` | `agent_core`, `coding_agent` |
 | `lemon_router` | `agent_core`, `ai`, `coding_agent`, `lemon_channels`, `lemon_core` |
 | `lemon_services` | *(none)* |

--- a/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
+++ b/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
@@ -1,6 +1,6 @@
 # Lemon ↔ Hermes-Class Agent Harness Parity Scorecard
 
-Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, third slice wires relevant-skill preselection into the native session prompt path, and fourth slice adds an audited agent-facing skill authoring tool.
+Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, third slice wires relevant-skill preselection into the native session prompt path, fourth slice adds an audited agent-facing skill authoring tool, fifth slice adds redacted skill load/write telemetry, sixth slice adds usage counters plus pin/archive curation state, and seventh slice audits missed relevant-skill loads.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ Track where Lemon already has Hermes-class agent harness behavior, where it is p
 
 Lemon already has the hard architectural primitives: supervised BEAM sessions, channel routing, CLI engine adapters, task/subagent execution, skill registry, memory search, tool policies, approvals, and a control plane. The biggest near-term gaps are mostly harness-contract gaps: making the native Lemon agent reliably use those primitives every run, then adding tests/evals that prevent regressions.
 
-The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`. The fourth slice adds `skill_manage` so agents can turn reusable workflows into audited project/global skills.
+The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`. The fourth slice adds `skill_manage` so agents can turn reusable workflows into audited project/global skills. The fifth slice emits and persists redacted `read_skill` and `skill_manage` telemetry with tool-call and session correlation fields. The sixth slice keeps Hermes-style usage/curation sidecars with counters, agent-authored provenance, and pin/archive workflows. The seventh slice records `:missed_skill_observed` when relevant skills were shown but not loaded.
 
 ## Capability scorecard
 
@@ -56,11 +56,14 @@ The first code slice from this scorecard made `read_skill` available in the defa
   - Native session prompt refresh passes the current user prompt into relevance scoring and renders concise `<relevant-skills>` hints per turn.
   - `read_skill` can read full content, summaries, sections, and linked files.
   - `skill_manage` can create, edit, patch, delete, and maintain audited project/global skills and supporting files.
+  - `read_skill` and `skill_manage` emit redacted load/write telemetry with tool-call and session correlation fields, then project it into introspection events.
+  - `LemonSkills.Usage` persists load/write counters, agent-authored creation provenance, and curation state.
+  - `skill_manage` can pin/unpin/archive/restore skills; pinned skills are protected from archive/delete, and archived skills are disabled.
+  - Session end audits record `:missed_skill_observed` when `<relevant-skills>` hints were not loaded with `read_skill`.
   - Install/update audit gates exist.
 - Gaps:
-  - Missed-skill detection is not yet audited as a run outcome.
-  - Skill authoring now exists but lacks Hermes-style usage telemetry, curation lifecycle, and pin/archive workflows.
-  - Per-turn relevant-skill hints are guided, but not yet enforced through observed tool-call telemetry.
+  - Skill curation exists, but there is no automated stale-skill review or curator loop yet.
+  - Missed-skill detection is observable, but there is not yet a behavioral eval that drives a real model trace through the contract.
 - Priority: high.
 - Acceptance tests:
   - Native Lemon default tools include `read_skill`.
@@ -218,12 +221,31 @@ The first code slice from this scorecard made `read_skill` available in the defa
 2. Wrapped `skill_manage` into the default CodingAgent tool surface, builtin registry, minimal-core policy, and harness contract.
 3. Treated `skill_manage` as dangerous in safe/subagent-restricted profiles and documented audited write behavior.
 
+### Slice 5: Skill load/write telemetry
+
+1. Added `LemonSkills.Telemetry` and emitted `[:lemon_skills, :skill, :load]` from `read_skill` for found and missing skill requests.
+2. Emitted `[:lemon_skills, :skill, :write]` from `skill_manage` for accepted and rejected write attempts without recording skill bodies, patch strings, or supporting-file contents.
+3. Threaded CodingAgent `session_key`, `session_id`, `agent_id`, and optional `run_id` tool options into those events when available.
+4. Projected the telemetry into `:skill_load_observed` and `:skill_write_observed` introspection events.
+5. Documented event fields and added regression tests for successful/missing loads, successful/rejected writes, and introspection projection.
+
+### Slice 6: Skill usage and curation state
+
+1. Added `LemonSkills.Usage` sidecars for global and project usage metadata.
+2. Recorded load/write counters, last-use metadata, and agent-authored creation provenance from skill telemetry.
+3. Extended `skill_manage` with `pin`, `unpin`, `archive`, and `restore`; archived skills use the existing disabled-skill config, and pinned skills must be unpinned before archive/delete.
+4. Added regression tests for usage counters, provenance, curation state, and archived-skill restore behavior.
+
+### Slice 7: Missed relevant-skill audit
+
+1. Added a session-end audit that parses `<relevant-skills>` from the current prompt and compares those keys with observed `read_skill` tool results.
+2. Persisted `:missed_skill_observed` introspection events for relevant skills that were not loaded.
+3. Documented the event so operators can query missed skill usage.
+
 ## Follow-up backlog
 
-1. Add skill-load telemetry fields to run events or session metadata.
-2. Add skill-write and skill-load telemetry fields to run events or session metadata.
-3. Add missed-skill audit warnings based on `LemonSkills.find_relevant/2` and observed tool calls.
-4. Add Hermes-style skill curation lifecycle: usage counters, stale/archive/pinned states, and agent-authored provenance.
-5. Clarify memory/session-search/skills/todos in docs and prompt text.
-6. Add cron parity scorecard and scheduled job prompt validation.
-7. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, reusable workflow → `skill_manage`, async task receipt → `join` before final answer.
+1. Thread native Lemon run identifiers into tool options so persisted skill introspection can be queried by run as well as session.
+2. Add automated stale-skill review/curator prompts using `LemonSkills.Usage` lifecycle state.
+3. Clarify memory/session-search/skills/todos in docs and prompt text.
+4. Add cron parity scorecard and scheduled job prompt validation.
+5. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, reusable workflow → `skill_manage`, async task receipt → `join` before final answer.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -338,6 +338,22 @@ relevant = LemonSkills.find_relevant(user_query, cwd: cwd, max_results: 3)
 # Skills are automatically injected into the system prompt when relevant
 ```
 
+Agent tool usage emits skill-specific telemetry:
+
+- `read_skill` emits `[:lemon_skills, :skill, :load]` for successful and missing skill loads.
+- `skill_manage` emits `[:lemon_skills, :skill, :write]` for accepted and rejected write attempts.
+
+Both events include `tool_call_id`, include session metadata when built through CodingAgent tool factories, avoid recording skill body content, update `LemonSkills.Usage`, and are persisted into introspection as `:skill_load_observed` / `:skill_write_observed`.
+
+Usage and curation metadata lives outside `SKILL.md`:
+
+| Scope | Sidecar |
+|-------|---------|
+| Global | `~/.lemon/agent/skills.usage.json` |
+| Project | `<cwd>/.lemon/skills.usage.json` |
+
+The sidecar tracks load/write counters, last-use fields, agent-authored creation provenance, and `lifecycle_state` (`active`, `stale`, `archived`, or `pinned`). Agents can use `skill_manage` actions `pin`, `unpin`, `archive`, and `restore` for curation. Pinned skills are protected from delete/archive operations; archived skills are disabled through the normal `skills.json` mechanism.
+
 ## Project vs Global Skills
 
 | Aspect | Project Skills | Global Skills |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -240,6 +240,77 @@ Emitted when a tool result message is appended to context.
 
 `trust` comes from tool result trust normalization in the tool-call loop. Only `:untrusted` is emitted as untrusted; all other values are emitted as `:trusted`.
 
+## LemonSkills Events
+
+These events record skill lifecycle decisions with redacted metadata. They include `tool_call_id` so operators can correlate them with `[:agent_core, :tool_task, ...]` and `[:agent_core, :tool_result, :emit]` events for the same tool invocation. When the tool is built through the CodingAgent tool factories, they also include `session_key`, `session_id`, and `agent_id`.
+
+LemonSkills also attaches an introspection bridge on application start. The bridge persists `[:lemon_skills, :skill, :load]` as `:skill_load_observed` and `[:lemon_skills, :skill, :write]` as `:skill_write_observed`, lifting `run_id`, `session_key`, and `agent_id` into the canonical introspection envelope when those fields are present. The same bridge updates `LemonSkills.Usage` sidecars for load/write counters and curation metadata.
+
+### Skill Load Events
+
+#### [:lemon_skills, :skill, :load]
+
+Emitted when `read_skill` returns a skill or a not-found result.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| **Measurements** | | |
+| `count` | integer | Always 1 |
+| `system_time` | integer | Emit time in native units |
+| **Metadata** | | |
+| `result` | string | `ok` or `not_found` |
+| `key` | string | Requested skill key |
+| `name` | string | Skill display name when found |
+| `source` | string | Skill source when found |
+| `path` | string | Skill directory when found |
+| `view` | string | Requested `read_skill` view |
+| `section` | string | Requested section, when present |
+| `file_path` | string | Requested file path, when present |
+| `include_status` | boolean | Whether status output was requested |
+| `include_manifest` | boolean | Whether manifest output was requested |
+| `tool_call_id` | string | Tool invocation identifier |
+| `run_id` | string | Run identifier, when provided |
+| `session_key` | string | CodingAgent session key, when provided |
+| `session_id` | string | CodingAgent session id, when provided |
+| `agent_id` | string | Agent id, when provided |
+| `cwd` | string | Project working directory, when present |
+
+### Skill Write Events
+
+#### [:lemon_skills, :skill, :write]
+
+Emitted when `skill_manage` accepts or rejects a skill write operation. The event intentionally excludes skill body content, replacement strings, and supporting-file content.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| **Measurements** | | |
+| `count` | integer | Always 1 |
+| `system_time` | integer | Emit time in native units |
+| **Metadata** | | |
+| `result` | string | `ok` or `error` |
+| `action` | string | `create`, `edit`, `patch`, `delete`, `write_file`, or `remove_file` |
+| `name` | string | Skill key requested by the agent |
+| `scope` | string | `project` or `global` |
+| `path` | string | Skill directory after a successful write |
+| `file_path` | string | Relative supporting file path, when applicable |
+| `audit_status` | string | Audit verdict for successful audited writes |
+| `replacements` | integer | Number of patch replacements, when applicable |
+| `reason` | string | Truncated rejection reason for failed writes |
+| `tool_call_id` | string | Tool invocation identifier |
+| `run_id` | string | Run identifier, when provided |
+| `session_key` | string | CodingAgent session key, when provided |
+| `session_id` | string | CodingAgent session id, when provided |
+| `agent_id` | string | Agent id, when provided |
+| `cwd` | string | Project working directory, when present |
+
+### Introspection Projection
+
+| Event Type | Source Telemetry | Payload |
+|---|---|---|
+| `:skill_load_observed` | `[:lemon_skills, :skill, :load]` | Same redacted metadata except envelope fields (`run_id`, `session_key`, `session_id`, `agent_id`) |
+| `:skill_write_observed` | `[:lemon_skills, :skill, :write]` | Same redacted metadata except envelope fields (`run_id`, `session_key`, `session_id`, `agent_id`) |
+| `:missed_skill_observed` | Session end audit | `missed_skill_keys` and `loaded_skill_keys` when the prompt surfaced `<relevant-skills>` but the agent did not load them |
+
 ### Context Events
 
 #### [:agent_core, :context, :size]


### PR DESCRIPTION
## Summary
- add skill lifecycle telemetry, usage sidecars, curation actions, and missed relevant-skill audits
- remove the gateway compile-time dependency from control-plane/gateway boundary metadata
- harden transport status and gateway health introspection with runtime-safe checks

## Validation
- mix test apps/coding_agent/test/coding_agent/session/event_handler_test.exs apps/lemon_skills/test/lemon_skills/tools/read_skill_test.exs apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs apps/lemon_skills/test/lemon_skills/usage_test.exs apps/lemon_control_plane/test/lemon_control_plane/methods/introspection_methods_test.exs apps/lemon_gateway/test/health_test.exs apps/lemon_core/test/lemon_core/quality/architecture_check_test.exs
- MIX_ENV=test mix compile --warnings-as-errors
- mix lemon.quality
- git diff --check