### PR TITLE
Encapsulate coding session subsystem state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [CalVer](https://calver.org/) — `YYYY.MM.PATCH`.
 
 ## [Unreleased]
 
+### Changed
+
+- `CodingAgent.Session` now keeps heartbeat, automatic-compaction, and
+  overflow-recovery bookkeeping in state structs owned by those subsystems
+  instead of twenty loose session fields. Public APIs, emitted events, and
+  the persisted session format are unchanged.
+
 ### Fixed
 
 - Hermes skill install/update requests no longer block their own control-plane

--- a/apps/coding_agent/lib/coding_agent/session.ex
+++ b/apps/coding_agent/lib/coding_agent/session.ex
@@ -101,12 +101,6 @@ defmodule CodingAgent.Session do
     :context_frozen,
     :is_streaming,
     :pending_prompt_timer_ref,
-    :heartbeat,
-    :heartbeat_due,
-    :heartbeat_timer_ref,
-    :heartbeat_timer_token,
-    :heartbeat_idle_timer_ref,
-    :heartbeat_idle_token,
     :event_listeners,
     :event_streams,
     :abort_signal,
@@ -130,20 +124,9 @@ defmodule CodingAgent.Session do
     :wasm_sidecar_pid,
     :wasm_tool_names,
     :wasm_status,
-    :auto_compaction_in_progress,
-    :auto_compaction_signature,
-    :auto_compaction_task_pid,
-    :auto_compaction_task_monitor_ref,
-    :auto_compaction_task_timeout_ref,
-    :overflow_recovery_in_progress,
-    :overflow_recovery_attempted,
-    :overflow_recovery_signature,
-    :overflow_recovery_task_pid,
-    :overflow_recovery_task_monitor_ref,
-    :overflow_recovery_task_timeout_ref,
-    :overflow_recovery_started_at_ms,
-    :overflow_recovery_error_reason,
-    :overflow_recovery_partial_state
+    heartbeat: %Heartbeat.State{},
+    auto_compaction: %CompactionLifecycle.State{},
+    overflow_recovery: %OverflowRecovery.State{}
   ]
 
   @type session_signature ::
@@ -172,12 +155,7 @@ defmodule CodingAgent.Session do
           context_frozen: boolean(),
           is_streaming: boolean(),
           pending_prompt_timer_ref: reference() | nil,
-          heartbeat: Heartbeat.t() | nil,
-          heartbeat_due: boolean(),
-          heartbeat_timer_ref: reference() | nil,
-          heartbeat_timer_token: reference() | nil,
-          heartbeat_idle_timer_ref: reference() | nil,
-          heartbeat_idle_token: reference() | nil,
+          heartbeat: Heartbeat.State.t(),
           event_listeners: [{pid(), reference()}],
           event_streams: %{reference() => %{pid: pid(), stream: pid()}},
           abort_signal: reference() | nil,
@@ -201,20 +179,8 @@ defmodule CodingAgent.Session do
           wasm_sidecar_pid: pid() | nil,
           wasm_tool_names: [String.t()],
           wasm_status: map() | nil,
-          auto_compaction_in_progress: boolean(),
-          auto_compaction_signature: session_signature() | nil,
-          auto_compaction_task_pid: pid() | nil,
-          auto_compaction_task_monitor_ref: reference() | nil,
-          auto_compaction_task_timeout_ref: reference() | nil,
-          overflow_recovery_in_progress: boolean(),
-          overflow_recovery_attempted: boolean(),
-          overflow_recovery_signature: session_signature() | nil,
-          overflow_recovery_task_pid: pid() | nil,
-          overflow_recovery_task_monitor_ref: reference() | nil,
-          overflow_recovery_task_timeout_ref: reference() | nil,
-          overflow_recovery_started_at_ms: non_neg_integer() | nil,
-          overflow_recovery_error_reason: term() | nil,
-          overflow_recovery_partial_state: term() | nil
+          auto_compaction: CompactionLifecycle.State.t(),
+          overflow_recovery: OverflowRecovery.State.t()
         }
 
   @type event_handler_callbacks :: %{
@@ -1162,7 +1128,7 @@ defmodule CodingAgent.Session do
     # Stripped here, before the recovery branch, for the same reason the clause
     # below strips: everything this event reaches is a record of the
     # conversation. That includes the copy overflow recovery parks in
-    # `overflow_recovery_partial_state` and re-broadcasts if the retry also
+    # `overflow_recovery.partial_state` and re-broadcasts if the retry also
     # fails, which is why the strip has to happen above the branch and not
     # inside the `:no_recovery` arm.
     {:error, reason, partial_state} = event = strip_recalled_context_from_event(raw_event)
@@ -1207,10 +1173,10 @@ defmodule CodingAgent.Session do
 
   def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
     cond do
-      state.auto_compaction_task_monitor_ref == ref ->
+      state.auto_compaction.task_monitor_ref == ref ->
         {:noreply, CompactionManager.handle_auto_compaction_task_down(state)}
 
-      state.overflow_recovery_task_monitor_ref == ref ->
+      state.overflow_recovery.task_monitor_ref == ref ->
         {:noreply, handle_overflow_recovery_task_down(state)}
 
       true ->
@@ -1363,7 +1329,7 @@ defmodule CodingAgent.Session do
     _ =
       CompactionManager.maybe_kill_background_task(
         state,
-        state.auto_compaction_task_pid,
+        state.auto_compaction.task_pid,
         :session_terminated
       )
 
@@ -1953,18 +1919,18 @@ defmodule CodingAgent.Session do
     end
   end
 
-  defp maybe_schedule_due_heartbeat(%{heartbeat_due: true} = state),
+  defp maybe_schedule_due_heartbeat(%{heartbeat: %Heartbeat.State{due: true}} = state),
     do: Heartbeat.schedule_idle_check(state)
 
   defp maybe_schedule_due_heartbeat(state), do: state
 
-  defp maybe_dispatch_heartbeat(%{heartbeat_due: false} = state), do: state
-  defp maybe_dispatch_heartbeat(%{heartbeat: nil} = state), do: state
+  defp maybe_dispatch_heartbeat(%{heartbeat: %Heartbeat.State{due: false}} = state), do: state
+  defp maybe_dispatch_heartbeat(%{heartbeat: %Heartbeat.State{config: nil}} = state), do: state
 
   defp maybe_dispatch_heartbeat(state) do
     cond do
       state.is_streaming or not is_nil(state.pending_prompt_timer_ref) or
-        state.auto_compaction_in_progress or state.overflow_recovery_in_progress ->
+        state.auto_compaction.in_progress or state.overflow_recovery.in_progress ->
         state
 
       Heartbeat.queued_user_input?() ->
@@ -2102,7 +2068,10 @@ defmodule CodingAgent.Session do
   defp apply_compaction_result(state, result, custom_summary),
     do: CompactionLifecycle.apply_result(state, result, custom_summary, session_callbacks())
 
-  defp maybe_trigger_compaction(%__MODULE__{auto_compaction_in_progress: true} = state), do: state
+  defp maybe_trigger_compaction(
+         %__MODULE__{auto_compaction: %CompactionLifecycle.State{in_progress: true}} = state
+       ),
+       do: state
 
   @spec maybe_trigger_compaction(t()) :: t()
   defp maybe_trigger_compaction(state),

--- a/apps/coding_agent/lib/coding_agent/session/compaction_lifecycle.ex
+++ b/apps/coding_agent/lib/coding_agent/session/compaction_lifecycle.ex
@@ -7,11 +7,36 @@ defmodule CodingAgent.Session.CompactionLifecycle do
   worker is canceled and demonitoring/timer cleanup happens synchronously
   before the prompt is deferred. This keeps prompt latency independent of the
   stale worker and prevents its late result from mutating the new turn.
+
+  Its slot in the session state is one field, `auto_compaction`, holding a
+  `CodingAgent.Session.CompactionLifecycle.State`.
   """
 
   require Logger
 
   alias CodingAgent.Session.CompactionManager
+
+  defmodule State do
+    @moduledoc """
+    Auto-compaction's slot in the session state: whether a background
+    compaction is running, the session signature it captured, and the task
+    it tracks (pid, monitor, timeout timer).
+    """
+
+    @type t :: %__MODULE__{
+            in_progress: boolean(),
+            signature: CodingAgent.Session.CompactionManager.session_signature() | nil,
+            task_pid: pid() | nil,
+            task_monitor_ref: reference() | nil,
+            task_timeout_ref: reference() | nil
+          }
+
+    defstruct in_progress: false,
+              signature: nil,
+              task_pid: nil,
+              task_monitor_ref: nil,
+              task_timeout_ref: nil
+  end
 
   @type callbacks(state) :: %{
           required(:restore_messages_from_session) => (map() -> [map()]),
@@ -35,14 +60,14 @@ defmodule CodingAgent.Session.CompactionLifecycle do
   end
 
   @spec cancel_for_new_prompt(map(), callbacks(map())) :: map()
-  def cancel_for_new_prompt(%{auto_compaction_in_progress: false} = state, _callbacks),
+  def cancel_for_new_prompt(%{auto_compaction: %State{in_progress: false}} = state, _callbacks),
     do: state
 
   def cancel_for_new_prompt(state, callbacks) do
     state =
       state
       |> CompactionManager.maybe_kill_background_task(
-        state.auto_compaction_task_pid,
+        state.auto_compaction.task_pid,
         :superseded_by_prompt
       )
       |> CompactionManager.clear_auto_compaction_state()
@@ -52,8 +77,12 @@ defmodule CodingAgent.Session.CompactionLifecycle do
   end
 
   @spec maybe_trigger(map(), pid(), callbacks(map())) :: map()
-  def maybe_trigger(%{auto_compaction_in_progress: true} = state, _session_pid, _callbacks),
-    do: state
+  def maybe_trigger(
+        %{auto_compaction: %State{in_progress: true}} = state,
+        _session_pid,
+        _callbacks
+      ),
+      do: state
 
   def maybe_trigger(state, session_pid, callbacks) do
     agent_state = LemonAgent.Agent.get_state(state.agent)
@@ -106,11 +135,13 @@ defmodule CodingAgent.Session.CompactionLifecycle do
         {:ok, task_meta} ->
           %{
             state
-            | auto_compaction_in_progress: true,
-              auto_compaction_signature: signature,
-              auto_compaction_task_pid: task_meta.pid,
-              auto_compaction_task_monitor_ref: task_meta.monitor_ref,
-              auto_compaction_task_timeout_ref: task_meta.timeout_ref
+            | auto_compaction: %State{
+                in_progress: true,
+                signature: signature,
+                task_pid: task_meta.pid,
+                task_monitor_ref: task_meta.monitor_ref,
+                task_timeout_ref: task_meta.timeout_ref
+              }
           }
 
         {:error, reason} ->
@@ -126,10 +157,10 @@ defmodule CodingAgent.Session.CompactionLifecycle do
   @spec handle_result(map(), term(), {:ok, map()} | {:error, term()}, callbacks(map())) :: map()
   def handle_result(state, signature, result, callbacks) do
     cond do
-      not state.auto_compaction_in_progress ->
+      not state.auto_compaction.in_progress ->
         state
 
-      state.auto_compaction_signature != signature ->
+      state.auto_compaction.signature != signature ->
         state
 
       signature != CompactionManager.session_signature(state) ->
@@ -153,11 +184,11 @@ defmodule CodingAgent.Session.CompactionLifecycle do
 
   @spec handle_timeout(map(), reference(), callbacks(map())) :: {:handled, map()} | :stale
   def handle_timeout(state, monitor_ref, callbacks) do
-    if state.auto_compaction_task_monitor_ref == monitor_ref do
+    if state.auto_compaction.task_monitor_ref == monitor_ref do
       state =
         state
         |> CompactionManager.maybe_kill_background_task(
-          state.auto_compaction_task_pid,
+          state.auto_compaction.task_pid,
           :auto_compaction_timeout
         )
         |> CompactionManager.clear_auto_compaction_state()

--- a/apps/coding_agent/lib/coding_agent/session/compaction_manager.ex
+++ b/apps/coding_agent/lib/coding_agent/session/compaction_manager.ex
@@ -44,19 +44,22 @@ defmodule CodingAgent.Session.CompactionManager do
   @spec clear_auto_compaction_state(map()) :: map()
   def clear_auto_compaction_state(state) do
     state = clear_auto_compaction_task_tracking(state)
-    %{state | auto_compaction_in_progress: false, auto_compaction_signature: nil}
+    %{state | auto_compaction: %{state.auto_compaction | in_progress: false, signature: nil}}
   end
 
   @spec clear_auto_compaction_task_tracking(map()) :: map()
   def clear_auto_compaction_task_tracking(state) do
-    maybe_cancel_timer(state.auto_compaction_task_timeout_ref)
-    maybe_demonitor(state.auto_compaction_task_monitor_ref)
+    maybe_cancel_timer(state.auto_compaction.task_timeout_ref)
+    maybe_demonitor(state.auto_compaction.task_monitor_ref)
 
     %{
       state
-      | auto_compaction_task_pid: nil,
-        auto_compaction_task_monitor_ref: nil,
-        auto_compaction_task_timeout_ref: nil
+      | auto_compaction: %{
+          state.auto_compaction
+          | task_pid: nil,
+            task_monitor_ref: nil,
+            task_timeout_ref: nil
+        }
     }
   end
 
@@ -65,7 +68,7 @@ defmodule CodingAgent.Session.CompactionManager do
     state = clear_auto_compaction_task_tracking(state)
 
     cond do
-      not state.auto_compaction_in_progress ->
+      not state.auto_compaction.in_progress ->
         state
 
       true ->
@@ -83,32 +86,43 @@ defmodule CodingAgent.Session.CompactionManager do
 
     %{
       state
-      | overflow_recovery_in_progress: false,
-        overflow_recovery_signature: nil,
-        overflow_recovery_started_at_ms: nil
+      | overflow_recovery: %{
+          state.overflow_recovery
+          | in_progress: false,
+            signature: nil,
+            started_at_ms: nil
+        }
     }
   end
 
   @spec clear_overflow_recovery_state(map()) :: map()
   def clear_overflow_recovery_state(state) do
+    state = clear_overflow_recovery_task_state(state)
+
     %{
-      clear_overflow_recovery_task_state(state)
-      | overflow_recovery_attempted: false,
-        overflow_recovery_error_reason: nil,
-        overflow_recovery_partial_state: nil
+      state
+      | overflow_recovery: %{
+          state.overflow_recovery
+          | attempted: false,
+            error_reason: nil,
+            partial_state: nil
+        }
     }
   end
 
   @spec clear_overflow_recovery_task_tracking(map()) :: map()
   def clear_overflow_recovery_task_tracking(state) do
-    maybe_cancel_timer(state.overflow_recovery_task_timeout_ref)
-    maybe_demonitor(state.overflow_recovery_task_monitor_ref)
+    maybe_cancel_timer(state.overflow_recovery.task_timeout_ref)
+    maybe_demonitor(state.overflow_recovery.task_monitor_ref)
 
     %{
       state
-      | overflow_recovery_task_pid: nil,
-        overflow_recovery_task_monitor_ref: nil,
-        overflow_recovery_task_timeout_ref: nil
+      | overflow_recovery: %{
+          state.overflow_recovery
+          | task_pid: nil,
+            task_monitor_ref: nil,
+            task_timeout_ref: nil
+        }
     }
   end
 
@@ -117,7 +131,7 @@ defmodule CodingAgent.Session.CompactionManager do
     state = clear_overflow_recovery_task_tracking(state)
 
     cond do
-      not state.overflow_recovery_in_progress ->
+      not state.overflow_recovery.in_progress ->
         state
 
       true ->
@@ -133,7 +147,10 @@ defmodule CodingAgent.Session.CompactionManager do
 
         # Return the failed state; the caller should call finalize_overflow_recovery_failure
         # with the appropriate event handling callbacks
-        %{failed_state | overflow_recovery_error_reason: failure_reason}
+        %{
+          failed_state
+          | overflow_recovery: %{failed_state.overflow_recovery | error_reason: failure_reason}
+        }
     end
   end
 
@@ -181,7 +198,7 @@ defmodule CodingAgent.Session.CompactionManager do
 
   @spec overflow_recovery_duration_ms(map()) :: non_neg_integer() | nil
   def overflow_recovery_duration_ms(state) do
-    case state.overflow_recovery_started_at_ms do
+    case state.overflow_recovery.started_at_ms do
       started when is_integer(started) and started > 0 ->
         max(System.monotonic_time(:millisecond) - started, 0)
 

--- a/apps/coding_agent/lib/coding_agent/session/heartbeat.ex
+++ b/apps/coding_agent/lib/coding_agent/session/heartbeat.ex
@@ -9,7 +9,10 @@ defmodule CodingAgent.Session.Heartbeat do
   introducing a second scheduler or store.
 
   The session owns dispatch. This module owns state validation, persistence,
-  timer bookkeeping, and the prompt rendered when a due heartbeat fires.
+  timer bookkeeping, and the prompt rendered when a due heartbeat fires. Its
+  slot in the session state is one field, `heartbeat`, holding a
+  `CodingAgent.Session.Heartbeat.State`: the persisted configuration plus the
+  runtime timers, so the session never touches a timer reference directly.
   """
 
   require Logger
@@ -24,6 +27,30 @@ defmodule CodingAgent.Session.Heartbeat do
   @idle_defer_ms 25
   @retry_after_persist_error_ms 5_000
   @max_prompt_bytes 16_384
+
+  defmodule State do
+    @moduledoc """
+    The heartbeat's slot in the session state: the persisted configuration
+    (`config`, `nil` when no heartbeat is set), whether it is due, and the
+    timers the session process owns for it.
+    """
+
+    @type t :: %__MODULE__{
+            config: CodingAgent.Session.Heartbeat.t() | nil,
+            due: boolean(),
+            timer_ref: reference() | nil,
+            timer_token: reference() | nil,
+            idle_timer_ref: reference() | nil,
+            idle_token: reference() | nil
+          }
+
+    defstruct config: nil,
+              due: false,
+              timer_ref: nil,
+              timer_token: nil,
+              idle_timer_ref: nil,
+              idle_token: nil
+  end
 
   @typedoc "One session's persisted heartbeat configuration."
   @type t :: %{
@@ -44,8 +71,7 @@ defmodule CodingAgent.Session.Heartbeat do
   def restore(state) do
     state
     |> cancel_runtime_timers()
-    |> Map.put(:heartbeat, load(state.session_manager))
-    |> Map.put(:heartbeat_due, false)
+    |> put_config(load(state.session_manager))
     |> schedule_next()
   end
 
@@ -66,8 +92,10 @@ defmodule CodingAgent.Session.Heartbeat do
   end
 
   @doc "Return a user-facing status snapshot without exposing runtime timer refs."
-  @spec status(t() | nil, non_neg_integer()) :: map()
+  @spec status(State.t() | t() | nil, non_neg_integer()) :: map()
   def status(heartbeat, now_ms \\ now_ms())
+
+  def status(%State{config: config}, now_ms), do: status(config, now_ms)
 
   def status(nil, _now_ms) do
     %{
@@ -126,36 +154,32 @@ defmodule CodingAgent.Session.Heartbeat do
 
   @doc "Pause the heartbeat without deleting its prompt or history."
   @spec pause(map()) :: {:ok, map()} | {:error, term(), map()}
-  def pause(%{heartbeat: nil} = state), do: {:error, :not_configured, state}
+  def pause(%{heartbeat: %State{config: nil}} = state), do: {:error, :not_configured, state}
 
   def pause(state) do
-    heartbeat = %{state.heartbeat | status: :paused}
+    heartbeat = %{state.heartbeat.config | status: :paused}
     persist_and_install(state, heartbeat)
   end
 
   @doc "Resume and re-anchor the heartbeat so stale time never fires immediately."
   @spec resume(map()) :: {:ok, map()} | {:error, term(), map()}
-  def resume(%{heartbeat: nil} = state), do: {:error, :not_configured, state}
+  def resume(%{heartbeat: %State{config: nil}} = state), do: {:error, :not_configured, state}
 
   def resume(state) do
-    heartbeat = %{state.heartbeat | status: :active, last_fired_at_ms: now_ms()}
+    heartbeat = %{state.heartbeat.config | status: :active, last_fired_at_ms: now_ms()}
     persist_and_install(state, heartbeat)
   end
 
   @doc "Persist a cleared tombstone and remove the live heartbeat."
   @spec clear(map()) :: {:ok, map()} | {:error, term(), map()}
-  def clear(%{heartbeat: nil} = state), do: {:error, :not_configured, state}
+  def clear(%{heartbeat: %State{config: nil}} = state), do: {:error, :not_configured, state}
 
   def clear(state) do
-    data = encode(%{state.heartbeat | status: :paused}) |> Map.put("status", "cleared")
+    data = encode(%{state.heartbeat.config | status: :paused}) |> Map.put("status", "cleared")
 
     case persist_entry(state, data) do
       {:ok, persisted} ->
-        {:ok,
-         persisted
-         |> cancel_runtime_timers()
-         |> Map.put(:heartbeat, nil)
-         |> Map.put(:heartbeat_due, false)}
+        {:ok, persisted |> cancel_runtime_timers() |> put_config(nil)}
 
       {:error, reason} ->
         {:error, reason, state}
@@ -164,15 +188,17 @@ defmodule CodingAgent.Session.Heartbeat do
 
   @doc "Mark the active timer as due when its token is still current."
   @spec mark_due(map(), reference()) :: map()
-  def mark_due(%{heartbeat_timer_token: token} = state, token) when is_reference(token) do
-    state = %{state | heartbeat_timer_ref: nil, heartbeat_timer_token: nil}
+  def mark_due(%{heartbeat: %State{timer_token: token} = heartbeat} = state, token)
+      when is_reference(token) do
+    heartbeat = %{heartbeat | timer_ref: nil, timer_token: nil}
+    state = %{state | heartbeat: heartbeat}
 
     cond do
-      not active?(state.heartbeat) ->
+      not active?(heartbeat.config) ->
         state
 
-      due?(state.heartbeat) ->
-        %{state | heartbeat_due: true}
+      due?(heartbeat.config) ->
+        put_due(state, true)
 
       true ->
         schedule_next(state)
@@ -185,28 +211,31 @@ defmodule CodingAgent.Session.Heartbeat do
   @spec schedule_idle_check(map(), non_neg_integer()) :: map()
   def schedule_idle_check(state, delay_ms \\ @idle_defer_ms)
 
-  def schedule_idle_check(%{heartbeat_due: true, heartbeat_idle_timer_ref: nil} = state, delay_ms)
+  def schedule_idle_check(
+        %{heartbeat: %State{due: true, idle_timer_ref: nil} = heartbeat} = state,
+        delay_ms
+      )
       when is_integer(delay_ms) and delay_ms >= 0 do
     token = make_ref()
     timer_ref = Process.send_after(self(), {:session_heartbeat_idle, token}, delay_ms)
 
-    %{state | heartbeat_idle_timer_ref: timer_ref, heartbeat_idle_token: token}
+    %{state | heartbeat: %{heartbeat | idle_timer_ref: timer_ref, idle_token: token}}
   end
 
   def schedule_idle_check(state, _delay_ms), do: state
 
   @doc "Consume the current idle-check token, leaving stale checks harmless."
   @spec consume_idle_check(map(), reference()) :: {:current | :stale, map()}
-  def consume_idle_check(%{heartbeat_idle_token: token} = state, token)
+  def consume_idle_check(%{heartbeat: %State{idle_token: token} = heartbeat} = state, token)
       when is_reference(token) do
-    {:current, %{state | heartbeat_idle_timer_ref: nil, heartbeat_idle_token: nil}}
+    {:current, %{state | heartbeat: %{heartbeat | idle_timer_ref: nil, idle_token: nil}}}
   end
 
   def consume_idle_check(state, _stale_token), do: {:stale, state}
 
   @doc "Persist a fire claim before the recurring prompt enters the agent loop."
   @spec claim_fire(map()) :: {:ok, String.t(), map()} | {:error, term(), map()}
-  def claim_fire(%{heartbeat: heartbeat} = state) when is_map(heartbeat) do
+  def claim_fire(%{heartbeat: %State{config: %{} = heartbeat}} = state) do
     now = now_ms()
 
     claimed = %{
@@ -220,8 +249,7 @@ defmodule CodingAgent.Session.Heartbeat do
         next_state =
           persisted
           |> cancel_runtime_timers()
-          |> Map.put(:heartbeat, claimed)
-          |> Map.put(:heartbeat_due, false)
+          |> put_config(claimed)
           |> schedule_next()
 
         {:ok, render_prompt(claimed), next_state}
@@ -231,7 +259,7 @@ defmodule CodingAgent.Session.Heartbeat do
 
         {:error, reason,
          state
-         |> Map.put(:heartbeat_due, true)
+         |> put_due(true)
          |> schedule_idle_check(@retry_after_persist_error_ms)}
     end
   end
@@ -243,8 +271,7 @@ defmodule CodingAgent.Session.Heartbeat do
   def clear_runtime(state) do
     state
     |> cancel_runtime_timers()
-    |> Map.put(:heartbeat, nil)
-    |> Map.put(:heartbeat_due, false)
+    |> put_config(nil)
   end
 
   @doc "Whether a real user-facing prompt is already queued behind the idle check."
@@ -281,8 +308,7 @@ defmodule CodingAgent.Session.Heartbeat do
         {:ok,
          persisted
          |> cancel_runtime_timers()
-         |> Map.put(:heartbeat, heartbeat)
-         |> Map.put(:heartbeat_due, false)
+         |> put_config(heartbeat)
          |> schedule_next()}
 
       {:error, reason} ->
@@ -305,27 +331,39 @@ defmodule CodingAgent.Session.Heartbeat do
     end
   end
 
-  defp schedule_next(%{heartbeat: heartbeat} = state) do
-    if active?(heartbeat) do
+  defp schedule_next(%{heartbeat: %State{config: config} = heartbeat} = state) do
+    if active?(config) do
       token = make_ref()
-      delay_ms = min(max(next_fire_at_ms(heartbeat) - now_ms(), 0), @max_timer_ms)
+      delay_ms = min(max(next_fire_at_ms(config) - now_ms(), 0), @max_timer_ms)
       timer_ref = Process.send_after(self(), {:session_heartbeat_due, token}, delay_ms)
-      %{state | heartbeat_timer_ref: timer_ref, heartbeat_timer_token: token}
+      %{state | heartbeat: %{heartbeat | timer_ref: timer_ref, timer_token: token}}
     else
       state
     end
   end
 
   defp cancel_runtime_timers(state) do
-    cancel_timer(Map.get(state, :heartbeat_timer_ref))
-    cancel_timer(Map.get(state, :heartbeat_idle_timer_ref))
+    heartbeat = slot(state)
+    cancel_timer(heartbeat.timer_ref)
+    cancel_timer(heartbeat.idle_timer_ref)
 
-    state
-    |> Map.put(:heartbeat_timer_ref, nil)
-    |> Map.put(:heartbeat_timer_token, nil)
-    |> Map.put(:heartbeat_idle_timer_ref, nil)
-    |> Map.put(:heartbeat_idle_token, nil)
+    Map.put(state, :heartbeat, %{
+      heartbeat
+      | timer_ref: nil,
+        timer_token: nil,
+        idle_timer_ref: nil,
+        idle_token: nil
+    })
   end
+
+  # A state built before the heartbeat slot existed (a bare map in a test)
+  # gets an empty slot rather than a KeyError.
+  defp slot(state), do: Map.get(state, :heartbeat) || %State{}
+
+  defp put_config(state, config),
+    do: Map.put(state, :heartbeat, %{slot(state) | config: config, due: false})
+
+  defp put_due(state, due?), do: Map.put(state, :heartbeat, %{slot(state) | due: due?})
 
   defp cancel_timer(ref) when is_reference(ref) do
     _ = Process.cancel_timer(ref)

--- a/apps/coding_agent/lib/coding_agent/session/lifecycle.ex
+++ b/apps/coding_agent/lib/coding_agent/session/lifecycle.ex
@@ -8,9 +8,11 @@ defmodule CodingAgent.Session.Lifecycle do
 
   alias CodingAgent.Session.{
     BackgroundTasks,
+    CompactionLifecycle,
     Heartbeat,
     ModelResolver,
     Notifier,
+    OverflowRecovery,
     Persistence,
     PromptComposer,
     ProviderFallback,
@@ -262,20 +264,9 @@ defmodule CodingAgent.Session.Lifecycle do
       wasm_sidecar_pid: wasm_boot.sidecar_pid,
       wasm_tool_names: wasm_boot.wasm_tool_names,
       wasm_status: wasm_boot.wasm_status,
-      auto_compaction_in_progress: false,
-      auto_compaction_signature: nil,
-      auto_compaction_task_pid: nil,
-      auto_compaction_task_monitor_ref: nil,
-      auto_compaction_task_timeout_ref: nil,
-      overflow_recovery_in_progress: false,
-      overflow_recovery_attempted: false,
-      overflow_recovery_signature: nil,
-      overflow_recovery_task_pid: nil,
-      overflow_recovery_task_monitor_ref: nil,
-      overflow_recovery_task_timeout_ref: nil,
-      overflow_recovery_started_at_ms: nil,
-      overflow_recovery_error_reason: nil,
-      overflow_recovery_partial_state: nil
+      heartbeat: %Heartbeat.State{},
+      auto_compaction: %CompactionLifecycle.State{},
+      overflow_recovery: %OverflowRecovery.State{}
     }
 
     {:ok, state, lifecycle.extension_status_report}
@@ -436,7 +427,9 @@ defmodule CodingAgent.Session.Lifecycle do
     LemonAgent.Agent.wait_for_idle(state.agent, timeout: reset_abort_wait_ms)
   end
 
-  defp clear_heartbeat_for_rotation(%{heartbeat: nil} = state), do: {:ok, state}
+  defp clear_heartbeat_for_rotation(%{heartbeat: %Heartbeat.State{config: nil}} = state),
+    do: {:ok, state}
+
   defp clear_heartbeat_for_rotation(state), do: Heartbeat.clear(state)
 
   # Persistent Python REPL owner cleanup. The module is injectable via the

--- a/apps/coding_agent/lib/coding_agent/session/overflow_recovery.ex
+++ b/apps/coding_agent/lib/coding_agent/session/overflow_recovery.ex
@@ -1,10 +1,46 @@
 defmodule CodingAgent.Session.OverflowRecovery do
-  @moduledoc false
+  @moduledoc """
+  One attempt per turn to recover from a context-length error: compact in
+  the background, then retry the turn. Its slot in the session state is one
+  field, `overflow_recovery`, holding a
+  `CodingAgent.Session.OverflowRecovery.State`.
+  """
 
   require Logger
 
   alias CodingAgent.Session.CompactionLifecycle
   alias CodingAgent.Session.CompactionManager
+
+  defmodule State do
+    @moduledoc """
+    Overflow recovery's slot in the session state: whether a recovery is
+    running and whether one was already attempted this turn, the session
+    signature it captured, the task it tracks, and the error it is recovering
+    from (kept so the failure can be re-broadcast if the retry also fails).
+    """
+
+    @type t :: %__MODULE__{
+            in_progress: boolean(),
+            attempted: boolean(),
+            signature: CodingAgent.Session.CompactionManager.session_signature() | nil,
+            task_pid: pid() | nil,
+            task_monitor_ref: reference() | nil,
+            task_timeout_ref: reference() | nil,
+            started_at_ms: non_neg_integer() | nil,
+            error_reason: term() | nil,
+            partial_state: term() | nil
+          }
+
+    defstruct in_progress: false,
+              attempted: false,
+              signature: nil,
+              task_pid: nil,
+              task_monitor_ref: nil,
+              task_timeout_ref: nil,
+              started_at_ms: nil,
+              error_reason: nil,
+              partial_state: nil
+  end
 
   @type callbacks(state) :: %{
           required(:restore_messages_from_session) => (map() -> [map()]),
@@ -19,7 +55,7 @@ defmodule CodingAgent.Session.OverflowRecovery do
     state = CompactionManager.clear_overflow_recovery_task_tracking(state)
 
     cond do
-      not state.overflow_recovery_in_progress ->
+      not state.overflow_recovery.in_progress ->
         state
 
       true ->
@@ -47,10 +83,10 @@ defmodule CodingAgent.Session.OverflowRecovery do
       not state.is_streaming ->
         :no_recovery
 
-      state.overflow_recovery_in_progress ->
+      state.overflow_recovery.in_progress ->
         :no_recovery
 
-      state.overflow_recovery_attempted ->
+      state.overflow_recovery.attempted ->
         :no_recovery
 
       not CompactionManager.context_length_exceeded_error?(reason) ->
@@ -92,15 +128,17 @@ defmodule CodingAgent.Session.OverflowRecovery do
             {:ok,
              %{
                state
-               | overflow_recovery_in_progress: true,
-                 overflow_recovery_attempted: true,
-                 overflow_recovery_signature: signature,
-                 overflow_recovery_task_pid: task_meta.pid,
-                 overflow_recovery_task_monitor_ref: task_meta.monitor_ref,
-                 overflow_recovery_task_timeout_ref: task_meta.timeout_ref,
-                 overflow_recovery_started_at_ms: started_at_ms,
-                 overflow_recovery_error_reason: reason,
-                 overflow_recovery_partial_state: partial_state
+               | overflow_recovery: %State{
+                   in_progress: true,
+                   attempted: true,
+                   signature: signature,
+                   task_pid: task_meta.pid,
+                   task_monitor_ref: task_meta.monitor_ref,
+                   task_timeout_ref: task_meta.timeout_ref,
+                   started_at_ms: started_at_ms,
+                   error_reason: reason,
+                   partial_state: partial_state
+                 }
              }}
 
           {:error, task_reason} ->
@@ -116,10 +154,10 @@ defmodule CodingAgent.Session.OverflowRecovery do
   @spec handle_result(map(), term(), {:ok, map()} | {:error, term()}, callbacks(map())) :: map()
   def handle_result(state, signature, result, callbacks) do
     cond do
-      not state.overflow_recovery_in_progress ->
+      not state.overflow_recovery.in_progress ->
         state
 
-      state.overflow_recovery_signature != signature ->
+      state.overflow_recovery.signature != signature ->
         state
 
       signature != CompactionManager.session_signature(state) ->
@@ -172,13 +210,13 @@ defmodule CodingAgent.Session.OverflowRecovery do
 
   @spec handle_timeout(map(), reference(), callbacks(map())) :: {:handled, map()} | :stale
   def handle_timeout(state, monitor_ref, callbacks) do
-    if state.overflow_recovery_task_monitor_ref == monitor_ref do
+    if state.overflow_recovery.task_monitor_ref == monitor_ref do
       failure_reason = :overflow_recovery_timeout
 
       failed_state =
         state
         |> CompactionManager.maybe_kill_background_task(
-          state.overflow_recovery_task_pid,
+          state.overflow_recovery.task_pid,
           :overflow_recovery_timeout
         )
         |> CompactionManager.clear_overflow_recovery_task_state()
@@ -207,8 +245,11 @@ defmodule CodingAgent.Session.OverflowRecovery do
              %{
                state
                | is_streaming: true,
-                 overflow_recovery_error_reason: nil,
-                 overflow_recovery_partial_state: nil
+                 overflow_recovery: %{
+                   state.overflow_recovery
+                   | error_reason: nil,
+                     partial_state: nil
+                 }
              }}
 
           {:error, reason} ->
@@ -221,8 +262,8 @@ defmodule CodingAgent.Session.OverflowRecovery do
   end
 
   defp finalize_failure(state, fallback_reason, callbacks) do
-    reason = state.overflow_recovery_error_reason || fallback_reason
-    event = {:error, reason, state.overflow_recovery_partial_state}
+    reason = state.overflow_recovery.error_reason || fallback_reason
+    event = {:error, reason, state.overflow_recovery.partial_state}
 
     callbacks.broadcast_event.(state, event)
     state = callbacks.handle_agent_event.(event, state)

--- a/apps/coding_agent/lib/coding_agent/session/state.ex
+++ b/apps/coding_agent/lib/coding_agent/session/state.ex
@@ -163,12 +163,15 @@ defmodule CodingAgent.Session.State do
       | is_streaming: true,
         pending_prompt_timer_ref: timer_ref,
         turn_index: state.turn_index + 1,
-        overflow_recovery_in_progress: false,
-        overflow_recovery_attempted: false,
-        overflow_recovery_signature: nil,
-        overflow_recovery_started_at_ms: nil,
-        overflow_recovery_error_reason: nil,
-        overflow_recovery_partial_state: nil
+        overflow_recovery: %{
+          state.overflow_recovery
+          | in_progress: false,
+            attempted: false,
+            signature: nil,
+            started_at_ms: nil,
+            error_reason: nil,
+            partial_state: nil
+        }
     }
   end
 
@@ -184,14 +187,16 @@ defmodule CodingAgent.Session.State do
         session_file: nil,
         steering_queue: :queue.new(),
         follow_up_queue: :queue.new(),
-        auto_compaction_in_progress: false,
-        auto_compaction_signature: nil,
-        overflow_recovery_in_progress: false,
-        overflow_recovery_attempted: false,
-        overflow_recovery_signature: nil,
-        overflow_recovery_started_at_ms: nil,
-        overflow_recovery_error_reason: nil,
-        overflow_recovery_partial_state: nil
+        auto_compaction: %{state.auto_compaction | in_progress: false, signature: nil},
+        overflow_recovery: %{
+          state.overflow_recovery
+          | in_progress: false,
+            attempted: false,
+            signature: nil,
+            started_at_ms: nil,
+            error_reason: nil,
+            partial_state: nil
+        }
     }
   end
 

--- a/apps/coding_agent/test/coding_agent/session/state_test.exs
+++ b/apps/coding_agent/test/coding_agent/session/state_test.exs
@@ -4,6 +4,7 @@ defmodule CodingAgent.Session.StateTest do
   alias LemonAgent.Types.AgentTool
   alias LemonAi.Types.{TextContent, ToolResultMessage}
   alias CodingAgent.Session.State
+  alias CodingAgent.Session.OverflowRecovery
 
   test "normalize_extra_tools keeps only AgentTool structs" do
     tool = %AgentTool{
@@ -79,12 +80,14 @@ defmodule CodingAgent.Session.StateTest do
       is_streaming: false,
       pending_prompt_timer_ref: nil,
       turn_index: 4,
-      overflow_recovery_in_progress: true,
-      overflow_recovery_attempted: true,
-      overflow_recovery_signature: :sig,
-      overflow_recovery_started_at_ms: 12,
-      overflow_recovery_error_reason: :boom,
-      overflow_recovery_partial_state: %{foo: :bar}
+      overflow_recovery: %OverflowRecovery.State{
+        in_progress: true,
+        attempted: true,
+        signature: :sig,
+        started_at_ms: 12,
+        error_reason: :boom,
+        partial_state: %{foo: :bar}
+      }
     }
 
     next_state = State.begin_prompt(state, timer_ref)
@@ -92,12 +95,7 @@ defmodule CodingAgent.Session.StateTest do
     assert next_state.is_streaming
     assert next_state.pending_prompt_timer_ref == timer_ref
     assert next_state.turn_index == 5
-    refute next_state.overflow_recovery_in_progress
-    refute next_state.overflow_recovery_attempted
-    assert next_state.overflow_recovery_signature == nil
-    assert next_state.overflow_recovery_started_at_ms == nil
-    assert next_state.overflow_recovery_error_reason == nil
-    assert next_state.overflow_recovery_partial_state == nil
+    assert next_state.overflow_recovery == %OverflowRecovery.State{}
   end
 
   defp marker_count(text, marker) do

--- a/apps/coding_agent/test/coding_agent/session_auto_compaction_async_test.exs
+++ b/apps/coding_agent/test/coding_agent/session_auto_compaction_async_test.exs
@@ -26,14 +26,12 @@ defmodule CodingAgent.SessionAutoCompactionAsyncTest do
 
   defp mark_auto_compaction_in_progress(session, signature) do
     :sys.replace_state(session, fn state ->
-      state
-      |> Map.put(:auto_compaction_signature, signature)
-      |> Map.put(:auto_compaction_in_progress, true)
+      Map.update!(state, :auto_compaction, &%{&1 | signature: signature, in_progress: true})
     end)
   end
 
   defp auto_compaction_in_progress?(state) do
-    Map.get(state, :auto_compaction_in_progress) == true
+    state.auto_compaction.in_progress == true
   end
 
   defp trigger_auto_compaction_result(session, signature, result) do
@@ -141,19 +139,25 @@ defmodule CodingAgent.SessionAutoCompactionAsyncTest do
     monitor_ref = Process.monitor(task_pid)
 
     :sys.replace_state(session, fn current ->
-      current
-      |> Map.put(:auto_compaction_signature, signature)
-      |> Map.put(:auto_compaction_in_progress, true)
-      |> Map.put(:auto_compaction_task_pid, task_pid)
-      |> Map.put(:auto_compaction_task_monitor_ref, monitor_ref)
+      Map.update!(
+        current,
+        :auto_compaction,
+        &%{
+          &1
+          | signature: signature,
+            in_progress: true,
+            task_pid: task_pid,
+            task_monitor_ref: monitor_ref
+        }
+      )
     end)
 
     send(session, {:auto_compaction_task_timeout, monitor_ref})
 
     state_after = Session.get_state(session)
-    refute state_after.auto_compaction_in_progress
-    assert state_after.auto_compaction_task_pid == nil
-    assert state_after.auto_compaction_task_monitor_ref == nil
+    refute state_after.auto_compaction.in_progress
+    assert state_after.auto_compaction.task_pid == nil
+    assert state_after.auto_compaction.task_monitor_ref == nil
   end
 
   test "a new prompt cancels stale auto compaction without accepting its late result" do
@@ -179,22 +183,28 @@ defmodule CodingAgent.SessionAutoCompactionAsyncTest do
       timeout_ref =
         Process.send_after(self(), {:auto_compaction_task_timeout, monitor_ref}, 60_000)
 
-      current
-      |> Map.put(:auto_compaction_signature, signature)
-      |> Map.put(:auto_compaction_in_progress, true)
-      |> Map.put(:auto_compaction_task_pid, task_pid)
-      |> Map.put(:auto_compaction_task_monitor_ref, monitor_ref)
-      |> Map.put(:auto_compaction_task_timeout_ref, timeout_ref)
+      Map.update!(
+        current,
+        :auto_compaction,
+        &%{
+          &1
+          | signature: signature,
+            in_progress: true,
+            task_pid: task_pid,
+            task_monitor_ref: monitor_ref,
+            task_timeout_ref: timeout_ref
+        }
+      )
     end)
 
     assert :ok = Session.prompt(session, "new turn")
 
     state_after_prompt = Session.get_state(session)
-    refute state_after_prompt.auto_compaction_in_progress
-    assert state_after_prompt.auto_compaction_signature == nil
-    assert state_after_prompt.auto_compaction_task_pid == nil
-    assert state_after_prompt.auto_compaction_task_monitor_ref == nil
-    assert state_after_prompt.auto_compaction_task_timeout_ref == nil
+    refute state_after_prompt.auto_compaction.in_progress
+    assert state_after_prompt.auto_compaction.signature == nil
+    assert state_after_prompt.auto_compaction.task_pid == nil
+    assert state_after_prompt.auto_compaction.task_monitor_ref == nil
+    assert state_after_prompt.auto_compaction.task_timeout_ref == nil
     assert state_after_prompt.is_streaming
 
     assert eventually(fn -> not Process.alive?(task_pid) end)

--- a/apps/coding_agent/test/coding_agent/session_heartbeat_test.exs
+++ b/apps/coding_agent/test/coding_agent/session_heartbeat_test.exs
@@ -197,7 +197,7 @@ defmodule CodingAgent.SessionHeartbeatTest do
     old_state = Session.get_state(session)
     old_session_id = old_state.session_manager.header.id
     old_session_file = old_state.session_file
-    old_timer_token = old_state.heartbeat_timer_token
+    old_timer_token = old_state.heartbeat.timer_token
 
     assert :ok = Session.reset(session)
 

--- a/apps/coding_agent/test/coding_agent/session_overflow_recovery_test.exs
+++ b/apps/coding_agent/test/coding_agent/session_overflow_recovery_test.exs
@@ -3,6 +3,7 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
 
   alias LemonAgent.Test.Mocks
   alias CodingAgent.Session
+  alias CodingAgent.Session.OverflowRecovery
   alias CodingAgent.SessionManager
 
   defp start_session(opts \\ []) do
@@ -46,13 +47,15 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
       %{
         state
         | is_streaming: true,
-          overflow_recovery_in_progress: true,
-          overflow_recovery_attempted: attempted,
-          overflow_recovery_signature: signature,
-          overflow_recovery_task_pid: task_pid,
-          overflow_recovery_task_monitor_ref: monitor_ref,
-          overflow_recovery_error_reason: reason,
-          overflow_recovery_partial_state: partial_state
+          overflow_recovery: %OverflowRecovery.State{
+            in_progress: true,
+            attempted: attempted,
+            signature: signature,
+            task_pid: task_pid,
+            task_monitor_ref: monitor_ref,
+            error_reason: reason,
+            partial_state: partial_state
+          }
       }
     end)
   end
@@ -66,9 +69,9 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
     send(session, {:overflow_recovery_result, :stale_signature, {:error, :cannot_compact}})
 
     state_after = Session.get_state(session)
-    assert state_after.overflow_recovery_in_progress
-    assert state_after.overflow_recovery_signature == signature
-    assert state_after.overflow_recovery_attempted
+    assert state_after.overflow_recovery.in_progress
+    assert state_after.overflow_recovery.signature == signature
+    assert state_after.overflow_recovery.attempted
   end
 
   test "failed overflow compaction finalizes session and clears recovery flags" do
@@ -80,8 +83,8 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
     send(session, {:overflow_recovery_result, signature, {:error, :cannot_compact}})
 
     state_after = Session.get_state(session)
-    refute state_after.overflow_recovery_in_progress
-    refute state_after.overflow_recovery_attempted
+    refute state_after.overflow_recovery.in_progress
+    refute state_after.overflow_recovery.attempted
     refute state_after.is_streaming
   end
 
@@ -92,7 +95,7 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
       %{
         state
         | is_streaming: true,
-          overflow_recovery_attempted: true
+          overflow_recovery: %{state.overflow_recovery | attempted: true}
       }
     end)
 
@@ -102,8 +105,8 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
     )
 
     state_after = Session.get_state(session)
-    refute state_after.overflow_recovery_in_progress
-    refute state_after.overflow_recovery_attempted
+    refute state_after.overflow_recovery.in_progress
+    refute state_after.overflow_recovery.attempted
     refute state_after.is_streaming
   end
 
@@ -114,7 +117,7 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
       %{
         state
         | is_streaming: true,
-          overflow_recovery_attempted: true
+          overflow_recovery: %{state.overflow_recovery | attempted: true}
       }
     end)
 
@@ -124,8 +127,8 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
     )
 
     state_after = Session.get_state(session)
-    refute state_after.overflow_recovery_in_progress
-    refute state_after.overflow_recovery_attempted
+    refute state_after.overflow_recovery.in_progress
+    refute state_after.overflow_recovery.attempted
     refute state_after.is_streaming
   end
 
@@ -171,9 +174,9 @@ defmodule CodingAgent.SessionOverflowRecoveryTest do
     send(session, {:overflow_recovery_task_timeout, monitor_ref})
 
     state_after = Session.get_state(session)
-    refute state_after.overflow_recovery_in_progress
-    assert state_after.overflow_recovery_task_pid == nil
-    assert state_after.overflow_recovery_task_monitor_ref == nil
+    refute state_after.overflow_recovery.in_progress
+    assert state_after.overflow_recovery.task_pid == nil
+    assert state_after.overflow_recovery.task_monitor_ref == nil
     refute state_after.is_streaming
   end
 end


### PR DESCRIPTION
## Summary
- replace 20 loose session fields with heartbeat, compaction, and overflow-recovery state structs
- move timer and task bookkeeping behind each subsystem boundary
- update internal state assertions without changing public APIs, emitted events, or persisted session data

## Validation
- directly affected tests: 25 passed
- full session-focused suite: 460 passed
- formatting and diff checks passed

This is the focused replacement for the session/state cleanup portion of #37. It excludes the old ratchet bump and every unrelated architecture or product move.