### PR TITLE
chore: add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,16 @@
+{
+  "name": "Lemon (Elixir umbrella)",
+  "install": "./.cursor/install.sh",
+  "terminals": [
+    {
+      "name": "lemon-runtime",
+      "command": "export ASDF_DATA_DIR=\"$HOME/.asdf\"; export BUN_INSTALL=\"$HOME/.bun\"; export PATH=\"$ASDF_DATA_DIR/shims:/usr/local/bin:$BUN_INSTALL/bin:$PATH\"; ./bin/lemon --no-distribution",
+      "description": "Unified Lemon runtime (gateway + control plane + router + channels + web). Control plane http://localhost:4040, Web UI http://localhost:4080, Sim UI http://localhost:4090."
+    }
+  ],
+  "ports": [
+    { "name": "control-plane", "port": 4040 },
+    { "name": "web-ui", "port": 4080 },
+    { "name": "sim-ui", "port": 4090 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for the Lemon Elixir umbrella.
+#
+# Idempotent: installs the exact BEAM toolchain pinned in .tool-versions
+# (Erlang/OTP + Elixir) via asdf, Bun for the TUI client, fetches and compiles
+# the umbrella, and installs TUI dependencies. Safe to run repeatedly.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+log() { printf '\033[0;32m[install]\033[0m %s\n' "$1"; }
+
+# --- System build dependencies (Erlang builds from source via kerl) ----------
+log "Installing system build dependencies"
+sudo apt-get update -qq
+sudo apt-get install -y -qq \
+  build-essential autoconf m4 \
+  libncurses-dev libssl-dev libssh-dev unixodbc-dev libgmp-dev \
+  inotify-tools curl git unzip
+
+# --- asdf --------------------------------------------------------------------
+export ASDF_DATA_DIR="$HOME/.asdf"
+export PATH="$ASDF_DATA_DIR/shims:/usr/local/bin:$PATH"
+
+if ! command -v asdf >/dev/null 2>&1; then
+  log "Installing asdf"
+  ASDF_VERSION="v0.18.0"
+  curl -fsSL -o /tmp/asdf.tar.gz \
+    "https://github.com/asdf-vm/asdf/releases/download/${ASDF_VERSION}/asdf-${ASDF_VERSION}-linux-amd64.tar.gz"
+  tar -xzf /tmp/asdf.tar.gz -C /tmp
+  sudo mv /tmp/asdf /usr/local/bin/asdf
+  rm -f /tmp/asdf.tar.gz
+fi
+
+# Persist toolchain paths for future login shells and terminals.
+if ! grep -q 'ASDF_DATA_DIR' "$HOME/.bashrc" 2>/dev/null; then
+  cat >> "$HOME/.bashrc" <<'RC'
+
+# Lemon dev toolchain (asdf-managed Erlang/Elixir + Bun)
+export ASDF_DATA_DIR="$HOME/.asdf"
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$ASDF_DATA_DIR/shims:/usr/local/bin:$BUN_INSTALL/bin:$PATH"
+RC
+fi
+
+log "Adding asdf plugins"
+asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git 2>/dev/null || true
+asdf plugin add elixir https://github.com/asdf-vm/asdf-elixir.git 2>/dev/null || true
+
+# Headless Erlang build: skip GUI/JVM/docs to keep the build fast and dependency-light.
+export KERL_CONFIGURE_OPTIONS="--without-wx --without-javac --without-observer --without-debugger --without-et --disable-docs"
+export KERL_BUILD_DOCS="no"
+
+log "Installing Erlang/Elixir from .tool-versions (this compiles Erlang; ~2 min)"
+asdf install
+
+# --- Hex / Rebar -------------------------------------------------------------
+log "Installing Hex and Rebar"
+mix local.hex --force
+mix local.rebar --force
+
+# --- Umbrella dependencies + compile ----------------------------------------
+log "Fetching and compiling umbrella dependencies"
+mix deps.get
+mix compile
+
+# --- Bun + TUI client dependencies ------------------------------------------
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+BUN_VERSION="$(cat clients/tui/.bun-version)"
+if [ "$(bun --version 2>/dev/null || true)" != "$BUN_VERSION" ]; then
+  log "Installing Bun ${BUN_VERSION}"
+  curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+fi
+
+log "Installing TUI client dependencies"
+(cd clients/tui && bun install --frozen-lockfile)
+
+log "Environment setup complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for the Lemon Elixir umbrella and verifies it end-to-end by booting the unified runtime and the client test suite.

Adds:
- `.cursor/install.sh` — idempotent install script that installs the pinned BEAM toolchain from `.tool-versions` (Erlang/OTP 28.5 + Elixir 1.19.5) via `asdf`, plus Bun (pinned by `clients/tui/.bun-version`), then fetches/compiles the umbrella and installs TUI deps.
- `.cursor/environment.json` — repository-managed environment: default base image, `install` runs the script above, a `lemon-runtime` terminal boots `./bin/lemon --no-distribution`, and ports `4040` (control plane), `4080` (Web UI), `4090` (Sim UI) are exposed.

## How it was built

- Erlang is built headless (`KERL_CONFIGURE_OPTIONS=--without-wx --without-javac --without-observer --without-debugger --without-et --disable-docs`), matching the CI toolchain (`erlef/setup-beam@v1` with OTP `28.5` / Elixir `1.19.5`) while avoiding GUI/JVM build dependencies.
- Toolchain versions match `.tool-versions` and `clients/tui/.bun-version` exactly.

## Validation

- `mix compile` — full umbrella compiles cleanly.
- `mix test apps/lemon_core/test/lemon_core/config_test.exs` — 31 tests, 0 failures.
- `./bin/lemon --daemon` — all 9 `runtime_full` apps boot; health endpoints return `{"ok":true}` (control plane `:4040`) and `ok` (Web UI `:4080`); Sim UI `:4090` returns HTTP 200.
- Web UI and Sim UI render in Chrome (screenshots below).
- `bun test` (TUI client) — 1292 pass, 0 fail.
- `./.cursor/install.sh` re-run is idempotent (~6s when cached).

### Running Web UI (`http://localhost:4080/`)
[Lemon Web UI dashboard](https://cursor.com/agents/bc-dc83f78a-1c00-47d1-a134-22f63e628fec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flemon_web_ui.png)

### Running Sim UI (`http://localhost:4090/`)
[LemonSim Live UI lobby](https://cursor.com/agents/bc-dc83f78a-1c00-47d1-a134-22f63e628fec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flemon_sim_ui.png)

Note: the Web UI's "Setup needed" banner is expected — no provider API keys are configured in a fresh environment; the runtime itself is fully up and serving.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc83f78a-1c00-47d1-a134-22f63e628fec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc83f78a-1c00-47d1-a134-22f63e628fec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

