### PR TITLE
Validate configured engine runtime contracts at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ Versions follow [CalVer](https://calver.org/) — `YYYY.MM.PATCH`.
 
 - Configured engine runtimes are now checked against
   `LemonCore.EngineRuntime` when the router starts. Invalid wiring is reported
-  once while preserving router-only boot and the existing unavailable-runtime
-  handling.
+  once and disabled while preserving router-only boot and the existing
+  unavailable-runtime handling.
 - Persistent source and packaged launchers now provision a private,
   port-scoped control-plane operator credential under `~/.lemon/run`, allowing
   later TUI processes to attach automatically without exposing the bearer in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Versions follow [CalVer](https://calver.org/) — `YYYY.MM.PATCH`.
 
 ### Added
 
+- Configured engine runtimes are now checked against
+  `LemonCore.EngineRuntime` when the router starts. Invalid wiring is reported
+  once while preserving router-only boot and the existing unavailable-runtime
+  handling.
 - Persistent source and packaged launchers now provision a private,
   port-scoped control-plane operator credential under `~/.lemon/run`, allowing
   later TUI processes to attach automatically without exposing the bearer in

--- a/apps/lemon_core/AGENTS.md
+++ b/apps/lemon_core/AGENTS.md
@@ -5,6 +5,7 @@ This is the **base app** of the Lemon umbrella. All other apps depend on it. It 
 ## Purpose and Responsibilities
 
 - **Configuration management** - TOML-based config loading, caching, validation, and hot reloading
+- **Configured implementation validation** - Shared loadability and required-callback checks for behaviour-injected modules
 - **First-run readiness** - Shared read-only config/secrets/provider/model readiness for all clients
 - **Secrets management** - Encrypted storage with AES-256-GCM, keychain integration, and bounded read-only external sources
 - **Storage backends** - Pluggable storage (ETS, SQLite, JSONL) for state persistence
@@ -31,6 +32,7 @@ This is the **base app** of the Lemon umbrella. All other apps depend on it. It 
 |--------|---------|
 | `LemonCore` | Main module with module list |
 | `LemonCore.Config` | TOML config facade; delegates to `LemonCore.Config.Modular` for parsing/resolution and converts output into the legacy struct shape |
+| `LemonCore.Contract` | Shared loadability and required-callback validation for behaviour-injected modules |
 | `LemonCore.Config.Modular` | Canonical modular config loader with typed sub-structs per section (sole parser/resolver for runtime config semantics); `validate_settings/1` validates an already-decoded merged candidate before comment-preserving editors replace a live file |
 | `LemonCore.ConfigCache` | ETS-backed config cache with mtime-based invalidation |
 | `LemonCore.ConfigReloader` | Hot reload orchestrator with diff computation and Bus broadcast |

--- a/apps/lemon_core/CHANGELOG.md
+++ b/apps/lemon_core/CHANGELOG.md
@@ -18,6 +18,9 @@ Telegram, run history, durable memory, kanban boards, or `~/.lemon`.
 
 ### Added
 
+- `LemonCore.Contract` centralizes loadability and required-callback checks for
+  configuration-injected implementations. `LemonCore.EngineRuntime.validate/1`
+  exposes the check used by router startup; optional callbacks remain optional.
 - `LemonCore.A2A.Protocol`, `LemonCore.A2A.Client`, and `LemonCore.A2AStore`
   provide the generic A2A v1.0 wire helpers, credential-scrubbing HTTP client,
   and typed durable context/task/message storage shared by peer transports and

--- a/apps/lemon_core/CHANGELOG.md
+++ b/apps/lemon_core/CHANGELOG.md
@@ -20,7 +20,9 @@ Telegram, run history, durable memory, kanban boards, or `~/.lemon`.
 
 - `LemonCore.Contract` centralizes loadability and required-callback checks for
   configuration-injected implementations. `LemonCore.EngineRuntime.validate/1`
-  exposes the check used by router startup; optional callbacks remain optional.
+  exposes the check used by router startup; optional callbacks remain optional,
+  and invalid behaviour metadata returns a structured error instead of escaping
+  the validation boundary.
 - `LemonCore.A2A.Protocol`, `LemonCore.A2A.Client`, and `LemonCore.A2AStore`
   provide the generic A2A v1.0 wire helpers, credential-scrubbing HTTP client,
   and typed durable context/task/message storage shared by peer transports and

--- a/apps/lemon_core/README.md
+++ b/apps/lemon_core/README.md
@@ -1,6 +1,6 @@
 # LemonCore
 
-Foundational shared library for the Lemon umbrella project. All other apps depend on `lemon_core` -- it provides configuration management, encrypted secrets, pluggable storage, an event bus, live named-node invocation routing, session routing primitives, idempotency, execution approvals, telemetry, and quality tooling.
+Foundational shared library for the Lemon umbrella project. All other apps depend on `lemon_core` -- it provides configuration management, configured-implementation contract validation, encrypted secrets, pluggable storage, an event bus, live named-node invocation routing, session routing primitives, idempotency, execution approvals, telemetry, and quality tooling.
 
 `LemonCore.Context` is the shared versioned preview/resolve boundary for
 root-confined file and folder references, shell-free git diffs, SSRF-guarded
@@ -91,6 +91,7 @@ and `lemon_lsp`. Core doctor diagnostics may probe them at runtime, but
 | `LemonCore.Config.Logging` | Log file and rotation sub-module |
 | `LemonCore.Config.Validator` | Validation for both legacy and modular config structs |
 | `LemonCore.Config.ValidationError` | Raised by `Config.Modular.load!/1` on invalid config |
+| `LemonCore.Contract` | Validates configuration-injected modules for loadability and required behaviour callbacks |
 | `LemonCore.Config.Helpers` | Shared config parsing helpers |
 | `LemonCore.Config.TomlPatch` | Textual TOML editing for targeted key upserts |
 | `LemonCore.ConfigCache` | ETS cache with mtime/size fingerprint-based invalidation |

--- a/apps/lemon_core/lib/lemon_core.ex
+++ b/apps/lemon_core/lib/lemon_core.ex
@@ -18,6 +18,7 @@ defmodule LemonCore do
   - `LemonCore.Telemetry` - Telemetry event helpers
   - `LemonCore.Clock` - Time utilities
   - `LemonCore.Config` - Configuration access
+  - `LemonCore.Contract` - Configured implementation validation
   - `LemonCore.Setup.Readiness` - Shared first-run config/secrets/provider readiness
   """
 end

--- a/apps/lemon_core/lib/lemon_core/contract.ex
+++ b/apps/lemon_core/lib/lemon_core/contract.ex
@@ -64,12 +64,25 @@ defmodule LemonCore.Contract do
     callbacks = behaviour.behaviour_info(:callbacks)
     optional_callbacks = behaviour.behaviour_info(:optional_callbacks)
 
-    if is_list(callbacks) and is_list(optional_callbacks) do
+    if valid_callbacks?(callbacks) and valid_callbacks?(optional_callbacks) do
       {:ok, callbacks, optional_callbacks}
     else
       :error
     end
   end
+
+  defp valid_callbacks?(callbacks) when is_list(callbacks) do
+    Enum.all?(callbacks, fn
+      {function, arity}
+      when is_atom(function) and is_integer(arity) and arity >= 0 and arity <= 255 ->
+        true
+
+      _other ->
+        false
+    end)
+  end
+
+  defp valid_callbacks?(_callbacks), do: false
 
   defp loadable(module) do
     case Code.ensure_loaded(module) do

--- a/apps/lemon_core/lib/lemon_core/contract.ex
+++ b/apps/lemon_core/lib/lemon_core/contract.ex
@@ -1,0 +1,56 @@
+defmodule LemonCore.Contract do
+  @moduledoc """
+  Validates configuration-injected modules against behaviours.
+
+  Umbrella applications use module names in application configuration to
+  invert dependencies across package boundaries. `validate/2` gives those
+  seams one shared startup check: the implementation must be loadable and
+  export every required callback. Optional callbacks declared by the
+  behaviour are not required.
+
+  This validates the static shape of an implementation. Callback return
+  values and operational failures remain part of the behaviour's own runtime
+  contract.
+  """
+
+  @type callback :: {atom(), arity()}
+  @type error ::
+          {:not_a_module, term()}
+          | {:not_loadable, module()}
+          | {:missing_callbacks, module(), [callback()]}
+
+  @doc """
+  Validates that `module` is loadable and exports every required callback of
+  `behaviour`.
+  """
+  @spec validate(term(), module()) :: :ok | {:error, error()}
+  def validate(module, behaviour)
+      when is_atom(module) and not is_nil(module) and is_atom(behaviour) do
+    with :ok <- loadable(module) do
+      missing_callbacks =
+        Enum.reject(required_callbacks(behaviour), fn {function, arity} ->
+          function_exported?(module, function, arity)
+        end)
+
+      case missing_callbacks do
+        [] -> :ok
+        callbacks -> {:error, {:missing_callbacks, module, callbacks}}
+      end
+    end
+  end
+
+  def validate(other, _behaviour), do: {:error, {:not_a_module, other}}
+
+  @doc "Every callback of `behaviour` that an implementation must export."
+  @spec required_callbacks(module()) :: [callback()]
+  def required_callbacks(behaviour) when is_atom(behaviour) do
+    behaviour.behaviour_info(:callbacks) -- behaviour.behaviour_info(:optional_callbacks)
+  end
+
+  defp loadable(module) do
+    case Code.ensure_loaded(module) do
+      {:module, ^module} -> :ok
+      {:error, _reason} -> {:error, {:not_loadable, module}}
+    end
+  end
+end

--- a/apps/lemon_core/lib/lemon_core/contract.ex
+++ b/apps/lemon_core/lib/lemon_core/contract.ex
@@ -16,6 +16,7 @@ defmodule LemonCore.Contract do
   @type callback :: {atom(), arity()}
   @type error ::
           {:not_a_module, term()}
+          | {:not_a_behaviour, term()}
           | {:not_loadable, module()}
           | {:missing_callbacks, module(), [callback()]}
 
@@ -23,12 +24,18 @@ defmodule LemonCore.Contract do
   Validates that `module` is loadable and exports every required callback of
   `behaviour`.
   """
-  @spec validate(term(), module()) :: :ok | {:error, error()}
-  def validate(module, behaviour)
-      when is_atom(module) and not is_nil(module) and is_atom(behaviour) do
-    with :ok <- loadable(module) do
+  @spec validate(term(), term()) :: :ok | {:error, error()}
+  def validate(module, _behaviour) when not is_atom(module) or is_nil(module),
+    do: {:error, {:not_a_module, module}}
+
+  def validate(_module, behaviour) when not is_atom(behaviour) or is_nil(behaviour),
+    do: {:error, {:not_a_behaviour, behaviour}}
+
+  def validate(module, behaviour) do
+    with :ok <- loadable(module),
+         {:ok, required_callbacks} <- required_callbacks(behaviour) do
       missing_callbacks =
-        Enum.reject(required_callbacks(behaviour), fn {function, arity} ->
+        Enum.reject(required_callbacks, fn {function, arity} ->
           function_exported?(module, function, arity)
         end)
 
@@ -39,12 +46,29 @@ defmodule LemonCore.Contract do
     end
   end
 
-  def validate(other, _behaviour), do: {:error, {:not_a_module, other}}
+  defp required_callbacks(behaviour) do
+    with {:module, ^behaviour} <- Code.ensure_loaded(behaviour),
+         true <- function_exported?(behaviour, :behaviour_info, 1),
+         {:ok, callbacks, optional_callbacks} <- behaviour_callbacks(behaviour) do
+      {:ok, callbacks -- optional_callbacks}
+    else
+      _ -> {:error, {:not_a_behaviour, behaviour}}
+    end
+  rescue
+    _ -> {:error, {:not_a_behaviour, behaviour}}
+  catch
+    _, _ -> {:error, {:not_a_behaviour, behaviour}}
+  end
 
-  @doc "Every callback of `behaviour` that an implementation must export."
-  @spec required_callbacks(module()) :: [callback()]
-  def required_callbacks(behaviour) when is_atom(behaviour) do
-    behaviour.behaviour_info(:callbacks) -- behaviour.behaviour_info(:optional_callbacks)
+  defp behaviour_callbacks(behaviour) do
+    callbacks = behaviour.behaviour_info(:callbacks)
+    optional_callbacks = behaviour.behaviour_info(:optional_callbacks)
+
+    if is_list(callbacks) and is_list(optional_callbacks) do
+      {:ok, callbacks, optional_callbacks}
+    else
+      :error
+    end
   end
 
   defp loadable(module) do
@@ -52,5 +76,9 @@ defmodule LemonCore.Contract do
       {:module, ^module} -> :ok
       {:error, _reason} -> {:error, {:not_loadable, module}}
     end
+  rescue
+    _ -> {:error, {:not_loadable, module}}
+  catch
+    _, _ -> {:error, {:not_loadable, module}}
   end
 end

--- a/apps/lemon_core/lib/lemon_core/engine_runtime.ex
+++ b/apps/lemon_core/lib/lemon_core/engine_runtime.ex
@@ -23,16 +23,25 @@ defmodule LemonCore.EngineRuntime do
 
   ## Contract
 
-  Rules the callback signatures cannot express. The router defends itself
-  against all of them — every call is wrapped in `rescue`/`catch` and a
-  `function_exported?/3` guard — but a runtime that violates them degrades into
-  silent no-ops rather than errors, which is much harder to diagnose than a
-  clean `{:error, reason}`.
+  The configured module is validated against this behaviour when the router
+  starts. A module that is not loadable or lacks a required callback is
+  rejected with a structured configuration error and logged at that boundary.
+  For compatibility, a router-only node still boots in its documented
+  unavailable-runtime mode. After successful validation, required callbacks
+  are an invariant: consumers must not treat a missing callback as ordinary
+  operational unavailability or add a legacy callback fallback.
 
-    * **No callback may raise.** A raise from `c:submit_execution/1` is
-      converted to a submit failure and retried; a raise from the other three
-      is swallowed entirely, so a cancellation that raises simply does not
-      cancel.
+  Operational failures stay distinct from configuration errors. Expected
+  unavailability is a normal `false` or `{:error, reason}` return. An
+  implementation exception or exit is isolated at the owning process
+  boundary, where it must be logged and surfaced as that operation's
+  documented error or degraded result rather than escaping and crashing the
+  owner.
+
+    * **No callback should raise or exit.** `c:submit_execution/1` failures are
+      surfaced as submit errors. Liveness, lookup and cancellation failures
+      are isolated by the owning process and degrade according to the callback
+      documentation below.
     * **`c:submit_execution/1` is asynchronous.** `:ok` means *accepted*, not
       *finished*. Progress, output and completion travel back over the bus as
       run events keyed by the command's `run_id`; the return value carries no
@@ -50,21 +59,21 @@ defmodule LemonCore.EngineRuntime do
   ## Degradation
 
   Unavailability is a normal state, not a failure. When `c:available?/0`
-  returns `false`, when the configured module is not loadable, or when no
-  runtime is configured at all, the run process does not drop the run: it
-  re-arms `:submit_to_gateway` with exponential backoff and keeps the run
-  parked until a runtime shows up. A router-only node therefore boots and
-  queues work rather than crashing, and a gateway restart is absorbed.
+  returns `false`, or when no runtime is configured, the run process parks the
+  run and retries with exponential backoff. A router-only node therefore boots
+  and queues work rather than crashing, and a gateway restart is absorbed.
+  Persistent unavailability is bounded by the run's pre-start admission
+  deadline and then surfaced through its structured completion path.
 
   The same backoff handles `{:error, reason}` from `c:submit_execution/1`, and
-  it never gives up. Return `{:error, reason}` for a rejection the runtime
-  expects to outlive (a full queue, a locked engine); a permanently invalid
-  command will be retried forever, so reject those by completing the run with
-  an error event instead.
+  is bounded by that same deadline. Return `{:error, reason}` for a rejection
+  the runtime expects to outlive (a full queue, a locked engine); reject a
+  permanently invalid command by completing the run with an error event
+  instead of relying on retries.
 
-  For a runtime that predates `c:available?/0` and does not export it, the
-  router falls back to `GenServer.whereis/1` on the module name — implement the
-  callback rather than relying on that.
+  A runtime missing `c:available?/0` or any other required callback fails
+  startup validation. Missing callbacks are configuration errors, not a
+  degraded operational state.
 
   ## Cancellation reasons
 
@@ -124,6 +133,18 @@ defmodule LemonCore.EngineRuntime do
   alias LemonCore.ExecutionCommand
 
   @doc """
+  Validates that `module` is loadable and implements every required callback
+  of this behaviour.
+
+  The router runs this check for its configured runtime during startup.
+  Successful validation establishes that missing callbacks are impossible for
+  that configured module. An absent runtime remains a separately supported
+  router-only mode.
+  """
+  @spec validate(term()) :: :ok | {:error, LemonCore.Contract.error()}
+  def validate(module), do: LemonCore.Contract.validate(module, __MODULE__)
+
+  @doc """
   Accept a command for execution.
 
   `:ok` (or `{:ok, term}`, which the router treats identically) means the
@@ -136,7 +157,8 @@ defmodule LemonCore.EngineRuntime do
   different shape converts it into its own request type rather than pushing
   that type back across the boundary.
   """
-  @callback submit_execution(ExecutionCommand.t()) :: :ok | {:error, term()}
+  @callback submit_execution(ExecutionCommand.t()) ::
+              :ok | {:ok, term()} | {:error, term()}
 
   @doc """
   Cancel the run with this id, for this reason.
@@ -147,7 +169,9 @@ defmodule LemonCore.EngineRuntime do
   has the run.
 
   Cancellation is best-effort and asynchronous: returning `:ok` means the
-  request was delivered, not that the run has stopped.
+  request was delivered, not that the run has stopped. An implementation
+  exception or exit violates the contract; the owning process isolates and
+  records it, then preserves best-effort cancellation semantics.
   """
   @callback cancel_by_run_id(binary(), term()) :: :ok
 
@@ -157,7 +181,9 @@ defmodule LemonCore.EngineRuntime do
   Used by the router to decide whether cancelling is worth attempting and to
   monitor the executing process so a runtime crash is noticed promptly. Return
   `nil` for unknown, finished or queued-but-not-started runs; a pid the router
-  monitors should be one whose death really means the run is over.
+  monitors should be one whose death really means the run is over. An
+  implementation exception or exit violates the contract; the owning process
+  isolates and records it and treats the lookup as unknown (`nil`).
   """
   @callback run_pid(binary()) :: pid() | nil
 
@@ -169,6 +195,9 @@ defmodule LemonCore.EngineRuntime do
   makes this the right answer for "the runtime is down or still starting" and
   the wrong one for "the runtime is busy" — backpressure belongs in the
   runtime's own queue, where it can be reported and observed.
+
+  An implementation exception or exit violates the contract; the owning
+  process isolates and records it and treats the runtime as unavailable.
   """
   @callback available?() :: boolean()
 end

--- a/apps/lemon_core/lib/lemon_core/engine_runtime.ex
+++ b/apps/lemon_core/lib/lemon_core/engine_runtime.ex
@@ -25,23 +25,23 @@ defmodule LemonCore.EngineRuntime do
 
   The configured module is validated against this behaviour when the router
   starts. A module that is not loadable or lacks a required callback is
-  rejected with a structured configuration error and logged at that boundary.
-  For compatibility, a router-only node still boots in its documented
-  unavailable-runtime mode. After successful validation, required callbacks
-  are an invariant: consumers must not treat a missing callback as ordinary
-  operational unavailability or add a legacy callback fallback.
+  rejected with a structured configuration error, logged once and disabled at
+  that boundary. For compatibility, a router-only node still boots in its
+  documented unavailable-runtime mode.
 
   Operational failures stay distinct from configuration errors. Expected
   unavailability is a normal `false` or `{:error, reason}` return. An
-  implementation exception or exit is isolated at the owning process
-  boundary, where it must be logged and surfaced as that operation's
-  documented error or degraded result rather than escaping and crashing the
-  owner.
+  implementation exception is isolated at the owning process boundary and
+  converted to that operation's documented error or degraded result. A
+  non-local exit is converted into a submit error by `c:submit_execution/1`'s
+  caller, but exits from the other callbacks can escape; implementations must
+  not exit their callers.
 
-    * **No callback should raise or exit.** `c:submit_execution/1` failures are
-      surfaced as submit errors. Liveness, lookup and cancellation failures
-      are isolated by the owning process and degrade according to the callback
-      documentation below.
+    * **No callback should raise or exit.** `c:submit_execution/1` exceptions
+      and exits are surfaced as submit errors. Liveness, lookup and
+      cancellation exceptions are isolated by the owning process and degrade
+      according to the callback documentation below; exits from those three
+      callbacks violate the owning-process boundary and can terminate it.
     * **`c:submit_execution/1` is asynchronous.** `:ok` means *accepted*, not
       *finished*. Progress, output and completion travel back over the bus as
       run events keyed by the command's `run_id`; the return value carries no
@@ -170,8 +170,9 @@ defmodule LemonCore.EngineRuntime do
 
   Cancellation is best-effort and asynchronous: returning `:ok` means the
   request was delivered, not that the run has stopped. An implementation
-  exception or exit violates the contract; the owning process isolates and
-  records it, then preserves best-effort cancellation semantics.
+  exception violates the contract; the owning process isolates it and
+  preserves best-effort cancellation semantics. An exit can escape that
+  boundary and must not be used to report cancellation failure.
   """
   @callback cancel_by_run_id(binary(), term()) :: :ok
 
@@ -182,8 +183,9 @@ defmodule LemonCore.EngineRuntime do
   monitor the executing process so a runtime crash is noticed promptly. Return
   `nil` for unknown, finished or queued-but-not-started runs; a pid the router
   monitors should be one whose death really means the run is over. An
-  implementation exception or exit violates the contract; the owning process
-  isolates and records it and treats the lookup as unknown (`nil`).
+  implementation exception violates the contract; the owning process isolates
+  it and treats the lookup as unknown (`nil`). An exit can escape that boundary
+  and must not be used to report an unknown run.
   """
   @callback run_pid(binary()) :: pid() | nil
 
@@ -196,8 +198,9 @@ defmodule LemonCore.EngineRuntime do
   the wrong one for "the runtime is busy" — backpressure belongs in the
   runtime's own queue, where it can be reported and observed.
 
-  An implementation exception or exit violates the contract; the owning
-  process isolates and records it and treats the runtime as unavailable.
+  An implementation exception violates the contract; the owning process
+  isolates it and treats the runtime as unavailable. An exit can escape that
+  boundary and must not be used to report unavailability.
   """
   @callback available?() :: boolean()
 end

--- a/apps/lemon_core/test/lemon_core/contract_test.exs
+++ b/apps/lemon_core/test/lemon_core/contract_test.exs
@@ -20,9 +20,16 @@ defmodule LemonCore.ContractTest do
     def unrelated, do: :ok
   end
 
+  defmodule RaisingBehaviourInfo do
+    def behaviour_info(_kind), do: raise("broken behaviour metadata")
+  end
+
+  defmodule ExitingBehaviourInfo do
+    def behaviour_info(_kind), do: exit(:broken_behaviour_metadata)
+  end
+
   test "accepts a loadable module with all required callbacks" do
     assert Contract.validate(GreeterImplementation, Greeter) == :ok
-    assert Contract.required_callbacks(Greeter) == [hello: 0]
   end
 
   test "does not require optional callbacks" do
@@ -41,6 +48,26 @@ defmodule LemonCore.ContractTest do
 
     assert Contract.validate("runtime", Greeter) == {:error, {:not_a_module, "runtime"}}
     assert Contract.validate(nil, Greeter) == {:error, {:not_a_module, nil}}
+  end
+
+  test "rejects invalid behaviour inputs without raising" do
+    assert Contract.validate(GreeterImplementation, nil) ==
+             {:error, {:not_a_behaviour, nil}}
+
+    assert Contract.validate(GreeterImplementation, "greeter") ==
+             {:error, {:not_a_behaviour, "greeter"}}
+
+    assert Contract.validate(GreeterImplementation, No.Such.Behaviour) ==
+             {:error, {:not_a_behaviour, No.Such.Behaviour}}
+
+    assert Contract.validate(GreeterImplementation, String) ==
+             {:error, {:not_a_behaviour, String}}
+
+    assert Contract.validate(GreeterImplementation, RaisingBehaviourInfo) ==
+             {:error, {:not_a_behaviour, RaisingBehaviourInfo}}
+
+    assert Contract.validate(GreeterImplementation, ExitingBehaviourInfo) ==
+             {:error, {:not_a_behaviour, ExitingBehaviourInfo}}
   end
 
   test "EngineRuntime.validate/1 reports its complete required surface" do

--- a/apps/lemon_core/test/lemon_core/contract_test.exs
+++ b/apps/lemon_core/test/lemon_core/contract_test.exs
@@ -28,6 +28,36 @@ defmodule LemonCore.ContractTest do
     def behaviour_info(_kind), do: exit(:broken_behaviour_metadata)
   end
 
+  defmodule NonTupleCallbackBehaviourInfo do
+    def behaviour_info(:callbacks), do: [:hello]
+    def behaviour_info(:optional_callbacks), do: []
+  end
+
+  defmodule InvalidFunctionBehaviourInfo do
+    def behaviour_info(:callbacks), do: [{"hello", 0}]
+    def behaviour_info(:optional_callbacks), do: []
+  end
+
+  defmodule NonIntegerArityBehaviourInfo do
+    def behaviour_info(:callbacks), do: [{:hello, "0"}]
+    def behaviour_info(:optional_callbacks), do: []
+  end
+
+  defmodule NegativeArityBehaviourInfo do
+    def behaviour_info(:callbacks), do: [{:hello, -1}]
+    def behaviour_info(:optional_callbacks), do: []
+  end
+
+  defmodule OutOfRangeArityBehaviourInfo do
+    def behaviour_info(:callbacks), do: [{:hello, 256}]
+    def behaviour_info(:optional_callbacks), do: []
+  end
+
+  defmodule MalformedOptionalCallbacksBehaviourInfo do
+    def behaviour_info(:callbacks), do: [hello: 0]
+    def behaviour_info(:optional_callbacks), do: [{:goodbye, nil}]
+  end
+
   test "accepts a loadable module with all required callbacks" do
     assert Contract.validate(GreeterImplementation, Greeter) == :ok
   end
@@ -68,6 +98,20 @@ defmodule LemonCore.ContractTest do
 
     assert Contract.validate(GreeterImplementation, ExitingBehaviourInfo) ==
              {:error, {:not_a_behaviour, ExitingBehaviourInfo}}
+  end
+
+  test "rejects malformed callback metadata without raising" do
+    for behaviour <- [
+          NonTupleCallbackBehaviourInfo,
+          InvalidFunctionBehaviourInfo,
+          NonIntegerArityBehaviourInfo,
+          NegativeArityBehaviourInfo,
+          OutOfRangeArityBehaviourInfo,
+          MalformedOptionalCallbacksBehaviourInfo
+        ] do
+      assert Contract.validate(GreeterImplementation, behaviour) ==
+               {:error, {:not_a_behaviour, behaviour}}
+    end
   end
 
   test "EngineRuntime.validate/1 reports its complete required surface" do

--- a/apps/lemon_core/test/lemon_core/contract_test.exs
+++ b/apps/lemon_core/test/lemon_core/contract_test.exs
@@ -1,0 +1,57 @@
+defmodule LemonCore.ContractTest do
+  use ExUnit.Case, async: true
+
+  alias LemonCore.Contract
+
+  defmodule Greeter do
+    @callback hello() :: String.t()
+    @callback goodbye() :: String.t()
+    @optional_callbacks goodbye: 0
+  end
+
+  defmodule GreeterImplementation do
+    @behaviour Greeter
+
+    @impl true
+    def hello, do: "hello"
+  end
+
+  defmodule IncompleteImplementation do
+    def unrelated, do: :ok
+  end
+
+  test "accepts a loadable module with all required callbacks" do
+    assert Contract.validate(GreeterImplementation, Greeter) == :ok
+    assert Contract.required_callbacks(Greeter) == [hello: 0]
+  end
+
+  test "does not require optional callbacks" do
+    refute function_exported?(GreeterImplementation, :goodbye, 0)
+    assert Contract.validate(GreeterImplementation, Greeter) == :ok
+  end
+
+  test "reports every missing required callback" do
+    assert Contract.validate(IncompleteImplementation, Greeter) ==
+             {:error, {:missing_callbacks, IncompleteImplementation, [hello: 0]}}
+  end
+
+  test "rejects unloadable and non-module implementation values" do
+    assert Contract.validate(No.Such.Module, Greeter) ==
+             {:error, {:not_loadable, No.Such.Module}}
+
+    assert Contract.validate("runtime", Greeter) == {:error, {:not_a_module, "runtime"}}
+    assert Contract.validate(nil, Greeter) == {:error, {:not_a_module, nil}}
+  end
+
+  test "EngineRuntime.validate/1 reports its complete required surface" do
+    assert {:error, {:missing_callbacks, IncompleteImplementation, missing_callbacks}} =
+             LemonCore.EngineRuntime.validate(IncompleteImplementation)
+
+    assert Enum.sort(missing_callbacks) == [
+             available?: 0,
+             cancel_by_run_id: 2,
+             run_pid: 1,
+             submit_execution: 1
+           ]
+  end
+end

--- a/apps/lemon_router/AGENTS.md
+++ b/apps/lemon_router/AGENTS.md
@@ -118,6 +118,10 @@ class/name, status, reason, message, and validation errors.
 
 ## Config Contract
 
+- `LemonRouter.Application` validates a configured `:engine_runtime` through
+  `LemonCore.EngineRuntime.validate/1` at startup. Invalid wiring is logged,
+  while router-only boot and existing unavailable-runtime handling remain
+  supported.
 - Default model and thinking level live in config (`[defaults]`) as defaults only.
 - Current per-session/per-route/per-chat values are runtime policy/state managed by `LemonCore.PolicyStore`, not config.
 - Direct `Application.get_env(:lemon_router, :default_model)`, `Application.get_env(:lemon_router, :agent_policies)`, and `Application.get_env(:lemon_router, :runtime_policy)` reads are forbidden in runtime modules. These values must come from config defaults or `PolicyStore`.

--- a/apps/lemon_router/AGENTS.md
+++ b/apps/lemon_router/AGENTS.md
@@ -119,9 +119,9 @@ class/name, status, reason, message, and validation errors.
 ## Config Contract
 
 - `LemonRouter.Application` validates a configured `:engine_runtime` through
-  `LemonCore.EngineRuntime.validate/1` at startup. Invalid wiring is logged,
-  while router-only boot and existing unavailable-runtime handling remain
-  supported.
+  `LemonCore.EngineRuntime.validate/1` at startup. Invalid wiring is logged and
+  disabled, while router-only boot and existing unavailable-runtime handling
+  remain supported.
 - Default model and thinking level live in config (`[defaults]`) as defaults only.
 - Current per-session/per-route/per-chat values are runtime policy/state managed by `LemonCore.PolicyStore`, not config.
 - Direct `Application.get_env(:lemon_router, :default_model)`, `Application.get_env(:lemon_router, :agent_policies)`, and `Application.get_env(:lemon_router, :runtime_policy)` reads are forbidden in runtime modules. These values must come from config defaults or `PolicyStore`.

--- a/apps/lemon_router/CHANGELOG.md
+++ b/apps/lemon_router/CHANGELOG.md
@@ -12,6 +12,10 @@ internals other applications reached into.
 
 ### Added
 
+- Startup validates a configured engine-runtime module through
+  `LemonCore.EngineRuntime.validate/1` and logs invalid wiring once. A missing
+  or invalid runtime still leaves the router available and follows its existing
+  unavailable-runtime behavior.
 - `LemonRouter` is the supported API surface: `submit/1`, `abort/2`,
   `abort_run/2`, plus the new `available?/0`, `active_runs/0`, `run_active?/1`,
   `active_run_count/0` and `counts/0`. These were designed from the thirteen

--- a/apps/lemon_router/CHANGELOG.md
+++ b/apps/lemon_router/CHANGELOG.md
@@ -13,9 +13,9 @@ internals other applications reached into.
 ### Added
 
 - Startup validates a configured engine-runtime module through
-  `LemonCore.EngineRuntime.validate/1` and logs invalid wiring once. A missing
-  or invalid runtime still leaves the router available and follows its existing
-  unavailable-runtime behavior.
+  `LemonCore.EngineRuntime.validate/1`, logs invalid wiring once, and disables
+  the invalid binding. A missing or invalid runtime still leaves the router
+  available and follows its existing unavailable-runtime behavior.
 - `LemonRouter` is the supported API surface: `submit/1`, `abort/2`,
   `abort_run/2`, plus the new `available?/0`, `active_runs/0`, `run_active?/1`,
   `active_run_count/0` and `counts/0`. These were designed from the thirteen

--- a/apps/lemon_router/README.md
+++ b/apps/lemon_router/README.md
@@ -72,9 +72,10 @@ attachment policy.
 ## Important Contracts
 
 - Router startup validates the configured `:engine_runtime` through
-  `LemonCore.EngineRuntime.validate/1`. Invalid wiring is logged once without
-  changing the router-only degraded mode: the router still boots and runtime
-  operations retain their existing unavailable-runtime handling.
+  `LemonCore.EngineRuntime.validate/1`. Invalid wiring is logged once and its
+  binding is disabled without changing the router-only degraded mode: the
+  router still boots and runtime operations retain their existing
+  unavailable-runtime handling.
 - Inbound callers should provide structured resume data through `LemonCore.RunRequest.resume` when they already know it.
 - Top-level runs always use the native executor; model validation belongs to `LemonAi`, and default cwd resolution should use `LemonCore.Cwd`.
 - Router emits `LemonCore.DeliveryIntent`, not `LemonChannels.OutboundPayload`.

--- a/apps/lemon_router/README.md
+++ b/apps/lemon_router/README.md
@@ -71,6 +71,10 @@ attachment policy.
 
 ## Important Contracts
 
+- Router startup validates the configured `:engine_runtime` through
+  `LemonCore.EngineRuntime.validate/1`. Invalid wiring is logged once without
+  changing the router-only degraded mode: the router still boots and runtime
+  operations retain their existing unavailable-runtime handling.
 - Inbound callers should provide structured resume data through `LemonCore.RunRequest.resume` when they already know it.
 - Top-level runs always use the native executor; model validation belongs to `LemonAi`, and default cwd resolution should use `LemonCore.Cwd`.
 - Router emits `LemonCore.DeliveryIntent`, not `LemonChannels.OutboundPayload`.

--- a/apps/lemon_router/lib/lemon_router/application.ex
+++ b/apps/lemon_router/lib/lemon_router/application.ex
@@ -8,6 +8,8 @@ defmodule LemonRouter.Application do
 
   @impl true
   def start(_type, _args) do
+    _ = LemonRouter.EngineRuntimeConfiguration.validate_configured()
+
     children =
       [
         # Agent profiles configuration

--- a/apps/lemon_router/lib/lemon_router/engine_runtime_configuration.ex
+++ b/apps/lemon_router/lib/lemon_router/engine_runtime_configuration.ex
@@ -1,0 +1,28 @@
+defmodule LemonRouter.EngineRuntimeConfiguration do
+  @moduledoc false
+
+  require Logger
+
+  @spec validate_configured() :: :ok | {:error, LemonCore.Contract.error()}
+  def validate_configured do
+    module = Application.get_env(:lemon_router, :engine_runtime)
+
+    case validate(module) do
+      :ok ->
+        :ok
+
+      {:error, reason} = error ->
+        Logger.error(
+          "configured :engine_runtime #{inspect(module)} does not implement " <>
+            "LemonCore.EngineRuntime (#{inspect(reason)}); runtime operations will remain " <>
+            "unavailable until a valid runtime is configured"
+        )
+
+        error
+    end
+  end
+
+  @spec validate(term()) :: :ok | {:error, LemonCore.Contract.error()}
+  def validate(nil), do: :ok
+  def validate(module), do: LemonCore.EngineRuntime.validate(module)
+end

--- a/apps/lemon_router/lib/lemon_router/engine_runtime_configuration.ex
+++ b/apps/lemon_router/lib/lemon_router/engine_runtime_configuration.ex
@@ -14,10 +14,11 @@ defmodule LemonRouter.EngineRuntimeConfiguration do
       {:error, reason} = error ->
         Logger.error(
           "configured :engine_runtime #{inspect(module)} does not implement " <>
-            "LemonCore.EngineRuntime (#{inspect(reason)}); runtime operations will remain " <>
-            "unavailable until a valid runtime is configured"
+            "LemonCore.EngineRuntime (#{inspect(reason)}); disabling the invalid binding so " <>
+            "runtime operations use the supported unavailable-runtime path"
         )
 
+        Application.delete_env(:lemon_router, :engine_runtime)
         error
     end
   end

--- a/apps/lemon_router/test/lemon_router/engine_runtime_configuration_test.exs
+++ b/apps/lemon_router/test/lemon_router/engine_runtime_configuration_test.exs
@@ -26,13 +26,12 @@ defmodule LemonRouter.EngineRuntimeConfigurationTest do
   end
 
   setup do
-    original_runtime = Application.get_env(:lemon_router, :engine_runtime)
+    original_runtime = Application.fetch_env(:lemon_router, :engine_runtime)
 
     on_exit(fn ->
-      if original_runtime do
-        Application.put_env(:lemon_router, :engine_runtime, original_runtime)
-      else
-        Application.delete_env(:lemon_router, :engine_runtime)
+      case original_runtime do
+        {:ok, runtime} -> Application.put_env(:lemon_router, :engine_runtime, runtime)
+        :error -> Application.delete_env(:lemon_router, :engine_runtime)
       end
     end)
   end
@@ -43,6 +42,13 @@ defmodule LemonRouter.EngineRuntimeConfigurationTest do
 
   test "accepts a runtime implementing the complete configured contract" do
     assert EngineRuntimeConfiguration.validate(Runtime) == :ok
+  end
+
+  test "the startup boundary preserves a valid configured runtime" do
+    Application.put_env(:lemon_router, :engine_runtime, Runtime)
+
+    assert EngineRuntimeConfiguration.validate_configured() == :ok
+    assert Application.fetch_env(:lemon_router, :engine_runtime) == {:ok, Runtime}
   end
 
   test "rejects an invalid configured runtime with structured details" do
@@ -70,6 +76,7 @@ defmodule LemonRouter.EngineRuntimeConfigurationTest do
 
     assert log =~ "configured :engine_runtime #{inspect(IncompleteRuntime)}"
     assert log =~ "does not implement LemonCore.EngineRuntime"
-    assert log =~ "runtime operations will remain unavailable"
+    assert log =~ "disabling the invalid binding"
+    assert Application.fetch_env(:lemon_router, :engine_runtime) == :error
   end
 end

--- a/apps/lemon_router/test/lemon_router/engine_runtime_configuration_test.exs
+++ b/apps/lemon_router/test/lemon_router/engine_runtime_configuration_test.exs
@@ -1,0 +1,75 @@
+defmodule LemonRouter.EngineRuntimeConfigurationTest do
+  use ExUnit.Case, async: false
+
+  alias LemonRouter.EngineRuntimeConfiguration
+
+  import ExUnit.CaptureLog
+
+  defmodule Runtime do
+    @behaviour LemonCore.EngineRuntime
+
+    @impl true
+    def submit_execution(_command), do: :ok
+
+    @impl true
+    def cancel_by_run_id(_run_id, _reason), do: :ok
+
+    @impl true
+    def run_pid(_run_id), do: nil
+
+    @impl true
+    def available?, do: true
+  end
+
+  defmodule IncompleteRuntime do
+    def available?, do: true
+  end
+
+  setup do
+    original_runtime = Application.get_env(:lemon_router, :engine_runtime)
+
+    on_exit(fn ->
+      if original_runtime do
+        Application.put_env(:lemon_router, :engine_runtime, original_runtime)
+      else
+        Application.delete_env(:lemon_router, :engine_runtime)
+      end
+    end)
+  end
+
+  test "accepts an absent runtime for router-only startup" do
+    assert EngineRuntimeConfiguration.validate(nil) == :ok
+  end
+
+  test "accepts a runtime implementing the complete configured contract" do
+    assert EngineRuntimeConfiguration.validate(Runtime) == :ok
+  end
+
+  test "rejects an invalid configured runtime with structured details" do
+    assert {:error, {:missing_callbacks, IncompleteRuntime, missing_callbacks}} =
+             EngineRuntimeConfiguration.validate(IncompleteRuntime)
+
+    assert Enum.sort(missing_callbacks) == [
+             cancel_by_run_id: 2,
+             run_pid: 1,
+             submit_execution: 1
+           ]
+
+    assert EngineRuntimeConfiguration.validate("runtime") ==
+             {:error, {:not_a_module, "runtime"}}
+  end
+
+  test "the startup boundary reports invalid configured wiring once" do
+    Application.put_env(:lemon_router, :engine_runtime, IncompleteRuntime)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:missing_callbacks, IncompleteRuntime, _missing_callbacks}} =
+                 EngineRuntimeConfiguration.validate_configured()
+      end)
+
+    assert log =~ "configured :engine_runtime #{inspect(IncompleteRuntime)}"
+    assert log =~ "does not implement LemonCore.EngineRuntime"
+    assert log =~ "runtime operations will remain unavailable"
+  end
+end

--- a/apps/lemon_router/test/lemon_router/engine_runtime_configuration_test.exs
+++ b/apps/lemon_router/test/lemon_router/engine_runtime_configuration_test.exs
@@ -79,4 +79,23 @@ defmodule LemonRouter.EngineRuntimeConfigurationTest do
     assert log =~ "disabling the invalid binding"
     assert Application.fetch_env(:lemon_router, :engine_runtime) == :error
   end
+
+  test "the router application startup validates and removes an invalid runtime binding" do
+    on_exit(fn ->
+      {:ok, _started} = Application.ensure_all_started(:lemon_router)
+    end)
+
+    assert :ok = Application.stop(:lemon_router)
+    Application.put_env(:lemon_router, :engine_runtime, IncompleteRuntime)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, started} = Application.ensure_all_started(:lemon_router)
+        assert :lemon_router in started
+      end)
+
+    assert log =~ "configured :engine_runtime #{inspect(IncompleteRuntime)}"
+    assert log =~ "disabling the invalid binding"
+    assert Application.fetch_env(:lemon_router, :engine_runtime) == :error
+  end
 end

--- a/apps/lemon_router/test/lemon_router/run_process_test.exs
+++ b/apps/lemon_router/test/lemon_router/run_process_test.exs
@@ -119,6 +119,27 @@ defmodule LemonRouter.RunProcessTest do
     end
   end
 
+  defmodule TupleAcceptingRuntime do
+    @moduledoc false
+    @behaviour LemonCore.EngineRuntime
+
+    @impl true
+    def available?, do: true
+
+    @impl true
+    def submit_execution(%LemonCore.ExecutionCommand{} = request) do
+      pid = :persistent_term.get({__MODULE__, :notify_pid}, nil)
+      if is_pid(pid), do: send(pid, {:tuple_accepting_runtime_submit, request})
+      {:ok, %{accepted: true}}
+    end
+
+    @impl true
+    def cancel_by_run_id(_run_id, _reason), do: :ok
+
+    @impl true
+    def run_pid(_run_id), do: nil
+  end
+
   defmodule TestRunOrchestrator do
     @moduledoc false
     use GenServer
@@ -530,6 +551,41 @@ defmodule LemonRouter.RunProcessTest do
   end
 
   describe ":submit_to_gateway retry/backoff" do
+    test "treats an {:ok, term} runtime response as an accepted submission" do
+      run_id = "run_#{System.unique_integer([:positive])}"
+      session_key = SessionKey.main("test-agent")
+      job = make_test_request(run_id)
+
+      :persistent_term.put({TupleAcceptingRuntime, :notify_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({TupleAcceptingRuntime, :notify_pid})
+      end)
+
+      assert {:ok, pid} =
+               RunProcess.start_link(%{
+                 run_id: run_id,
+                 session_key: session_key,
+                 execution_request: job,
+                 engine_runtime: TupleAcceptingRuntime
+               })
+
+      assert_receive {:tuple_accepting_runtime_submit,
+                      %LemonCore.ExecutionCommand{
+                        run_id: ^run_id,
+                        session_key: ^session_key
+                      }},
+                     500
+
+      assert eventually(fn ->
+               state = :sys.get_state(pid)
+               state.gateway_submitted? and state.gateway_submit_attempt == 0
+             end)
+
+      refute_receive {:tuple_accepting_runtime_submit, _request}, 150
+      GenServer.stop(pid)
+    end
+
     test "terminalizes exactly once when runtime submission never succeeds" do
       run_id = "run_#{System.unique_integer([:positive])}"
       session_key = SessionKey.main("test-agent")


### PR DESCRIPTION
Extracts configured-contract validation from PR #37 without changing RouterBridge or runtime return shapes.

What changed:
- adds `LemonCore.Contract` for loadability and required-callback validation
- makes contract validation total over malformed callback metadata, including malformed tuples, function names, optional callbacks, and invalid arities
- adds `LemonCore.EngineRuntime.validate/1`
- validates the configured runtime before the router supervisor starts
- reports invalid wiring once with a structured reason while preserving supported router-only/degraded startup
- documents the startup boundary and compatibility behavior
- adds direct regressions for actual Router application startup and `RunProcess` acceptance of `{:ok, term}`

Validation:
- LemonCore contract tests — 7 passed
- focused router runtime-configuration + RunProcess tests — 56 passed
- full LemonCore — 2,228 tests, 51 doctests, 19 properties; 0 failures, 3 excluded
- full LemonRouter — 501 tests, 1 property; 0 failures
- startup-hook mutation proof — deleting the validation call produces the expected 1-test failure
- `LEMON_GATEWAY_ENABLE_A2A=false mix lemon.quality`
- `mix format --check-formatted`
- `git diff --check`

This PR intentionally preserves existing public return shapes. The truthful RouterBridge API migration is being handled separately with all callers and changelog treatment.
