### PR TITLE
Declare RunStore table ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ Versions follow [CalVer](https://calver.org/) — `YYYY.MM.PATCH`.
 - `LemonCore.ChatStateStore` now adopts that ownership contract for the cached
   `:chat` table and its existing `:expires_at` retention policy without moving
   TTL, expiry, sweep, or cache behavior out of the specialized Store runtime.
+- `LemonCore.RunStore` now declares ownership of the `:runs` and
+  `:sessions_index` tables through `LemonCore.Store.Table`, with cache and
+  persistence policy recorded explicitly. The existing run lifecycle and
+  finalization behavior is unchanged.
 
 - Configured engine runtimes are now checked against
   `LemonCore.EngineRuntime` when the router starts. Invalid wiring is reported

--- a/apps/lemon_core/AGENTS.md
+++ b/apps/lemon_core/AGENTS.md
@@ -51,6 +51,7 @@ This is the **base app** of the Lemon umbrella. All other apps depend on it. It 
 | `LemonCore.OAuth.LocalCallbackListener` | Caller-owned one-shot localhost OAuth callback listener; monitors its listener manager so early failure returns immediately instead of consuming the authorization timeout |
 | `LemonCore.Store` | Storage GenServer with pluggable backends, `put_new/3` claims, strict `fetch/3` and `fetch_all/2` reads, serialized `take/2`, and exact-value `compare_and_swap/4`, `compare_and_delete/3`, and multi-snapshot `compare_and_delete_many/1` transitions |
 | `LemonCore.Store.Table` | Declarative table owner and policy metadata; the architecture gate checks owner calls against exact declared tables |
+| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; keep finalization behavior on the existing specialized Store path until its dedicated migration |
 | `LemonCore.Store.ReadCache` | ETS read cache for hot domains (`:chat`, `:runs`, `:progress`, `:sessions_index`, plus tables collaborators add with `register_cached_table/1`) |
 | `LemonCore.Store.EtsBackend` | In-memory ETS (ephemeral, default) with `:ets.insert_new/2` claims |
 | `LemonCore.Store.SqliteBackend` | SQLite with WAL mode (persistent) and `ON CONFLICT DO NOTHING` claims |
@@ -400,6 +401,11 @@ Use the generic table API only for backend internals, wrapper modules, or explic
 `[expires_at: :expires_at]` retention. Keep its typed API delegated to the
 specialized Store operations, which remain responsible for configured TTL
 stamping, lazy expiry, periodic sweeping, and cache coherence.
+
+`LemonCore.RunStore` owns the cached `:runs` table (`persistence: :ephemeral`)
+and the cached `:sessions_index` table (`persistence: :durable`). Keep
+finalization and retry behavior on the existing specialized Store path until
+that dedicated migration.
 
 New generic-table wrappers must declare ownership with `use LemonCore.Store.Table`.
 The declaration generates no CRUD API and does not yet change backend runtime

--- a/apps/lemon_core/CHANGELOG.md
+++ b/apps/lemon_core/CHANGELOG.md
@@ -33,6 +33,10 @@ Telegram, run history, durable memory, kanban boards, or `~/.lemon`.
   and its `:expires_at` retention policy. Its public API and the specialized
   Store runtime that applies TTL, expiry, sweeping, and cache behavior are
   unchanged.
+- `LemonCore.RunStore` declares `:runs` and `:sessions_index` as its owned
+  tables. The declaration records their cache and persistence intent explicitly
+  and brings the existing wrapper under the AST ownership gate without changing
+  the specialized `LemonCore.Store` run lifecycle or finalization semantics.
 
 - `LemonCore.Contract` centralizes loadability and required-callback checks for
   configuration-injected implementations. `LemonCore.EngineRuntime.validate/1`

--- a/apps/lemon_core/README.md
+++ b/apps/lemon_core/README.md
@@ -166,6 +166,7 @@ ids, message bodies, proof details, credentials, or secret names.
 |--------|---------|
 | `LemonCore.Store` | GenServer with pluggable backends and specialized APIs |
 | `LemonCore.Store.Table` | Declarative owner and policy metadata for generic Store tables |
+| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; runtime writes still use the specialized Store lifecycle path |
 | `LemonCore.Store.Backend` | Behaviour for storage backends (init/put/put_new/get/delete/list) |
 | `LemonCore.Store.EtsBackend` | In-memory ETS backend (ephemeral, default) |
 | `LemonCore.Store.SqliteBackend` | SQLite backend with WAL mode and optional ephemeral tables |
@@ -485,7 +486,10 @@ Shared-domain callers should prefer typed wrappers:
 - **Chat state**: `LemonCore.ChatStateStore.put/2`, `get/1`, `delete/1`; owns
   the cached `:chat` table with `:expires_at` retention metadata while the
   specialized Store runtime continues to enforce TTL and expiry
-- **Run history**: `LemonCore.RunStore.append_event/2`, `finalize/2`, `history/2`, `get/1`
+- **Run history**: `LemonCore.RunStore.append_event/2`, `finalize/2`, `history/2`, `get/1`;
+  owns cached `:runs` (`persistence: :ephemeral`) and cached `:sessions_index`
+  (`persistence: :durable`) while specialized Store lifecycle/finalization
+  remains the runtime path
 - **Policies**: `LemonCore.PolicyStore.put_agent/2`, `put_channel/2`, `put_session/2`, `put_runtime/1`
 - **Idempotency**: `LemonCore.IdempotencyStore.put/3`, `get/2`, `delete/2`
 - **Progress mapping**: `LemonCore.ProgressStore.put/3`, `get_run/2`
@@ -499,6 +503,11 @@ Agent workspace coordination — goals, kanban boards, and heartbeats — is bui
 `:session_policies`, and `:runtime_policy` as durable version-1 tables. The
 declaration is ownership metadata only: its public functions continue to use
 the specialized policy operations provided by `LemonCore.Store`.
+
+`LemonCore.RunStore` declares cached `:runs` (`persistence: :ephemeral`) and
+cached `:sessions_index` (`persistence: :durable`). The declaration is
+ownership metadata only; runtime writes still use the specialized Store
+lifecycle path, and finalization behavior is unchanged.
 
 ### ReadCache
 

--- a/apps/lemon_core/lib/lemon_core/run_store.ex
+++ b/apps/lemon_core/lib/lemon_core/run_store.ex
@@ -1,7 +1,18 @@
 defmodule LemonCore.RunStore do
   @moduledoc """
   Typed wrapper for run lifecycle and history persistence.
+
+  This module owns the `:runs` and `:sessions_index` table contracts. The
+  declaration is architecture metadata only: the existing specialized
+  `LemonCore.Store` lifecycle operations continue to provide the runtime
+  behavior while run storage is migrated incrementally.
   """
+
+  use LemonCore.Store.Table,
+    tables: [
+      runs: [cached: true, persistence: :ephemeral],
+      sessions_index: [cached: true, persistence: :durable]
+    ]
 
   alias LemonCore.Store
   alias LemonCore.RunHistoryStore

--- a/apps/lemon_core/test/lemon_core/run_store_test.exs
+++ b/apps/lemon_core/test/lemon_core/run_store_test.exs
@@ -2,13 +2,43 @@ defmodule LemonCore.RunStoreTest do
   use ExUnit.Case, async: false
 
   alias LemonCore.RunStore
+  alias LemonCore.Store.Table
+
+  test "declares the run-domain tables without changing their runtime path" do
+    assert [runs, sessions_index] = RunStore.__store_tables__()
+
+    assert %Table{
+             name: :runs,
+             owner: RunStore,
+             cached: true,
+             persistence: :ephemeral,
+             retention: nil,
+             version: 1
+           } = runs
+
+    assert %Table{
+             name: :sessions_index,
+             owner: RunStore,
+             cached: true,
+             persistence: :durable,
+             retention: nil,
+             version: 1
+           } = sessions_index
+  end
 
   test "appends, fetches, finalizes, and lists run history through the typed wrapper" do
     session_key = "agent:test:main:#{System.unique_integer([:positive])}"
     run_id = "run_#{System.unique_integer([:positive])}"
 
-    assert :ok = RunStore.append_event(run_id, %{type: :prompt, text: "hello", session_key: session_key})
+    assert :ok =
+             RunStore.append_event(run_id, %{
+               type: :prompt,
+               text: "hello",
+               session_key: session_key
+             })
+
     assert is_map(RunStore.get(run_id))
+
     assert :ok =
              RunStore.finalize(run_id, %{
                completed: %{ok: true, answer: "world"},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refreshes #43 onto current `main` and addresses the Copilot review: `sessions_index` now declares `persistence: :durable` explicitly instead of relying on the `LemonCore.Store.Table` default.

- declare `:runs` and `:sessions_index` as RunStore-owned tables
- record cache and persistence policy metadata explicitly for both tables
- prove the ownership contract without changing existing specialized Store behavior
- document that runtime migration remains incremental

This is the next one-domain storage ownership follow-up after #40, #48, and #49. It intentionally excludes finalization/retry semantics.

## Type of change

- [x] Refactor (no behavior change)
- [x] Documentation
- [x] Test

## Related issues

Supersedes #43

## Checklist

- [x] Quality / compile / dialyzer CI passed on the first run
- [ ] `elixir-test-suite` is being retriggered after two unrelated process-lifetime flakes
- [x] CHANGELOG.md updated

## Security considerations

Does this change affect:
- Secret handling or storage?
- Tool policy / approval gates?
- Skill trust or installation policy?
- Memory document content or filtering?

No. Ownership metadata only; specialized run lifecycle and finalization are unchanged.

## Testing notes

Focused RunStore ownership assertions plus the existing append/finalize/history wrapper test.

The first `elixir-test-suite` run reported `lemon_core` as `2266 tests, 0 failures`. The job failed on unrelated races:

- `LemonBrowser.ComputerUseSessionTest` calling `status/0` on a dead session PID
- `CodingAgent.CoordinatorEdgeCasesTest` abort_all/stop racing coordinator cleanup

CI was retriggered with an empty commit. Merge once the suite is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a60087aa-2dbb-4abe-bfb1-ef5e949c9fc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a60087aa-2dbb-4abe-bfb1-ef5e949c9fc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

