### PR TITLE
Consolidate get_x_mentions response formatting

### DIFF
--- a/apps/x_api/lib/x_api/tools/get_x_mentions.ex
+++ b/apps/x_api/lib/x_api/tools/get_x_mentions.ex
@@ -86,39 +86,14 @@ defmodule XApi.Tools.GetXMentions do
   # Private Functions
   # ============================================================================
 
-  defp format_mentions_result(%{"data" => mentions, "includes" => includes})
-       when is_list(mentions) do
+  defp format_mentions_result(%{"data" => mentions} = response) when is_list(mentions) do
     users =
-      Map.get(includes, "users", [])
-      |> Map.new(fn u -> {u["id"], u} end)
+      case get_in(response, ["includes", "users"]) do
+        users when is_list(users) -> Map.new(users, fn user -> {user["id"], user} end)
+        _ -> %{}
+      end
 
-    formatted_mentions =
-      Enum.map(mentions, fn m ->
-        author = Map.get(users, m["author_id"], %{})
-
-        %{
-          id: m["id"],
-          text: m["text"],
-          author_username: author["username"],
-          author_name: author["name"],
-          created_at: m["created_at"]
-        }
-      end)
-
-    build_result(formatted_mentions, length(mentions))
-  end
-
-  defp format_mentions_result(%{"data" => mentions}) when is_list(mentions) do
-    formatted_mentions =
-      Enum.map(mentions, fn m ->
-        %{
-          id: m["id"],
-          text: m["text"],
-          author_id: m["author_id"],
-          created_at: m["created_at"]
-        }
-      end)
-
+    formatted_mentions = Enum.map(mentions, &format_mention(&1, users))
     build_result(formatted_mentions, length(mentions))
   end
 
@@ -135,6 +110,19 @@ defmodule XApi.Tools.GetXMentions do
 
   defp format_mentions_result(other) do
     return_error("Unexpected response from X API: #{inspect(other)}")
+  end
+
+  defp format_mention(mention, users) do
+    author = Map.get(users, mention["author_id"], %{})
+
+    %{
+      id: mention["id"],
+      text: mention["text"],
+      author_id: mention["author_id"],
+      author_username: author["username"],
+      author_name: author["name"],
+      created_at: mention["created_at"]
+    }
   end
 
   defp ensure_configured do

--- a/apps/x_api/test/x_api/tools/get_x_mentions_test.exs
+++ b/apps/x_api/test/x_api/tools/get_x_mentions_test.exs
@@ -3,6 +3,8 @@ defmodule XApi.Tools.GetXMentionsTest do
 
   alias LemonAgent.Types.AgentToolResult
   alias LemonAi.Types.TextContent
+  alias XApi
+  alias XApi.TokenManager
   alias XApi.Tools.GetXMentions
 
   @x_env_vars [
@@ -20,10 +22,13 @@ defmodule XApi.Tools.GetXMentionsTest do
   ]
 
   setup do
+    previous_req_defaults = Req.default_options()
     previous = Application.get_env(:x_api, XApi)
     previous_use_secrets = Application.get_env(:x_api, :use_secrets)
     previous_env = Map.new(@x_env_vars, fn key -> {key, System.get_env(key)} end)
 
+    Req.default_options(plug: {Req.Test, __MODULE__})
+    Req.Test.set_req_test_to_shared(%{})
     Application.delete_env(:x_api, XApi)
     Application.put_env(:x_api, :use_secrets, false)
     Enum.each(@x_env_vars, &System.delete_env/1)
@@ -48,6 +53,9 @@ defmodule XApi.Tools.GetXMentionsTest do
       else
         Application.put_env(:x_api, :use_secrets, previous_use_secrets)
       end
+
+      Req.default_options(previous_req_defaults)
+      Req.Test.set_req_test_to_private(%{})
     end)
 
     :ok
@@ -72,5 +80,150 @@ defmodule XApi.Tools.GetXMentionsTest do
     assert %AgentToolResult{
              details: %{error: "Parameter 'limit' must be a positive integer"}
            } = GetXMentions.execute("call-3", %{"limit" => 0}, nil, nil)
+  end
+
+  test "formats mentions with included user metadata" do
+    configure_oauth2(default_account_id: "2022351619589873664")
+    start_token_manager!()
+    test_pid = self()
+
+    Req.Test.stub(__MODULE__, fn conn ->
+      send(test_pid, {:req, conn.request_path})
+
+      case conn.request_path do
+        "/2/oauth2/token" ->
+          oauth_refresh_response(conn)
+
+        "/2/users/2022351619589873664/mentions" ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(
+            200,
+            Jason.encode!(%{
+              "data" => [
+                %{
+                  "id" => "1860000000000000001",
+                  "author_id" => "42",
+                  "text" => "Hey @lemon_agent",
+                  "created_at" => "2026-05-18T01:02:03.000Z"
+                }
+              ],
+              "includes" => %{
+                "users" => [%{"id" => "42", "username" => "fan42", "name" => "Fan 42"}]
+              },
+              "meta" => %{"result_count" => 1}
+            })
+          )
+
+        unexpected ->
+          flunk("unexpected request path: #{unexpected}")
+      end
+    end)
+
+    assert %AgentToolResult{
+             content: [%TextContent{text: text}],
+             details: %{count: 1, mentions: [mention]}
+           } = GetXMentions.execute("call-4", %{"limit" => 5}, nil, nil)
+
+    assert text =~ "Found 1 recent mention"
+    assert text =~ "@fan42 (Fan 42)"
+    assert text =~ "Hey @lemon_agent"
+    assert mention.id == "1860000000000000001"
+    assert mention.author_id == "42"
+    assert mention.author_username == "fan42"
+    assert mention.author_name == "Fan 42"
+
+    assert_receive {:req, "/2/users/2022351619589873664/mentions"}
+  end
+
+  test "formats mentions without includes by falling back to author_id" do
+    configure_oauth2(default_account_id: "2022351619589873664")
+    start_token_manager!()
+    test_pid = self()
+
+    Req.Test.stub(__MODULE__, fn conn ->
+      send(test_pid, {:req, conn.request_path})
+
+      case conn.request_path do
+        "/2/oauth2/token" ->
+          oauth_refresh_response(conn)
+
+        "/2/users/2022351619589873664/mentions" ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(
+            200,
+            Jason.encode!(%{
+              "data" => [
+                %{
+                  "id" => "1860000000000000002",
+                  "author_id" => "99",
+                  "text" => "Ping",
+                  "created_at" => "2026-05-18T02:02:03.000Z"
+                }
+              ],
+              "meta" => %{"result_count" => 1}
+            })
+          )
+
+        unexpected ->
+          flunk("unexpected request path: #{unexpected}")
+      end
+    end)
+
+    assert %AgentToolResult{
+             content: [%TextContent{text: text}],
+             details: %{count: 1, mentions: [mention]}
+           } = GetXMentions.execute("call-5", %{"limit" => 5}, nil, nil)
+
+    assert text =~ "@99 (99)"
+    assert mention.author_id == "99"
+    assert is_nil(mention.author_username)
+    assert is_nil(mention.author_name)
+  end
+
+  defp configure_oauth2(overrides \\ []) do
+    config =
+      Keyword.merge(
+        [
+          client_id: "client-id",
+          client_secret: "client-secret",
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          token_expires_at:
+            DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_iso8601()
+        ],
+        overrides
+      )
+
+    Application.put_env(:x_api, XApi, config)
+  end
+
+  defp start_token_manager! do
+    case Process.whereis(TokenManager) do
+      pid when is_pid(pid) ->
+        GenServer.stop(pid)
+
+      _ ->
+        :ok
+    end
+
+    case start_supervised({TokenManager, []}) do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+
+  defp oauth_refresh_response(conn) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(
+      200,
+      Jason.encode!(%{
+        "access_token" => "refreshed-access-token",
+        "refresh_token" => "refresh-token",
+        "expires_in" => 3600
+      })
+    )
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`XApi.Tools.GetXMentions` had two nearly identical `format_mentions_result/1` clauses — one for API responses with `includes.users` and one without. This PR merges them into a single code path that optionally enriches mentions from included user metadata, matching the pattern already used by `XApi.Tools.XSearch`.

The consolidated formatter also always includes `author_id` in mention details, so responses with and without `includes` now produce a consistent shape.

## Type of change

- [x] Refactor (no behavior change)
- [x] Test

## Related issues

One-off code improvement hunt.

## Checklist

- [x] `mix test` passes
- [ ] `mix lemon.quality` passes (lint + architecture boundaries + doc freshness)
- [ ] New docs files registered in `docs/catalog.exs`
- [ ] New features gated behind a feature flag (if applicable)
- [ ] CODEOWNERS updated for new files (if applicable)
- [ ] CHANGELOG.md updated (if user-visible change)

## Security considerations

No security impact. This is internal response formatting for the read-only `get_x_mentions` tool.

## Testing notes

Added integration tests in `apps/x_api/test/x_api/tools/get_x_mentions_test.exs` covering:

- Mentions with `includes.users` (username/name enrichment)
- Mentions without includes (fallback to `author_id` in rendered text)

Verified with:

```bash
mix test apps/x_api/test/x_api/tools/get_x_mentions_test.exs
```

5 tests, 0 failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04141-f524-7a38-b37f-0f0ff9c556a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04141-f524-7a38-b37f-0f0ff9c556a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

