### PR TITLE
test(channels): synchronize port restart fixture

### DIFF
--- a/apps/lemon_channels/test/lemon_channels/port_bridge_contract_test.exs
+++ b/apps/lemon_channels/test/lemon_channels/port_bridge_contract_test.exs
@@ -131,7 +131,13 @@ defmodule LemonChannels.PortBridgeContractTest do
 
         counter_path = Path.join(bridge_dir, "bridge_start_count.txt")
         script_path = Path.join(bridge_dir, "bridge_restart_fixture.mjs")
-        :ok = File.write(script_path, restart_fixture_script(counter_path))
+
+        # One deliberately slow first boot proves that response deadlines begin
+        # at fixture readiness while the immediately queued command is preserved.
+        startup_delay_ms = if bridge.label == "xmtp", do: 2_500, else: 0
+
+        :ok =
+          File.write(script_path, restart_fixture_script(counter_path, startup_delay_ms))
 
         with_bridge(bridge, script_path, fn pid ->
           bridge.module.command(pid, %{
@@ -139,27 +145,48 @@ defmodule LemonChannels.PortBridgeContractTest do
             "identity" => "test-#{bridge.label}"
           })
 
-          assert_receive {event_tag,
-                          %{"type" => "bridge_test_connect", "generation" => first_generation}},
-                         2_000
+          assert_receive {ready_event_tag,
+                          %{
+                            "type" => "bridge_test_ready",
+                            "generation" => first_generation
+                          }},
+                         8_000
 
-          assert event_tag == bridge.event_tag
+          assert ready_event_tag == bridge.event_tag
 
-          assert_receive {event_tag, %{"type" => "error", "message" => exit_message}},
-                         4_000
-
-          assert event_tag == bridge.event_tag
-          assert exit_message == "#{bridge.label} bridge exited"
-
-          assert_receive {event_tag,
+          assert_receive {connect_event_tag,
                           %{
                             "type" => "bridge_test_connect",
+                            "generation" => ^first_generation
+                          }},
+                         2_000
+
+          assert connect_event_tag == bridge.event_tag
+
+          assert_receive {exit_event_tag, %{"type" => "error", "message" => exit_message}},
+                         4_000
+
+          assert exit_event_tag == bridge.event_tag
+          assert exit_message == "#{bridge.label} bridge exited"
+
+          assert_receive {restart_ready_event_tag,
+                          %{
+                            "type" => "bridge_test_ready",
                             "generation" => second_generation
                           }},
                          8_000
 
-          assert event_tag == bridge.event_tag
+          assert restart_ready_event_tag == bridge.event_tag
           assert second_generation == first_generation + 1
+
+          assert_receive {replay_event_tag,
+                          %{
+                            "type" => "bridge_test_connect",
+                            "generation" => ^second_generation
+                          }},
+                         2_000
+
+          assert replay_event_tag == bridge.event_tag
         end)
       end)
     else
@@ -195,7 +222,7 @@ defmodule LemonChannels.PortBridgeContractTest do
     """
   end
 
-  defp restart_fixture_script(counter_path) do
+  defp restart_fixture_script(counter_path, startup_delay_ms) do
     """
     #!/usr/bin/env node
     import fs from "node:fs";
@@ -212,6 +239,14 @@ defmodule LemonChannels.PortBridgeContractTest do
     fs.writeFileSync(counterPath, String(generation));
 
     const emit = (payload) => process.stdout.write(JSON.stringify(payload) + "\\n");
+    const startupDelayMs = #{startup_delay_ms};
+
+    // Model a cold Node startup that is slower than the command-response timeout.
+    // The bridge pipe may accept a command before the fixture installs its reader.
+    if (generation === 1 && startupDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, startupDelayMs));
+    }
+
     const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 
     rl.on("line", (line) => {
@@ -224,10 +259,12 @@ defmodule LemonChannels.PortBridgeContractTest do
       }
 
       if (command?.op === "connect") {
-        emit({ type: "bridge_test_connect", generation });
-        process.exit(0);
+        const event = JSON.stringify({ type: "bridge_test_connect", generation }) + "\\n";
+        process.stdout.write(event, () => process.exit(0));
       }
     });
+
+    emit({ type: "bridge_test_ready", generation });
     """
   end
 end


### PR DESCRIPTION
## Summary

- wait for an explicit generation-tagged Node fixture readiness event before starting response deadlines
- preserve coverage that the initial connect command is queued before the fixture becomes ready
- flush the terminal connect event before the fixture exits
- retain a deliberate slow cold start as deterministic regression coverage

## Why

Hosted CI exposed a race in `PortBridgeContractTest`: `Port.open/2` confirms the OS process was spawned, not that Node installed its readline handler. The test incorrectly charged cold startup against a two-second response assertion. The production restart/replay implementation is unchanged.

## Validation

- old assertion fails deterministically with the slow-start fixture at the original line 142
- repaired contract test passes across 5 seeds
- `mix test apps/lemon_channels/test` — 839 passed
- `mix test apps/lemon_channels/test --cover` — 839 passed, 60.06% coverage (47% threshold)
- `mix lemon.quality`
- `mix format --check-formatted`
- `git diff --check`