### PR TITLE
Integrate skill curation reports and quality scan fixes

### DIFF
--- a/apps/lemon_core/lib/lemon_core/quality/architecture_rules_check.ex
+++ b/apps/lemon_core/lib/lemon_core/quality/architecture_rules_check.ex
@@ -19,7 +19,17 @@ defmodule LemonCore.Quality.ArchitectureRulesCheck do
   @router_session_registry "LemonRouter." <> "SessionRegistry"
   @router_session_read_model "LemonRouter." <> "SessionReadModel"
   @router_registry_lookup "Registry.lookup(" <> @router_session_registry
-  @ignored_source_dirs MapSet.new(["_build", "cover", "deps", "node_modules", "tmp"])
+  @ignored_source_dirs MapSet.new([
+                         ".elixir_ls",
+                         ".expert",
+                         ".git",
+                         ".worktrees",
+                         "_build",
+                         "cover",
+                         "deps",
+                         "node_modules",
+                         "tmp"
+                       ])
 
   @rules [
     %{
@@ -527,9 +537,66 @@ defmodule LemonCore.Quality.ArchitectureRulesCheck do
 
   defp source_files(root, globs) do
     globs
-    |> Enum.flat_map(fn glob -> Path.wildcard(Path.join(root, glob)) end)
+    |> Enum.flat_map(&source_files_for_glob(root, &1))
     |> Enum.reject(&ignored_source_path?(root, &1))
     |> Enum.uniq()
+  end
+
+  defp source_files_for_glob(root, glob) do
+    if String.contains?(glob, "**") do
+      {base_glob, suffix} = split_recursive_glob(glob)
+      extension = Path.extname(suffix)
+
+      root
+      |> Path.join(base_glob)
+      |> Path.wildcard()
+      |> Enum.filter(&File.dir?/1)
+      |> Enum.flat_map(&walk_source_files(root, &1, extension))
+    else
+      Path.wildcard(Path.join(root, glob))
+    end
+  end
+
+  defp split_recursive_glob(glob) do
+    [base, suffix] = String.split(glob, "**", parts: 2)
+    {String.trim_trailing(base, "/"), suffix}
+  end
+
+  defp walk_source_files(root, dir, extension) do
+    if ignored_source_path?(root, dir) do
+      []
+    else
+      case File.ls(dir) do
+        {:ok, entries} ->
+          Enum.flat_map(entries, fn entry ->
+            path = Path.join(dir, entry)
+
+            cond do
+              ignored_source_path?(root, path) ->
+                []
+
+              symlink?(path) ->
+                []
+
+              File.dir?(path) ->
+                walk_source_files(root, path, extension)
+
+              extension == "" or String.ends_with?(path, extension) ->
+                [path]
+
+              true ->
+                []
+            end
+          end)
+
+        {:error, _} ->
+          []
+      end
+    end
+  end
+
+  defp symlink?(path) do
+    match?({:ok, %File.Stat{type: :symlink}}, File.lstat(path))
   end
 
   defp ignored_source_path?(root, file) do
@@ -542,11 +609,25 @@ defmodule LemonCore.Quality.ArchitectureRulesCheck do
   defp reject_excluded(files, _root, []), do: files
 
   defp reject_excluded(files, root, globs) do
-    excluded =
-      globs
-      |> Enum.flat_map(fn glob -> Path.wildcard(Path.join(root, glob)) end)
-      |> MapSet.new()
+    Enum.reject(files, fn file ->
+      relative = Path.relative_to(file, root)
+      Enum.any?(globs, &glob_match?(&1, relative))
+    end)
+  end
 
-    Enum.reject(files, &MapSet.member?(excluded, &1))
+  defp glob_match?(glob, relative) do
+    cond do
+      String.ends_with?(glob, "/**") ->
+        prefix = String.trim_trailing(glob, "/**")
+        relative == prefix or String.starts_with?(relative, prefix <> "/")
+
+      String.contains?(glob, "**") ->
+        {base, suffix} = split_recursive_glob(glob)
+        extension = Path.extname(suffix)
+        String.starts_with?(relative, base <> "/") and String.ends_with?(relative, extension)
+
+      true ->
+        relative == glob
+    end
   end
 end

--- a/apps/lemon_core/lib/mix/tasks/lemon.check_duplicate_tests.ex
+++ b/apps/lemon_core/lib/mix/tasks/lemon.check_duplicate_tests.ex
@@ -2,6 +2,18 @@ defmodule Mix.Tasks.Lemon.CheckDuplicateTests do
   use Mix.Task
 
   @shortdoc "Check for duplicate test module names"
+  @ignored_dirs MapSet.new([
+                  ".elixir_ls",
+                  ".expert",
+                  ".git",
+                  ".worktrees",
+                  "_build",
+                  "cover",
+                  "deps",
+                  "node_modules",
+                  "tmp"
+                ])
+
   @moduledoc """
   Scans test files for duplicate `defmodule` names.
 
@@ -22,8 +34,7 @@ defmodule Mix.Tasks.Lemon.CheckDuplicateTests do
 
     duplicates =
       root
-      |> Path.join("apps/**/*_test.exs")
-      |> Path.wildcard()
+      |> test_files()
       |> Enum.flat_map(&module_occurrences(root, &1))
       |> Enum.group_by(fn {module_name, _path} -> module_name end, fn {_module_name, path} ->
         path
@@ -62,4 +73,53 @@ defmodule Mix.Tasks.Lemon.CheckDuplicateTests do
       _ -> []
     end
   end
+
+  defp test_files(root) do
+    root
+    |> Path.join("apps")
+    |> walk_test_files(root)
+    |> Enum.uniq()
+  end
+
+  defp walk_test_files(dir, root) do
+    if ignored_path?(root, dir) do
+      []
+    else
+      case File.ls(dir) do
+        {:ok, entries} ->
+          Enum.flat_map(entries, fn entry ->
+            path = Path.join(dir, entry)
+
+            cond do
+              ignored_path?(root, path) ->
+                []
+
+              symlink?(path) ->
+                []
+
+              File.dir?(path) ->
+                walk_test_files(path, root)
+
+              String.ends_with?(path, "_test.exs") ->
+                [path]
+
+              true ->
+                []
+            end
+          end)
+
+        {:error, _} ->
+          []
+      end
+    end
+  end
+
+  defp ignored_path?(root, path) do
+    path
+    |> Path.relative_to(root)
+    |> Path.split()
+    |> Enum.any?(&MapSet.member?(@ignored_dirs, &1))
+  end
+
+  defp symlink?(path), do: match?({:ok, %File.Stat{type: :symlink}}, File.lstat(path))
 end

--- a/apps/lemon_core/test/lemon_core/quality/architecture_rules_check_test.exs
+++ b/apps/lemon_core/test/lemon_core/quality/architecture_rules_check_test.exs
@@ -31,6 +31,32 @@ defmodule LemonCore.Quality.ArchitectureRulesCheckTest do
     end
   end
 
+  test "does not traverse ignored symlink loops" do
+    tmp_dir = tmp_repo!()
+
+    try do
+      write_file!(
+        tmp_dir,
+        "apps/coding_agent/tmp/loop/a/bad.ex",
+        """
+        defmodule BadScratch do
+          LemonRouter.SessionRegistry
+        end
+        """
+      )
+
+      File.ln_s!(
+        Path.join(tmp_dir, "apps/coding_agent/tmp/loop"),
+        Path.join(tmp_dir, "apps/coding_agent/tmp/loop/a/back")
+      )
+
+      assert {:ok, report} = ArchitectureRulesCheck.run(root: tmp_dir)
+      assert report.issue_count == 0
+    after
+      File.rm_rf!(tmp_dir)
+    end
+  end
+
   test "flags forbidden router outbound payload construction" do
     tmp_dir = tmp_repo!()
 

--- a/apps/lemon_skills/AGENTS.md
+++ b/apps/lemon_skills/AGENTS.md
@@ -171,7 +171,7 @@ Skill loads and writes update a sidecar usage file outside `SKILL.md`:
 - global: `~/.lemon/agent/skills.usage.json`
 - project: `<cwd>/.lemon/skills.usage.json`
 
-The sidecar stores load/write counters, last-use metadata, agent-authored creation provenance, and lifecycle state. `skill_manage` supports `pin`, `unpin`, `archive`, and `restore`; pinned skills cannot be archived or deleted until unpinned, and archived project/global skills are disabled through `skills.json` so relevance selection stops surfacing them.
+The sidecar stores load/write counters, last-use metadata, agent-authored creation provenance, and lifecycle state. `skill_manage` supports `report`, `pin`, `unpin`, `archive`, and `restore`; `report` surfaces stale/archive candidates for agent-authored skills, pinned skills cannot be archived or deleted until unpinned, and archived project/global skills are disabled through `skills.json` so relevance selection stops surfacing them.
 
 ### HTTP Client Injection
 

--- a/apps/lemon_skills/README.md
+++ b/apps/lemon_skills/README.md
@@ -201,7 +201,7 @@ Project skills always rank above equivalently-scored global skills. Skills that 
 
 Every install/update for a non-builtin skill runs through the audit path before the skill is registered.
 
-Agent-authored skill writes use the same bundle audit path through `skill_manage`. The tool writes only to the configured project or global skill directories, restricts supporting files to `references/`, `templates/`, `scripts/`, and `assets/`, and rolls back blocked audit verdicts before refreshing the registry.
+Agent-authored skill writes use the same bundle audit path through `skill_manage`. The tool writes only to the configured project or global skill directories, restricts supporting files to `references/`, `templates/`, `scripts/`, and `assets/`, and rolls back blocked audit verdicts before refreshing the registry. `skill_manage` also exposes a `report` action that summarizes usage sidecar rows and flags stale/archive candidates before an agent curates skills.
 
 1. `LemonSkills.Bundle` computes a deterministic bundle hash across `SKILL.md` plus supported files under `references/`, `templates/`, `scripts/`, and `assets/`. Symlinked bundle entries are rejected so the audit payload cannot escape the skill root.
 2. `LemonSkills.Audit.BundleAudit` reuses cached results from `skills.audit.json` only when the bundle hash and audit fingerprint still match.

--- a/apps/lemon_skills/lib/lemon_skills.ex
+++ b/apps/lemon_skills/lib/lemon_skills.ex
@@ -265,4 +265,10 @@ defmodule LemonSkills do
   """
   @spec usage(String.t(), keyword()) :: map()
   defdelegate usage(key, opts \\ []), to: Usage, as: :get
+
+  @doc """
+  Return skill usage and curation rows for a scope.
+  """
+  @spec usage_report(keyword()) :: [map()]
+  defdelegate usage_report(opts \\ []), to: Usage, as: :report
 end

--- a/apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex
+++ b/apps/lemon_skills/lib/lemon_skills/tools/skill_manage.ex
@@ -52,7 +52,8 @@ defmodule LemonSkills.Tools.SkillManage do
               "pin",
               "unpin",
               "archive",
-              "restore"
+              "restore",
+              "report"
             ],
             "description" => "Skill operation to perform."
           },
@@ -91,9 +92,19 @@ defmodule LemonSkills.Tools.SkillManage do
           "replace_all" => %{
             "type" => "boolean",
             "description" => "Replace all occurrences for patch. Defaults to false."
+          },
+          "stale_after_days" => %{
+            "type" => "integer",
+            "description" =>
+              "For report: mark active agent-authored skills stale after this many idle days. Defaults to 30."
+          },
+          "archive_after_days" => %{
+            "type" => "integer",
+            "description" =>
+              "For report: mark active agent-authored skills archive candidates after this many idle days. Defaults to 90."
           }
         },
-        "required" => ["action", "name"]
+        "required" => ["action"]
       },
       execute: &execute(&1, &2, &3, &4, cwd, telemetry_context)
     }
@@ -124,10 +135,10 @@ defmodule LemonSkills.Tools.SkillManage do
         {:error, "Operation aborted"}
       else
         with {:ok, action} <- required_string(params, "action"),
-             {:ok, name} <- required_string(params, "name"),
-             :ok <- validate_name(name),
              {:ok, scope} <- parse_scope(Map.get(params, "scope", "project")),
-             {:ok, root} <- skills_root(scope, cwd) do
+             {:ok, root} <- skills_root(scope, cwd),
+             {:ok, name} <- name_for_action(action, params),
+             :ok <- validate_name_for_action(action, name) do
           dispatch(action, name, params, scope, root, cwd)
         end
       end
@@ -292,9 +303,26 @@ defmodule LemonSkills.Tools.SkillManage do
     end
   end
 
+  defp dispatch("report", _name, params, scope, _root, cwd) do
+    opts =
+      usage_opts(scope, cwd) ++
+        [
+          stale_after_days: positive_integer_param(params, "stale_after_days", 30),
+          archive_after_days: positive_integer_param(params, "archive_after_days", 90)
+        ]
+
+    rows = LemonSkills.Usage.report(opts)
+
+    ok(format_report(rows, scope), %{
+      action: "report",
+      scope: Atom.to_string(scope),
+      skills: rows
+    })
+  end
+
   defp dispatch(action, _name, _params, _scope, _root, _cwd) do
     {:error,
-     "Unknown action '#{action}'. Use create, edit, patch, delete, write_file, remove_file, pin, unpin, archive, or restore."}
+     "Unknown action '#{action}'. Use create, edit, patch, delete, write_file, remove_file, pin, unpin, archive, restore, or report."}
   end
 
   defp required_string(params, key, opts \\ []) do
@@ -319,6 +347,12 @@ defmodule LemonSkills.Tools.SkillManage do
   defp parse_scope("global"), do: {:ok, :global}
   defp parse_scope("project"), do: {:ok, :project}
   defp parse_scope(_), do: {:error, "scope must be 'project' or 'global'"}
+
+  defp name_for_action("report", params), do: {:ok, Map.get(params, "name", "")}
+  defp name_for_action(_action, params), do: required_string(params, "name")
+
+  defp validate_name_for_action("report", ""), do: :ok
+  defp validate_name_for_action(_action, name), do: validate_name(name)
 
   defp skills_root(:global, _cwd), do: {:ok, Config.global_skills_dir()}
 
@@ -492,6 +526,50 @@ defmodule LemonSkills.Tools.SkillManage do
   defp usage_opts(:global, _cwd), do: [scope: :global]
   defp usage_opts(:project, cwd), do: [scope: :project, cwd: cwd]
 
+  defp positive_integer_param(params, key, default) do
+    case Map.get(params, key, default) do
+      value when is_integer(value) and value > 0 ->
+        value
+
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {parsed, ""} when parsed > 0 -> parsed
+          _ -> default
+        end
+
+      _ ->
+        default
+    end
+  end
+
+  defp format_report([], scope), do: "No #{scope} skill usage records found."
+
+  defp format_report(rows, scope) do
+    header = "Skill usage report for #{scope} scope:"
+
+    body =
+      rows
+      |> Enum.map(fn row ->
+        markers =
+          [
+            if(row.archive_candidate, do: "archive-candidate"),
+            if(row.stale_candidate, do: "stale-candidate"),
+            row.lifecycle_state
+          ]
+          |> Enum.reject(&is_nil/1)
+          |> Enum.uniq()
+          |> Enum.join(", ")
+
+        last_activity = row.last_activity_at || "never"
+        idle_days = row.idle_days || "unknown"
+
+        "- #{row.name}: #{markers}; loads=#{row.load_count}; writes=#{row.write_count}; idle_days=#{idle_days}; last_activity=#{last_activity}"
+      end)
+      |> Enum.join("\n")
+
+    header <> "\n" <> body
+  end
+
   defp reject_pinned(name, scope, cwd, action) do
     if LemonSkills.Usage.pinned?(name, usage_opts(scope, cwd)) do
       {:error, "Skill '#{name}' is pinned; unpin it before #{action}."}
@@ -625,36 +703,44 @@ defmodule LemonSkills.Tools.SkillManage do
          cwd,
          telemetry_context
        ) do
-    %{
-      result: :ok,
-      action: details[:action] || Map.get(params, "action"),
-      name: Map.get(params, "name"),
-      scope: Map.get(params, "scope", "project"),
-      path: details[:path],
-      file_path: details[:file_path],
-      audit_status: get_in(details, [:audit, :status]),
-      lifecycle_state: details[:lifecycle_state],
-      replacements: details[:replacements],
-      tool_call_id: tool_call_id,
-      cwd: cwd
-    }
-    |> Map.merge(telemetry_context)
-    |> LemonSkills.Telemetry.skill_write()
+    if (details[:action] || Map.get(params, "action")) == "report" do
+      :ok
+    else
+      %{
+        result: :ok,
+        action: details[:action] || Map.get(params, "action"),
+        name: Map.get(params, "name"),
+        scope: Map.get(params, "scope", "project"),
+        path: details[:path],
+        file_path: details[:file_path],
+        audit_status: get_in(details, [:audit, :status]),
+        lifecycle_state: details[:lifecycle_state],
+        replacements: details[:replacements],
+        tool_call_id: tool_call_id,
+        cwd: cwd
+      }
+      |> Map.merge(telemetry_context)
+      |> LemonSkills.Telemetry.skill_write()
+    end
   end
 
   defp emit_skill_write({:error, reason}, params, tool_call_id, cwd, telemetry_context) do
-    %{
-      result: :error,
-      action: Map.get(params, "action"),
-      name: Map.get(params, "name"),
-      scope: Map.get(params, "scope", "project"),
-      file_path: Map.get(params, "file_path"),
-      reason: reason,
-      tool_call_id: tool_call_id,
-      cwd: cwd
-    }
-    |> Map.merge(telemetry_context)
-    |> LemonSkills.Telemetry.skill_write()
+    if Map.get(params, "action") == "report" do
+      :ok
+    else
+      %{
+        result: :error,
+        action: Map.get(params, "action"),
+        name: Map.get(params, "name"),
+        scope: Map.get(params, "scope", "project"),
+        file_path: Map.get(params, "file_path"),
+        reason: reason,
+        tool_call_id: tool_call_id,
+        cwd: cwd
+      }
+      |> Map.merge(telemetry_context)
+      |> LemonSkills.Telemetry.skill_write()
+    end
   end
 
   defp emit_skill_write(_result, _params, _tool_call_id, _cwd, _telemetry_context), do: :ok

--- a/apps/lemon_skills/lib/lemon_skills/usage.ex
+++ b/apps/lemon_skills/lib/lemon_skills/usage.ex
@@ -11,6 +11,8 @@ defmodule LemonSkills.Usage do
   @states ~w(active stale archived pinned)
   @lock_retries 50
   @lock_sleep_ms 10
+  @default_stale_after_days 30
+  @default_archive_after_days 90
 
   @type scope :: :global | :project
 
@@ -28,6 +30,34 @@ defmodule LemonSkills.Usage do
 
       :skip ->
         normalize_record(nil)
+    end
+  end
+
+  @doc """
+  Return a lifecycle report for all skills in the usage sidecar.
+
+  The report is intentionally sidecar-backed: it summarizes skills that have
+  usage/write telemetry, including agent-authored skills that are candidates
+  for curation.
+  """
+  @spec report(keyword()) :: [map()]
+  def report(opts \\ []) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+    stale_after_days = positive_integer(opts, :stale_after_days, @default_stale_after_days)
+    archive_after_days = positive_integer(opts, :archive_after_days, @default_archive_after_days)
+
+    case resolve_usage_file(opts) do
+      {:ok, path} ->
+        path
+        |> read_usage()
+        |> Map.get("skills", %{})
+        |> Enum.map(fn {key, record} ->
+          report_row(key, normalize_record(record), now, stale_after_days, archive_after_days)
+        end)
+        |> Enum.sort_by(fn row -> {candidate_rank(row), row.name} end)
+
+      :skip ->
+        []
     end
   end
 
@@ -181,6 +211,80 @@ defmodule LemonSkills.Usage do
   defp normalize_scope("project"), do: :project
   defp normalize_scope(:project), do: :project
   defp normalize_scope(_), do: :global
+
+  defp report_row(key, record, now, stale_after_days, archive_after_days) do
+    last_activity_at = last_activity_at(record)
+    idle_days = idle_days(last_activity_at, now)
+    lifecycle_state = Map.get(record, "lifecycle_state", "active")
+    agent_authored? = Map.get(record, "created_by") == "agent"
+    protected? = lifecycle_state in ["pinned", "archived"]
+
+    stale_candidate? =
+      agent_authored? and not protected? and is_integer(idle_days) and
+        idle_days >= stale_after_days
+
+    archive_candidate? =
+      agent_authored? and not protected? and is_integer(idle_days) and
+        idle_days >= archive_after_days
+
+    %{
+      name: key,
+      lifecycle_state: lifecycle_state,
+      agent_authored: agent_authored?,
+      load_count: integer_field(record, "load_count"),
+      write_count: integer_field(record, "write_count"),
+      write_error_count: integer_field(record, "write_error_count"),
+      created_at: Map.get(record, "created_at"),
+      last_loaded_at: Map.get(record, "last_loaded_at"),
+      last_write_at: Map.get(record, "last_write_at"),
+      last_activity_at: last_activity_at,
+      idle_days: idle_days,
+      stale_candidate: stale_candidate?,
+      archive_candidate: archive_candidate?
+    }
+  end
+
+  defp candidate_rank(%{archive_candidate: true}), do: 0
+  defp candidate_rank(%{stale_candidate: true}), do: 1
+  defp candidate_rank(_), do: 2
+
+  defp last_activity_at(record) do
+    ["last_loaded_at", "last_write_at", "created_at"]
+    |> Enum.map(&Map.get(record, &1))
+    |> Enum.filter(&is_binary/1)
+    |> Enum.max_by(&timestamp_sort_value/1, fn -> nil end)
+  end
+
+  defp timestamp_sort_value(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _} -> DateTime.to_unix(dt)
+      _ -> 0
+    end
+  end
+
+  defp idle_days(nil, _now), do: nil
+
+  defp idle_days(timestamp, now) do
+    with {:ok, timestamp, _} <- DateTime.from_iso8601(timestamp) do
+      max(DateTime.diff(now, timestamp, :day), 0)
+    else
+      _ -> nil
+    end
+  end
+
+  defp integer_field(record, key) do
+    case Map.get(record, key, 0) do
+      value when is_integer(value) -> value
+      _ -> 0
+    end
+  end
+
+  defp positive_integer(opts, key, default) do
+    case Keyword.get(opts, key, default) do
+      value when is_integer(value) and value > 0 -> value
+      _ -> default
+    end
+  end
 
   defp read_usage(path) do
     case File.read(path) do

--- a/apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs
@@ -231,6 +231,47 @@ defmodule LemonSkills.Tools.SkillManageTest do
       assert {:ok, _entry} = LemonSkills.Registry.get("curated-skill", cwd: tmp_dir)
     end
 
+    test "reports curation candidates without requiring a skill name", %{tmp_dir: tmp_dir} do
+      attach_handler([[:lemon_skills, :skill, :write]])
+
+      usage_path = Path.join([tmp_dir, ".lemon", "skills.usage.json"])
+      File.mkdir_p!(Path.dirname(usage_path))
+
+      File.write!(
+        usage_path,
+        Jason.encode!(%{
+          "version" => 1,
+          "skills" => %{
+            "old-agent-skill" => %{
+              "created_by" => "agent",
+              "lifecycle_state" => "active",
+              "load_count" => 2,
+              "write_count" => 1,
+              "last_loaded_at" => "2026-01-01T00:00:00Z"
+            }
+          }
+        })
+      )
+
+      result =
+        execute(tmp_dir, %{
+          "action" => "report",
+          "stale_after_days" => 1,
+          "archive_after_days" => 1
+        })
+
+      assert result.details.action == "report"
+      assert result.details.scope == "project"
+      assert [row] = result.details.skills
+      assert row.name == "old-agent-skill"
+      assert row.archive_candidate
+
+      [text] = result.content
+      assert text.text =~ "old-agent-skill"
+      assert text.text =~ "archive-candidate"
+      refute_receive {:telemetry_event, [:lemon_skills, :skill, :write], _, _}, 100
+    end
+
     test "rejects invalid frontmatter before writing", %{tmp_dir: tmp_dir} do
       assert {:error, message} =
                execute(tmp_dir, %{

--- a/apps/lemon_skills/test/lemon_skills/usage_test.exs
+++ b/apps/lemon_skills/test/lemon_skills/usage_test.exs
@@ -148,6 +148,63 @@ defmodule LemonSkills.UsageTest do
     refute Usage.pinned?("pin-me", scope: :project, cwd: tmp_dir)
   end
 
+  test "reports stale and archive candidates for agent-authored skills", %{tmp_dir: tmp_dir} do
+    usage_path = Path.join([tmp_dir, ".lemon", "skills.usage.json"])
+    File.mkdir_p!(Path.dirname(usage_path))
+
+    File.write!(
+      usage_path,
+      Jason.encode!(%{
+        "version" => 1,
+        "skills" => %{
+          "archive-me" => %{
+            "created_by" => "agent",
+            "lifecycle_state" => "active",
+            "load_count" => 3,
+            "write_count" => 1,
+            "last_loaded_at" => "2026-01-01T00:00:00Z"
+          },
+          "pin-me" => %{
+            "created_by" => "agent",
+            "lifecycle_state" => "pinned",
+            "last_loaded_at" => "2026-01-01T00:00:00Z"
+          },
+          "upstream" => %{
+            "lifecycle_state" => "active",
+            "last_loaded_at" => "2026-01-01T00:00:00Z"
+          }
+        }
+      })
+    )
+
+    now = ~U[2026-05-01 00:00:00Z]
+
+    rows =
+      Usage.report(
+        scope: :project,
+        cwd: tmp_dir,
+        now: now,
+        stale_after_days: 30,
+        archive_after_days: 90
+      )
+
+    archive_me = Enum.find(rows, &(&1.name == "archive-me"))
+    pin_me = Enum.find(rows, &(&1.name == "pin-me"))
+    upstream = Enum.find(rows, &(&1.name == "upstream"))
+
+    assert archive_me.agent_authored
+    assert archive_me.load_count == 3
+    assert archive_me.write_count == 1
+    assert archive_me.idle_days == 120
+    assert archive_me.stale_candidate
+    assert archive_me.archive_candidate
+
+    refute pin_me.stale_candidate
+    refute pin_me.archive_candidate
+    refute upstream.agent_authored
+    refute upstream.stale_candidate
+  end
+
   defp restore_env(key, nil), do: System.delete_env(key)
   defp restore_env(key, value), do: System.put_env(key, value)
 end

--- a/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
+++ b/docs/plans/lemon-hermes-agent-harness-parity-scorecard.md
@@ -1,6 +1,6 @@
 # Lemon ↔ Hermes-Class Agent Harness Parity Scorecard
 
-Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, third slice wires relevant-skill preselection into the native session prompt path, fourth slice adds an audited agent-facing skill authoring tool, fifth slice adds redacted skill load/write telemetry, sixth slice adds usage counters plus pin/archive curation state, and seventh slice audits missed relevant-skill loads.
+Status: working scorecard; first parity slice merged, second slice adds executable harness contract evals for memory and skills, third slice wires relevant-skill preselection into the native session prompt path, fourth slice adds an audited agent-facing skill authoring tool, fifth slice adds redacted skill load/write telemetry, sixth slice adds usage counters plus pin/archive curation state, seventh slice audits missed relevant-skill loads, and eighth slice exposes usage/curation reports to agents.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ Track where Lemon already has Hermes-class agent harness behavior, where it is p
 
 Lemon already has the hard architectural primitives: supervised BEAM sessions, channel routing, CLI engine adapters, task/subagent execution, skill registry, memory search, tool policies, approvals, and a control plane. The biggest near-term gaps are mostly harness-contract gaps: making the native Lemon agent reliably use those primitives every run, then adding tests/evals that prevent regressions.
 
-The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`. The fourth slice adds `skill_manage` so agents can turn reusable workflows into audited project/global skills. The fifth slice emits and persists redacted `read_skill` and `skill_manage` telemetry with tool-call and session correlation fields. The sixth slice keeps Hermes-style usage/curation sidecars with counters, agent-authored provenance, and pin/archive workflows. The seventh slice records `:missed_skill_observed` when relevant skills were shown but not loaded.
+The first code slice from this scorecard made `read_skill` available in the default native Lemon tool set and aligned `search_memory` with restricted tool policies. The second slice adds deterministic eval checks that verify memory search scope behavior, memory-topic scaffolding, and relevant-skill prompt progressive disclosure. The third slice feeds the current user prompt into native session prompt composition so Lemon can preselect concise relevant-skill hints before the model turn while keeping full skill bodies behind `read_skill`. The fourth slice adds `skill_manage` so agents can turn reusable workflows into audited project/global skills. The fifth slice emits and persists redacted `read_skill` and `skill_manage` telemetry with tool-call and session correlation fields. The sixth slice keeps Hermes-style usage/curation sidecars with counters, agent-authored provenance, and pin/archive workflows. The seventh slice records `:missed_skill_observed` when relevant skills were shown but not loaded. The eighth slice lets agents query usage/curation reports with stale/archive candidate flags before maintaining learned skills.
 
 ## Capability scorecard
 
@@ -62,7 +62,7 @@ The first code slice from this scorecard made `read_skill` available in the defa
   - Session end audits record `:missed_skill_observed` when `<relevant-skills>` hints were not loaded with `read_skill`.
   - Install/update audit gates exist.
 - Gaps:
-  - Skill curation exists, but there is no automated stale-skill review or curator loop yet.
+  - Skill curation and reporting exist, but there is no automated stale-skill review or curator loop yet.
   - Missed-skill detection is observable, but there is not yet a behavioral eval that drives a real model trace through the contract.
 - Priority: high.
 - Acceptance tests:
@@ -242,10 +242,16 @@ The first code slice from this scorecard made `read_skill` available in the defa
 2. Persisted `:missed_skill_observed` introspection events for relevant skills that were not loaded.
 3. Documented the event so operators can query missed skill usage.
 
+### Slice 8: Skill usage and curation report
+
+1. Added `LemonSkills.Usage.report/1` to summarize usage sidecar rows, counters, last activity, and stale/archive candidate flags for agent-authored skills.
+2. Added `skill_manage` action `report` so agents can inspect curation candidates before pinning, archiving, restoring, or deleting skills.
+3. Documented the report action in skill docs and user guidance.
+
 ## Follow-up backlog
 
 1. Thread native Lemon run identifiers into tool options so persisted skill introspection can be queried by run as well as session.
-2. Add automated stale-skill review/curator prompts using `LemonSkills.Usage` lifecycle state.
+2. Add automated stale-skill review/curator prompts using `LemonSkills.Usage.report/1` lifecycle state.
 3. Clarify memory/session-search/skills/todos in docs and prompt text.
 4. Add cron parity scorecard and scheduled job prompt validation.
 5. Add behavioral evals that observe actual agent traces: relevant skill → `read_skill`, prior-work prompt → `search_memory`, reusable workflow → `skill_manage`, async task receipt → `join` before final answer.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -352,7 +352,7 @@ Usage and curation metadata lives outside `SKILL.md`:
 | Global | `~/.lemon/agent/skills.usage.json` |
 | Project | `<cwd>/.lemon/skills.usage.json` |
 
-The sidecar tracks load/write counters, last-use fields, agent-authored creation provenance, and `lifecycle_state` (`active`, `stale`, `archived`, or `pinned`). Agents can use `skill_manage` actions `pin`, `unpin`, `archive`, and `restore` for curation. Pinned skills are protected from delete/archive operations; archived skills are disabled through the normal `skills.json` mechanism.
+The sidecar tracks load/write counters, last-use fields, agent-authored creation provenance, and `lifecycle_state` (`active`, `stale`, `archived`, or `pinned`). Agents can use `skill_manage` actions `report`, `pin`, `unpin`, `archive`, and `restore` for curation. `report` returns usage rows plus stale/archive candidate flags for agent-authored skills; pinned skills are protected from delete/archive operations; archived skills are disabled through the normal `skills.json` mechanism.
 
 ## Project vs Global Skills
 

--- a/docs/user-guide/skills.md
+++ b/docs/user-guide/skills.md
@@ -85,7 +85,9 @@ Agents can also maintain procedural memory with `skill_manage`. Use project
 scope for repository-specific workflows and global scope for reusable workflows.
 The tool can create, edit, patch, delete, and maintain supporting files under
 `references/`, `templates/`, `scripts/`, and `assets/`; each write is audited
-before the registry is refreshed.
+before the registry is refreshed. Use `action="report"` to inspect usage and
+stale/archive candidates before pinning, archiving, restoring, or deleting
+agent-authored skills.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add an agent-facing `skill_manage` report action backed by `LemonSkills.Usage.report/1` so agents can inspect stale and archive skill candidates.
- Document the curation report flow in the skills docs and Hermes parity scorecard.
- Make quality scanners skip ignored scratch/build directories and symlink loops before recursive traversal.

## Validation

- `mix test apps/lemon_skills/test/lemon_skills/usage_test.exs apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs`
- `MIX_ENV=test mix test apps/lemon_core/test/lemon_core/quality/architecture_rules_check_test.exs --timeout 180000`
- `MIX_ENV=test mix lemon.check_duplicate_tests --root /home/z80/dev/lemon`
- `timeout 180s scripts/test quality`
- `MIX_ENV=test mix compile --warnings-as-errors && mix test apps/lemon_skills/test/lemon_skills/usage_test.exs apps/lemon_skills/test/lemon_skills/tools/skill_manage_test.exs apps/lemon_core/test/lemon_core/quality/architecture_rules_check_test.exs