### PR TITLE
Declare RunStore table ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Versions follow [CalVer](https://calver.org/) — `YYYY.MM.PATCH`.
 
 ### Added
 
+- `LemonCore.RunStore` now declares ownership of the `:runs` and
+  `:sessions_index` tables through `LemonCore.Store.Table`. This is the first
+  focused domain adoption of the ownership metadata and architecture gate;
+  the existing run lifecycle and finalization behavior is unchanged.
+
 - `LemonCore.Store.Table` ownership metadata for incremental generic-store
   migrations. The architecture gate now analyzes generic Store calls from the
   AST across every supported operation and default/explicit server arity,

--- a/apps/lemon_core/AGENTS.md
+++ b/apps/lemon_core/AGENTS.md
@@ -49,6 +49,7 @@ This is the **base app** of the Lemon umbrella. All other apps depend on it. It 
 | `LemonCore.OAuth.LocalCallbackListener` | Caller-owned one-shot localhost OAuth callback listener; monitors its listener manager so early failure returns immediately instead of consuming the authorization timeout |
 | `LemonCore.Store` | Storage GenServer with pluggable backends, `put_new/3` claims, serialized `take/2`, and exact-value `compare_and_swap/4` |
 | `LemonCore.Store.Table` | Declarative table owner and policy metadata; the architecture gate checks owner calls against exact declared tables |
+| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; keep finalization behavior on the existing specialized Store path until its dedicated migration |
 | `LemonCore.Store.ReadCache` | ETS read cache for hot domains (`:chat`, `:runs`, `:progress`, `:sessions_index`, plus tables collaborators add with `register_cached_table/1`) |
 | `LemonCore.Store.EtsBackend` | In-memory ETS (ephemeral, default) with `:ets.insert_new/2` claims |
 | `LemonCore.Store.SqliteBackend` | SQLite with WAL mode (persistent) and `ON CONFLICT DO NOTHING` claims |

--- a/apps/lemon_core/CHANGELOG.md
+++ b/apps/lemon_core/CHANGELOG.md
@@ -18,6 +18,11 @@ Telegram, run history, durable memory, kanban boards, or `~/.lemon`.
 
 ### Added
 
+- `LemonCore.RunStore` declares `:runs` and `:sessions_index` as its owned
+  tables. The declaration documents their cache and persistence intent and
+  brings the existing wrapper under the AST ownership gate without changing
+  the specialized `LemonCore.Store` run lifecycle or finalization semantics.
+
 - `LemonCore.Store.Table` lets a domain wrapper declare table ownership plus
   future cache, retention, persistence, and schema-version metadata without
   generating CRUD functions or changing backend behavior. The existing

--- a/apps/lemon_core/README.md
+++ b/apps/lemon_core/README.md
@@ -165,6 +165,7 @@ ids, message bodies, proof details, credentials, or secret names.
 |--------|---------|
 | `LemonCore.Store` | GenServer with pluggable backends and specialized APIs |
 | `LemonCore.Store.Table` | Declarative owner and policy metadata for generic Store tables |
+| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; runtime writes still use the specialized Store lifecycle path |
 | `LemonCore.Store.Backend` | Behaviour for storage backends (init/put/put_new/get/delete/list) |
 | `LemonCore.Store.EtsBackend` | In-memory ETS backend (ephemeral, default) |
 | `LemonCore.Store.SqliteBackend` | SQLite backend with WAL mode and optional ephemeral tables |

--- a/apps/lemon_core/lib/lemon_core/run_store.ex
+++ b/apps/lemon_core/lib/lemon_core/run_store.ex
@@ -1,7 +1,18 @@
 defmodule LemonCore.RunStore do
   @moduledoc """
   Typed wrapper for run lifecycle and history persistence.
+
+  This module owns the `:runs` and `:sessions_index` table contracts. The
+  declaration is architecture metadata only: the existing specialized
+  `LemonCore.Store` lifecycle operations continue to provide the runtime
+  behavior while run storage is migrated incrementally.
   """
+
+  use LemonCore.Store.Table,
+    tables: [
+      runs: [cached: true, persistence: :ephemeral],
+      sessions_index: [cached: true]
+    ]
 
   alias LemonCore.Store
   alias LemonCore.RunHistoryStore

--- a/apps/lemon_core/test/lemon_core/run_store_test.exs
+++ b/apps/lemon_core/test/lemon_core/run_store_test.exs
@@ -2,13 +2,43 @@ defmodule LemonCore.RunStoreTest do
   use ExUnit.Case, async: false
 
   alias LemonCore.RunStore
+  alias LemonCore.Store.Table
+
+  test "declares the run-domain tables without changing their runtime path" do
+    assert [runs, sessions_index] = RunStore.__store_tables__()
+
+    assert %Table{
+             name: :runs,
+             owner: RunStore,
+             cached: true,
+             persistence: :ephemeral,
+             retention: nil,
+             version: 1
+           } = runs
+
+    assert %Table{
+             name: :sessions_index,
+             owner: RunStore,
+             cached: true,
+             persistence: :durable,
+             retention: nil,
+             version: 1
+           } = sessions_index
+  end
 
   test "appends, fetches, finalizes, and lists run history through the typed wrapper" do
     session_key = "agent:test:main:#{System.unique_integer([:positive])}"
     run_id = "run_#{System.unique_integer([:positive])}"
 
-    assert :ok = RunStore.append_event(run_id, %{type: :prompt, text: "hello", session_key: session_key})
+    assert :ok =
+             RunStore.append_event(run_id, %{
+               type: :prompt,
+               text: "hello",
+               session_key: session_key
+             })
+
     assert is_map(RunStore.get(run_id))
+
     assert :ok =
              RunStore.finalize(run_id, %{
                completed: %{ok: true, answer: "world"},


### PR DESCRIPTION
## Summary
- declare `:runs` and `:sessions_index` as RunStore-owned tables
- record cache and persistence policy metadata
- prove the ownership contract without changing existing specialized Store behavior
- document that runtime migration remains incremental

## Validation
- 62 focused RunStore, Store.Table, and architecture tests passed
- `LEMON_GATEWAY_ENABLE_A2A=false mix lemon.quality`
- formatting and diff checks passed

This is the first one-domain-at-a-time storage migration requested by the #37 review. It is stacked on #40 and intentionally excludes finalization/retry semantics.