### PR TITLE
Make run finalization retry-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ Versions follow [CalVer](https://calver.org/) — `YYYY.MM.PATCH`.
   control-plane, and portable-command callers were migrated atomically;
   user-facing run controls no longer report success for a request the router
   did not accept.
+- Run finalization no longer reports success when session indexing fails.
+  Retrying the same immutable summary repairs the derived index without
+  incrementing `run_count` twice; conflicting summaries fail closed, and
+  finalize hooks document their at-least-once delivery contract.
 - Hermes skill install/update requests no longer block their own control-plane
   WebSocket while waiting for approval or Git work. Approval events and
   liveness probes remain deliverable, and the TUI keeps the correlated skill

--- a/apps/lemon_core/AGENTS.md
+++ b/apps/lemon_core/AGENTS.md
@@ -51,7 +51,7 @@ This is the **base app** of the Lemon umbrella. All other apps depend on it. It 
 | `LemonCore.OAuth.LocalCallbackListener` | Caller-owned one-shot localhost OAuth callback listener; monitors its listener manager so early failure returns immediately instead of consuming the authorization timeout |
 | `LemonCore.Store` | Storage GenServer with pluggable backends, `put_new/3` claims, strict `fetch/3` and `fetch_all/2` reads, serialized `take/2`, and exact-value `compare_and_swap/4`, `compare_and_delete/3`, and multi-snapshot `compare_and_delete_many/1` transitions |
 | `LemonCore.Store.Table` | Declarative table owner and policy metadata; the architecture gate checks owner calls against exact declared tables |
-| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; keep finalization behavior on the existing specialized Store path until its dedicated migration |
+| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; specialized Store finalization is synchronous, retry-safe, summary-immutable, and invokes hooks at least once |
 | `LemonCore.Store.ReadCache` | ETS read cache for hot domains (`:chat`, `:runs`, `:progress`, `:sessions_index`, plus tables collaborators add with `register_cached_table/1`) |
 | `LemonCore.Store.EtsBackend` | In-memory ETS (ephemeral, default) with `:ets.insert_new/2` claims |
 | `LemonCore.Store.SqliteBackend` | SQLite with WAL mode (persistent) and `ON CONFLICT DO NOTHING` claims |

--- a/apps/lemon_core/CHANGELOG.md
+++ b/apps/lemon_core/CHANGELOG.md
@@ -15,6 +15,12 @@ Telegram, run history, durable memory, kanban boards, or `~/.lemon`.
 - Vendor CLI wrapper extension points. Subagent tasks now execute natively, and
   `[runtime.cli]` is rejected.
 
+### Fixed
+
+- Run finalization is now synchronous and retry-safe. A session-index failure
+  is returned to the caller, retrying repairs the index without double-counting
+  the run, conflicting summaries fail without exposing the original summary,
+  and finalize hooks explicitly use at-least-once delivery.
 
 ### Added
 

--- a/apps/lemon_core/README.md
+++ b/apps/lemon_core/README.md
@@ -166,7 +166,7 @@ ids, message bodies, proof details, credentials, or secret names.
 |--------|---------|
 | `LemonCore.Store` | GenServer with pluggable backends and specialized APIs |
 | `LemonCore.Store.Table` | Declarative owner and policy metadata for generic Store tables |
-| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; runtime writes still use the specialized Store lifecycle path |
+| `LemonCore.RunStore` | Typed run lifecycle/history wrapper and declared owner of `:runs` and `:sessions_index`; specialized finalization is synchronous and retry-safe |
 | `LemonCore.Store.Backend` | Behaviour for storage backends (init/put/put_new/get/delete/list) |
 | `LemonCore.Store.EtsBackend` | In-memory ETS backend (ephemeral, default) |
 | `LemonCore.Store.SqliteBackend` | SQLite backend with WAL mode and optional ephemeral tables |
@@ -497,6 +497,12 @@ Shared-domain callers should prefer typed wrappers:
 - **Project bindings**: `LemonCore.ProjectBindingStore.get_override/1`, `put_override/2`, `get_dynamic/1`
 - **Exec approvals**: `LemonCore.ExecApprovalStore.get_pending/1`, `put_pending/2`, policy getters/setters by scope
 
+`RunStore.finalize/2` returns `:ok` only after the immutable final summary and
+its session index are written. Retrying the same summary repairs a partial index
+failure without double-counting the run. Finalize hooks run after both writes
+and use at-least-once delivery, so hook implementations must be idempotent by
+run id.
+
 Agent workspace coordination — goals, kanban boards, and heartbeats — is built on this Store but lives in `agent_core` as `LemonAgent.Workspace.{GoalStore, KanbanStore, HeartbeatStore}`.
 
 `LemonCore.PolicyStore` declares `:agent_policies`, `:channel_policies`,
@@ -507,7 +513,7 @@ the specialized policy operations provided by `LemonCore.Store`.
 `LemonCore.RunStore` declares cached `:runs` (`persistence: :ephemeral`) and
 cached `:sessions_index` (`persistence: :durable`). The declaration is
 ownership metadata only; runtime writes still use the specialized Store
-lifecycle path, and finalization behavior is unchanged.
+lifecycle path, where finalization is synchronous and retry-safe.
 
 ### ReadCache
 

--- a/apps/lemon_core/lib/lemon_core/run_store.ex
+++ b/apps/lemon_core/lib/lemon_core/run_store.ex
@@ -2,10 +2,10 @@ defmodule LemonCore.RunStore do
   @moduledoc """
   Typed wrapper for run lifecycle and history persistence.
 
-  This module owns the `:runs` and `:sessions_index` table contracts. The
-  declaration is architecture metadata only: the existing specialized
-  `LemonCore.Store` lifecycle operations continue to provide the runtime
-  behavior while run storage is migrated incrementally.
+  This module owns the `:runs` and `:sessions_index` table contracts while the
+  existing specialized `LemonCore.Store` lifecycle path provides serialized
+  writes. Finalization is synchronous, retry-safe, and keeps its summary
+  immutable; see `finalize/3` for the hook delivery contract.
   """
 
   use LemonCore.Store.Table,
@@ -29,14 +29,26 @@ defmodule LemonCore.RunStore do
   @spec append_event(term(), term()) :: :ok | {:error, term()}
   def append_event(run_id, event), do: Store.append_run_event(run_id, event)
 
-  @spec finalize(term(), term()) :: :ok | {:error, term()}
-  def finalize(run_id, summary), do: Store.finalize_run(run_id, summary)
+  @doc """
+  Finalize a run synchronously.
+
+  `:ok` means both the immutable final summary and its derived session index
+  were written. Retrying the same summary repairs partial index failures
+  without double-counting the run. Finalize hooks use at-least-once delivery,
+  so hook implementations must be idempotent by run id.
+  """
+  @spec finalize(Store.server(), term(), map()) :: :ok | {:error, term()}
+  def finalize(server \\ Store, run_id, summary), do: Store.finalize_run(server, run_id, summary)
 
   @spec history(term(), keyword()) :: list()
   def history(session_key, opts \\ []), do: RunHistoryStore.get(session_key, opts)
 
-  @spec list_sessions() :: [{term(), map()}]
-  def list_sessions, do: Store.list(:sessions_index)
+  @spec list_sessions(Store.server()) :: [{term(), map()}]
+  def list_sessions(server \\ Store) do
+    server
+    |> Store.list(:sessions_index)
+    |> Enum.map(fn {session_key, entry} -> {session_key, public_session_entry(entry)} end)
+  end
 
   @spec delete_session_index(term()) :: :ok
   def delete_session_index(session_key), do: Store.delete(:sessions_index, session_key)
@@ -51,4 +63,10 @@ defmodule LemonCore.RunStore do
     delete_session_index(session_key)
     delete_history(session_key)
   end
+
+  defp public_session_entry(entry) when is_map(entry) do
+    Map.drop(entry, [:__indexed_run_ids__, :__legacy_run_count__])
+  end
+
+  defp public_session_entry(entry), do: entry
 end

--- a/apps/lemon_core/lib/lemon_core/store.ex
+++ b/apps/lemon_core/lib/lemon_core/store.ex
@@ -54,10 +54,13 @@ defmodule LemonCore.Store do
     * `put_chat_state/3` and `put_progress_mapping/4` are synchronous. They were
       casts with a caller-side cache write, which made a failed backend write
       look like a success and let two writers on one key land out of order.
-    * `append_run_event/3` and `finalize_run/3` stay asynchronous, because runs
-      stream events far more often than anything reads them back. Their cache
-      entry lands with the backend write, so a read taken before the cast drains
-      can lag by a message. `ping/1` is the barrier when that matters.
+    * `append_run_event/3` stays asynchronous, because runs stream events far
+      more often than anything reads them back. Its cache entry lands with the
+      backend write, so a read taken before the cast drains can lag by a
+      message. `ping/1` is the barrier when that matters.
+    * `finalize_run/3` is synchronous: success means both the immutable final
+      summary and its derived session index were written. A retry repairs a
+      partial index failure without incrementing the session twice.
   """
 
   use GenServer
@@ -188,11 +191,23 @@ defmodule LemonCore.Store do
 
   Hooks run in the store process, in registration order, and failures are
   isolated. Runs without a session key do not fire hooks.
+
+  Hook delivery is **at least once**. Hooks run only after the run record and
+  session index are written, but retrying a successful finalization invokes
+  them again. Hook implementations must therefore be idempotent by `run_id`.
   """
-  @spec finalize_run(server(), term(), map()) :: :ok
-  def finalize_run(server \\ __MODULE__, run_id, summary) do
-    GenServer.cast(server, {:finalize_run, run_id, summary})
+  @spec finalize_run(server(), term(), map()) :: :ok | {:error, term()}
+  def finalize_run(server \\ __MODULE__, run_id, summary)
+
+  def finalize_run(server, run_id, summary) when is_map(summary) do
+    safe_store_call(server, {:finalize_run, run_id, summary}, {:error, :store_unavailable},
+      op: :finalize_run,
+      table: :runs,
+      key: run_id
+    )
   end
+
+  def finalize_run(_server, _run_id, _summary), do: {:error, :invalid_summary}
 
   # Progress Mapping API
 
@@ -1136,6 +1151,11 @@ defmodule LemonCore.Store do
     end
   end
 
+  def handle_call({:finalize_run, run_id, summary}, _from, state) do
+    {reply, state} = finalize_run_record(state, run_id, summary)
+    {:reply, reply, state}
+  end
+
   def handle_call({:get_run_history, session_key, opts}, _from, state) do
     # Forwarded to the configured provider, which owns run history and keeps
     # potentially large history I/O off this process.
@@ -1518,65 +1538,6 @@ defmodule LemonCore.Store do
     end
   end
 
-  def handle_cast({:finalize_run, run_id, summary}, state) do
-    case state.backend.get(state.backend_state, :runs, run_id) do
-      {:ok, existing, backend_state} ->
-        record =
-          existing || %{events: [], summary: nil, started_at: System.system_time(:millisecond)}
-
-        record = %{record | summary: summary}
-
-        case state.backend.put(backend_state, :runs, run_id, record) do
-          {:ok, backend_state} ->
-            ReadCache.put(state.read_cache, :runs, run_id, record)
-            session_key = Map.get(summary, :session_key)
-            started_at = record.started_at
-
-            # Runs that belong to a session notify their collaborators (run
-            # history, memory ingest, ...) and update the sessions index.
-            backend_state =
-              if is_binary(session_key) and session_key != "" do
-                Hooks.invoke(
-                  finalize_run_hooks(state),
-                  %{
-                    store: state.name,
-                    run_id: run_id,
-                    record: record,
-                    summary: summary,
-                    session_key: session_key,
-                    started_at: started_at
-                  },
-                  op: :finalize_run,
-                  store: state.name,
-                  run_id: run_id
-                )
-
-                update_sessions_index(state, backend_state, session_key, summary, started_at)
-              else
-                backend_state
-              end
-
-            {:noreply, %{state | backend_state: backend_state}}
-
-          {:error, reason} ->
-            log_backend_error(:put, :runs, run_id, reason)
-            {:noreply, %{state | backend_state: backend_state}}
-
-          other ->
-            log_backend_unexpected(:put, :runs, run_id, other)
-            {:noreply, %{state | backend_state: backend_state}}
-        end
-
-      {:error, reason} ->
-        log_backend_error(:get, :runs, run_id, reason)
-        {:noreply, state}
-
-      other ->
-        log_backend_unexpected(:get, :runs, run_id, other)
-        {:noreply, state}
-    end
-  end
-
   def handle_cast({:delete_progress_mapping, scope, progress_msg_id}, state) do
     key = {scope, progress_msg_id}
 
@@ -1614,57 +1575,191 @@ defmodule LemonCore.Store do
     end
   end
 
-  # Update sessions_index when a run is finalized
-  defp update_sessions_index(state, backend_state, session_key, summary, timestamp) do
-    backend = state.backend
+  defp finalize_run_record(state, run_id, summary) do
+    with {:ok, record, backend_state} <- ensure_final_record(state, run_id, summary),
+         {:ok, backend_state} <-
+           finalize_run_session(state, backend_state, run_id, record, summary) do
+      {:ok, %{state | backend_state: backend_state}}
+    else
+      {:error, reason, backend_state} ->
+        {{:error, reason}, %{state | backend_state: backend_state}}
 
-    case backend.get(backend_state, :sessions_index, session_key) do
+      {:error, reason} ->
+        {{:error, reason}, state}
+    end
+  end
+
+  defp ensure_final_record(state, run_id, summary) do
+    case state.backend.get(state.backend_state, :runs, run_id) do
       {:ok, existing, backend_state} ->
-        # Parse agent_id from session_key if not in summary
+        case final_record(existing, run_id, summary) do
+          {:persist, record} -> persist_final_record(state, backend_state, run_id, record)
+          {:existing, record} -> {:ok, record, backend_state}
+          {:error, reason} -> {:error, reason, backend_state}
+        end
+
+      {:error, reason} ->
+        log_backend_error(:get, :runs, run_id, reason)
+        {:error, reason}
+
+      other ->
+        log_backend_unexpected(:get, :runs, run_id, other)
+        {:error, {:unexpected_backend_response, other}}
+    end
+  end
+
+  defp final_record(nil, _run_id, summary) do
+    {:persist, %{events: [], summary: summary, started_at: System.system_time(:millisecond)}}
+  end
+
+  defp final_record(%{summary: nil} = record, _run_id, summary) do
+    {:persist, %{record | summary: summary}}
+  end
+
+  defp final_record(%{summary: summary} = record, _run_id, summary), do: {:existing, record}
+
+  defp final_record(%{summary: _existing_summary}, run_id, _summary) do
+    # Do not include the prior summary in the error: summaries may contain
+    # prompts, answers, credentials, or other user content.
+    {:error, {:already_finalized, run_id}}
+  end
+
+  defp final_record(_invalid_record, run_id, _summary),
+    do: {:error, {:invalid_run_record, run_id}}
+
+  defp persist_final_record(state, backend_state, run_id, record) do
+    case state.backend.put(backend_state, :runs, run_id, record) do
+      {:ok, backend_state} ->
+        ReadCache.put(state.read_cache, :runs, run_id, record)
+        {:ok, record, backend_state}
+
+      {:error, reason} ->
+        log_backend_error(:put, :runs, run_id, reason)
+        {:error, reason, backend_state}
+
+      other ->
+        log_backend_unexpected(:put, :runs, run_id, other)
+        {:error, {:unexpected_backend_response, other}, backend_state}
+    end
+  end
+
+  defp finalize_run_session(state, backend_state, run_id, record, summary) do
+    session_key = Map.get(summary, :session_key)
+
+    if is_binary(session_key) and session_key != "" do
+      with {:ok, backend_state} <-
+             update_sessions_index(
+               state,
+               backend_state,
+               session_key,
+               run_id,
+               summary,
+               record.started_at
+             ) do
+        Hooks.invoke(
+          finalize_run_hooks(state),
+          %{
+            store: state.name,
+            run_id: run_id,
+            record: record,
+            summary: summary,
+            session_key: session_key,
+            started_at: record.started_at
+          },
+          op: :finalize_run,
+          store: state.name,
+          run_id: run_id
+        )
+
+        {:ok, backend_state}
+      end
+    else
+      {:ok, backend_state}
+    end
+  end
+
+  # Update sessions_index when a run is finalized. The private run-id set is
+  # the idempotency marker for partial-failure repair; typed public listings
+  # strip it before returning session entries.
+  defp update_sessions_index(state, backend_state, session_key, run_id, summary, timestamp) do
+    case state.backend.get(backend_state, :sessions_index, session_key) do
+      {:ok, existing, backend_state} ->
         agent_id = Map.get(summary, :agent_id) || parse_agent_id(session_key)
         origin = get_in(summary, [:meta, :origin]) || Map.get(summary, :origin) || :unknown
 
-        session_entry =
-          case existing do
-            nil ->
-              %{
-                session_key: session_key,
-                agent_id: agent_id,
-                origin: origin,
-                created_at_ms: timestamp,
-                updated_at_ms: timestamp,
-                run_count: 1
-              }
-
-            entry ->
-              %{entry | updated_at_ms: timestamp, run_count: (entry[:run_count] || 0) + 1}
-          end
-
-        case backend.put(backend_state, :sessions_index, session_key, session_entry) do
-          {:ok, backend_state} ->
-            # Write through: this bypasses the generic put path, so without it a
-            # cached :sessions_index read keeps serving the previous run_count.
-            ReadCache.put(state.read_cache, :sessions_index, session_key, session_entry)
-            backend_state
+        case next_session_entry(existing, session_key, run_id, agent_id, origin, timestamp) do
+          {:ok, session_entry} ->
+            put_session_index(state, backend_state, session_key, session_entry)
 
           {:error, reason} ->
-            log_backend_error(:put, :sessions_index, session_key, reason)
-            backend_state
-
-          other ->
-            log_backend_unexpected(:put, :sessions_index, session_key, other)
-            backend_state
+            {:error, reason, backend_state}
         end
 
       {:error, reason} ->
         log_backend_error(:get, :sessions_index, session_key, reason)
-        backend_state
+        {:error, reason, backend_state}
 
       other ->
         log_backend_unexpected(:get, :sessions_index, session_key, other)
-        backend_state
+        {:error, {:unexpected_backend_response, other}, backend_state}
     end
   end
+
+  defp next_session_entry(nil, session_key, run_id, agent_id, origin, timestamp) do
+    {:ok,
+     %{
+       session_key: session_key,
+       agent_id: agent_id,
+       origin: origin,
+       created_at_ms: timestamp,
+       updated_at_ms: timestamp,
+       run_count: 1,
+       __indexed_run_ids__: MapSet.new([run_id]),
+       __legacy_run_count__: 0
+     }}
+  end
+
+  defp next_session_entry(entry, _session_key, run_id, _agent_id, _origin, timestamp)
+       when is_map(entry) do
+    indexed_run_ids =
+      entry
+      |> Map.get(:__indexed_run_ids__, MapSet.new())
+      |> normalize_indexed_run_ids()
+      |> MapSet.put(run_id)
+
+    legacy_run_count =
+      Map.get_lazy(entry, :__legacy_run_count__, fn -> entry[:run_count] || 0 end)
+
+    {:ok,
+     entry
+     |> Map.put(:updated_at_ms, max(entry[:updated_at_ms] || timestamp, timestamp))
+     |> Map.put(:run_count, legacy_run_count + MapSet.size(indexed_run_ids))
+     |> Map.put(:__indexed_run_ids__, indexed_run_ids)
+     |> Map.put(:__legacy_run_count__, legacy_run_count)}
+  end
+
+  defp next_session_entry(_invalid, session_key, _run_id, _agent_id, _origin, _timestamp),
+    do: {:error, {:invalid_session_index, session_key}}
+
+  defp put_session_index(state, backend_state, session_key, session_entry) do
+    case state.backend.put(backend_state, :sessions_index, session_key, session_entry) do
+      {:ok, backend_state} ->
+        ReadCache.put(state.read_cache, :sessions_index, session_key, session_entry)
+        {:ok, backend_state}
+
+      {:error, reason} ->
+        log_backend_error(:put, :sessions_index, session_key, reason)
+        {:error, reason, backend_state}
+
+      other ->
+        log_backend_unexpected(:put, :sessions_index, session_key, other)
+        {:error, {:unexpected_backend_response, other}, backend_state}
+    end
+  end
+
+  defp normalize_indexed_run_ids(%MapSet{} = run_ids), do: run_ids
+  defp normalize_indexed_run_ids(run_ids) when is_list(run_ids), do: MapSet.new(run_ids)
+  defp normalize_indexed_run_ids(_), do: MapSet.new()
 
   defp parse_agent_id(nil), do: "default"
 

--- a/apps/lemon_core/lib/lemon_core/store/hooks.ex
+++ b/apps/lemon_core/lib/lemon_core/store/hooks.ex
@@ -8,8 +8,9 @@ defmodule LemonCore.Store.Hooks do
 
   ## Extension points
 
-    * `:finalize_run_hooks` — invoked after a run is finalized with a session
-      key. See `LemonCore.Store.finalize_run/3` for the payload.
+    * `:finalize_run_hooks` — invoked after a run and its session index are
+      finalized. Delivery is at least once, so hooks must be idempotent by run
+      id. See `LemonCore.Store.finalize_run/3` for the payload.
     * `:cached_tables` — generic tables the store mirrors into
       `LemonCore.Store.ReadCache`.
 

--- a/apps/lemon_core/test/lemon_core/run_store_test.exs
+++ b/apps/lemon_core/test/lemon_core/run_store_test.exs
@@ -1,8 +1,48 @@
 defmodule LemonCore.RunStoreTest do
   use ExUnit.Case, async: false
 
-  alias LemonCore.RunStore
+  alias LemonCore.{RunStore, Store}
+  alias LemonCore.Store.EtsBackend
   alias LemonCore.Store.Table
+
+  defmodule FailFirstSessionIndexPutBackend do
+    @behaviour LemonCore.Store.Backend
+
+    @impl true
+    defdelegate init(opts), to: EtsBackend
+
+    @impl true
+    def put(state, :sessions_index, key, value) do
+      failure_key = {__MODULE__, :failed_session_index_put}
+
+      if Process.get(failure_key, false) do
+        EtsBackend.put(state, :sessions_index, key, value)
+      else
+        Process.put(failure_key, true)
+        {:error, :injected_session_index_failure}
+      end
+    end
+
+    def put(state, table, key, value), do: EtsBackend.put(state, table, key, value)
+
+    @impl true
+    defdelegate put_new(state, table, key, value), to: EtsBackend
+
+    @impl true
+    defdelegate get(state, table, key), to: EtsBackend
+
+    @impl true
+    defdelegate delete(state, table, key), to: EtsBackend
+
+    @impl true
+    defdelegate list(state, table), to: EtsBackend
+  end
+
+  defp start_store(name, opts) do
+    spec = Supervisor.child_spec({Store, Keyword.put(opts, :name, name)}, id: name)
+    start_supervised!(spec)
+    name
+  end
 
   test "declares the run-domain tables without changing their runtime path" do
     assert [runs, sessions_index] = RunStore.__store_tables__()
@@ -51,6 +91,58 @@ defmodule LemonCore.RunStoreTest do
                stored_run_id == run_id
              end)
            end)
+  end
+
+  test "a retry repairs a failed session index without double-counting the run" do
+    store =
+      start_store(:run_store_partial_finalize,
+        backend: FailFirstSessionIndexPutBackend,
+        cached_tables: [:sessions_index]
+      )
+
+    parent = self()
+    hook = fn event -> send(parent, {:finalized, event.run_id}) end
+    :ok = Store.register_finalize_run_hook(store, hook)
+    on_exit(fn -> Store.unregister_finalize_run_hook(store, hook) end)
+
+    run_id = "run-partial"
+    session_key = "agent:partial:main"
+    summary = %{session_key: session_key, completed: %{ok: true}}
+
+    assert {:error, :injected_session_index_failure} =
+             RunStore.finalize(store, run_id, summary)
+
+    assert %{summary: ^summary} = Store.get(store, :runs, run_id)
+    assert Store.get(store, :sessions_index, session_key) == nil
+    refute_receive {:finalized, ^run_id}
+
+    assert :ok = RunStore.finalize(store, run_id, summary)
+    assert %{run_count: 1} = Store.get(store, :sessions_index, session_key)
+    assert_receive {:finalized, ^run_id}
+
+    # Record and index writes are idempotent. Hooks deliberately use
+    # at-least-once delivery, so an explicit retry invokes them again.
+    assert :ok = RunStore.finalize(store, run_id, summary)
+    assert %{run_count: 1} = Store.get(store, :sessions_index, session_key)
+    assert_receive {:finalized, ^run_id}
+
+    assert [{^session_key, public_entry}] = RunStore.list_sessions(store)
+    refute Map.has_key?(public_entry, :__indexed_run_ids__)
+    refute Map.has_key?(public_entry, :__legacy_run_count__)
+  end
+
+  test "finalizing a run with a different summary fails without leaking the first summary" do
+    store = start_store(:run_store_summary_conflict, backend: EtsBackend)
+
+    original = %{session_key: "agent:one:main", prompt: "private original prompt"}
+    conflicting = %{session_key: "agent:two:main", prompt: "replacement prompt"}
+
+    assert :ok = RunStore.finalize(store, "run-conflict", original)
+
+    assert {:error, {:already_finalized, "run-conflict"}} =
+             RunStore.finalize(store, "run-conflict", conflicting)
+
+    assert %{summary: ^original} = Store.get(store, :runs, "run-conflict")
   end
 
   defp eventually(fun, attempts \\ 20)

--- a/apps/lemon_core/test/lemon_core/store_hooks_test.exs
+++ b/apps/lemon_core/test/lemon_core/store_hooks_test.exs
@@ -30,8 +30,6 @@ defmodule LemonCore.StoreHooksTest do
 
   defp finalize(store, run_id, summary) do
     :ok = Store.finalize_run(store, run_id, summary)
-    # finalize_run is a cast; a call afterwards acts as a barrier.
-    :ok = Store.ping(store)
   end
 
   describe "finalize_run hooks" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refreshes #45 onto current `main` after RunStore ownership landed in #55.

- make specialized Store finalization synchronous and error-reporting
- preserve immutable summaries and fail closed on conflicting retries without leaking prior content
- repair a missing session index on retry without double-counting `run_count`
- invoke finalize hooks only after record and index success, with documented at-least-once delivery
- hide private idempotency bookkeeping from RunStore session listings
- address the original review feedback by documenting summary—not whole-record—immutability

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Test
- [ ] Chore (deps, CI, tooling)

## Related issues

Extracted from #37. Supersedes #45.

## Checklist

- [ ] `mix test` passes (full umbrella CI rerun in progress; the first run hit a confirmed unrelated `LemonAgent.LoopAbortTest` flake)
- [x] `mix lemon.quality` passes (lint + architecture boundaries + doc freshness)
- [x] New docs files registered in `docs/catalog.exs` (not applicable; no new docs files)
- [x] New features gated behind a feature flag (not applicable)
- [x] CODEOWNERS updated for new files (not applicable)
- [x] CHANGELOG.md updated (if user-visible change)

## Security considerations

Conflicting retries return only the run ID and never expose the previously stored summary, which may contain prompts, answers, or credentials. This change does not alter secret storage, tool policy, skill trust, or memory filtering.

## Testing notes

- 2,284 Lemon Core tests, 51 doctests, and 19 properties pass (3 excluded)
- 122 focused Store, hook, RunStore, and architecture-rule tests pass
- 154 focused quality tests and the Lemon eval harness pass
- `mix lemon.skill.lint` and `mix lemon.quality` pass
- source-launcher reuse check passes
- the first broad CI run had one unrelated abort-race failure in `apps/lemon_agent/test/lemon_agent/loop_abort_test.exs:443`; the exact test passes locally with the CI seed, so CI was retriggered
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d70c31c4-0a45-4a99-b055-c0c470dedab4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d70c31c4-0a45-4a99-b055-c0c470dedab4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

